### PR TITLE
Use mappings provided to context.init()

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -377,8 +377,10 @@ export default class {
     this.mappings = mappings;
   }
 
-  init() {
+  init(progress) {
     var me = this;
+    /* If mappings weren't provided, fall back to the ones provided to init() */
+    me.mappings = me.mappings || (progress && progress.mappings);
     /* First parse the input file */
     return getChanges(me.fileName, me.mappings)
       .then(

--- a/test/context.tests.js
+++ b/test/context.tests.js
@@ -279,8 +279,8 @@ describe('#context', () => {
       const dir = path.join(repoDir, constants.PAGES_DIRECTORY);
       createPagesDir(dir, target);
 
-      const context = new Context(repoDir, { val: 'someval' });
-      context.init()
+      const context = new Context(repoDir);
+      context.init({ mappings: { val: 'someval' } })
         .then(() => {
           check(done, function() {
             target.password_reset.htmlFile = '<html>this is pwd reset 2: "someval"</html>';


### PR DESCRIPTION
This addresses a hole in Issue #3.  The keyword mappings are passed into `context.init()` but not used.  They are pulled from the constructor of `context` instead, but aren't passed in the actual script (just the tests).

This fix is backward compatible in case anyone is using the current setup.  If backwards compatibility isn't needed, this could replace the current mappings code.