### PR TITLE
Handle normal db connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -27,7 +27,10 @@ function getDatabase(folder, mappings) {
     ...metaData,
     options: {
       ...metaData.options,
-      customScripts: metaData.customScripts || {}
+      // customScripts option only written if there are scripts
+      ...(metaData.customScripts && {
+        customScripts: metaData.customScripts
+      })
     }
   };
 
@@ -83,14 +86,17 @@ async function dump(context) {
       ],
       options: {
         ...database.options,
-        customScripts: Object.entries(database.options.customScripts || {}).reduce((scripts, [ name, script ]) => {
-          // Dump custom script to file
-          const scriptFile = path.join(dbFolder, `${name}.js`);
-          log.info(`Writing ${scriptFile}`);
-          fs.writeFileSync(scriptFile, script);
-          scripts[name] = `./${name}.js`;
-          return scripts;
-        }, {})
+        // customScripts option only written if there are scripts
+        ...(database.options.customScripts && {
+          customScripts: Object.entries(database.options.customScripts).reduce((scripts, [ name, script ]) => {
+            // Dump custom script to file
+            const scriptFile = path.join(dbFolder, `${name}.js`);
+            log.info(`Writing ${scriptFile}`);
+            fs.writeFileSync(scriptFile, script);
+            scripts[name] = `./${name}.js`;
+            return scripts;
+          }, {})
+        })
       }
     };
 

--- a/src/context/yaml/handlers/databases.js
+++ b/src/context/yaml/handlers/databases.js
@@ -13,10 +13,13 @@ async function parse(context) {
         ...database,
         options: {
           ...database.options,
-          customScripts: Object.entries(database.options.customScripts || {}).reduce((scripts, [ name, script ]) => ({
-            ...scripts,
-            [name]: context.loadFile(script)
-          }), {})
+          // customScripts option only written if there are scripts
+          ...(database.options.customScripts && {
+            customScripts: Object.entries(database.options.customScripts).reduce((scripts, [ name, script ]) => ({
+              ...scripts,
+              [name]: context.loadFile(script)
+            }), {})
+          })
         }
       }))
     ]
@@ -45,18 +48,21 @@ async function dump(context) {
         ],
         options: {
           ...database.options,
-          customScripts: Object.entries(database.options.customScripts || {}).reduce((scripts, [ name, script ]) => {
-            // Create Database folder
-            const dbFolder = path.join(context.basePath, 'databases', database.name);
-            fs.ensureDirSync(dbFolder);
+          // customScripts option only written if there are scripts
+          ...(database.options.customScripts && {
+            customScripts: Object.entries(database.options.customScripts).reduce((scripts, [ name, script ]) => {
+              // Create Database folder
+              const dbFolder = path.join(context.basePath, 'databases', database.name);
+              fs.ensureDirSync(dbFolder);
 
-            // Dump custom script to file
-            const scriptFile = path.join(dbFolder, `${name}.js`);
-            log.info(`Writing ${scriptFile}`);
-            fs.writeFileSync(scriptFile, script);
-            scripts[name] = `./databases/${database.name}/${name}.js`;
-            return scripts;
-          }, {})
+              // Dump custom script to file
+              const scriptFile = path.join(dbFolder, `${name}.js`);
+              log.info(`Writing ${scriptFile}`);
+              fs.writeFileSync(scriptFile, script);
+              scripts[name] = `./databases/${database.name}/${name}.js`;
+              return scripts;
+            }, {})
+          })
         }
       }))
     ]


### PR DESCRIPTION
## ✏️ Changes

The Deploy CLI seems to have been written with _custom_ database connections in mind, but wasn’t well tested with “normal” DB connections. As it stands, the CLI will configure a normal DB connection but put in a bad state (per the referenced issue). This PR fixes that by ensuring that the `customScripts` database option only gets written (import or export) if it exists in the source. The previous behavior had it _always_ being written with a default value of an empty object (`{}`), which was primarily causing issues in Auth0 server. A database connection with `options.customScripts: {}` would fool the Management API into thinking the database was a _custom_ database, even if `enabledDatabaseCustomization` wasn't set to `true`. Arguable, this is a bit of a bug in the Management API. However, the Deploy CLI shouldn't be creating default objects that don't exist in the source.
    
## 🔗 References
  
Fixes #63 
  
## 🎯 Testing

Four new tests were added:
* `test/context/directory/databases.test.js`
   * ["should process normal databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/directory/databases.test.js#L24-L44)
   * ["should dump normal databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/directory/databases.test.js#L170-L195)
* `test/context/yaml/databases.test.js`
   * ["should process normal database"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/yaml/databases.test.js#L17-L45)
   * ["should dump normal databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/yaml/databases.test.js#L96-L124)
  
Four existing tests were renamed to accommodate the expanded use case:
* `test/context/directory/databases.test.js`
   * "should process databases" > ["should process _custom_ databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/directory/databases.test.js#L103)
  * "should dump databases" > ["should dump _custom_ databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/directory/databases.test.js#L197)
* `test/context/yaml/databases.test.js`
   * "should process databases" > ["should process _custom_ databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/yaml/databases.test.js#L47)
   * "should dump databases" > ["should dump _custom_ databases"](https://github.com/twistedstream/auth0-deploy-cli/blob/18f1e2c7e0a0c5dec60c27ec769eeffe1eac2c23/test/context/yaml/databases.test.js#L126)

Some of the other existing tests were reordered so the test sequence made more sense. Also, when appropriate, common variables between a "normal" and a "custom" test were moved into the parent JavaScript scope for better resuse.

✅🚫 This change has unit test coverage
  
## 🚀 Deployment
  
✅🚫 This can be deployed any time
  
## 🎡 Rollout

This change can be verrified by testing the issue described in issue #63.