### PR TITLE
Fix H3 format for "Instructions"

### DIFF
--- a/examples/directory/README.md
+++ b/examples/directory/README.md
@@ -72,7 +72,7 @@ You can export your current tenant configuration. For example the following comm
 ## Example Import
 Included in this directory is an example structure.
 
-###Instructions
+### Instructions
 
 1. Copy config.json.example and fill out details
 2. Run deploy


### PR DESCRIPTION
## ✏️ Changes
  
Fix H3 format for "Instructions".
  
## 🚀 Deployment

> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅🚫 This can be deployed any time