### PR TITLE
added 'name' prop to pages examples

### DIFF
--- a/examples/directory/pages/login.json
+++ b/examples/directory/pages/login.json
@@ -1,3 +1,4 @@
 {
+  "name": "login",
   "enabled": true
 }

--- a/examples/directory/pages/password_reset.json
+++ b/examples/directory/pages/password_reset.json
@@ -1,3 +1,4 @@
 {
+  "name": "password_reset",
   "enabled": false
 }


### PR DESCRIPTION
## ✏️ Changes
  Required `name` property was missing in the examples for the `pages`. Added `name` in this change.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1547134385102300
