### PR TITLE
Ignore owners attribute for clients

### DIFF
--- a/src/readonly.js
+++ b/src/readonly.js
@@ -20,7 +20,8 @@ const readOnly = {
     'global',
     'tenant',
     'custom_login_page_preview',
-    'config_route'
+    'config_route',
+    'owners'
   ]
 };
 


### PR DESCRIPTION
## ✏️ Changes
Ignore owners attribute for clients. This is set when you add admins that have access only to an application instead of the whole tenant. As it's specific to the tenant it should be ignored on dump/read-only.

  
## 🔗 References  
Fixes #55
  
## 🚀 Deployment
    
✅ This can be deployed any time
  