### PR TITLE
Fix for using the wrong thing for proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ async function run() {
   // Monkey Patch the superagent for proxy use
   const proxy = params.proxy_url;
   if (proxy) {
-    log.info(`PROXY: ${proxy}`)
     const proxyAgent = new HttpProxyAgent(proxy);
     const proxyAgentSsl = new HttpsProxyAgent(proxy);
     const OrigRequest = superagent.Request;

--- a/src/index.js
+++ b/src/index.js
@@ -32,14 +32,15 @@ async function run() {
   }
 
   // Monkey Patch the superagent for proxy use
-  const proxy = args.proxy_url;
+  const proxy = params.proxy_url;
   if (proxy) {
+    log.info(`PROXY: ${proxy}`)
     const proxyAgent = new HttpProxyAgent(proxy);
     const proxyAgentSsl = new HttpsProxyAgent(proxy);
     const OrigRequest = superagent.Request;
     superagent.Request = function RequestWithAgent(method, url) {
       const req = new OrigRequest(method, url);
-      log.debug(`Setting proxy for ${method} to ${url}`);
+      log.info(`Setting proxy for ${method} to ${url}`);
       if (url.startsWith('https')) return req.agent(proxyAgentSsl);
       return req.agent(proxyAgent);
     };


### PR DESCRIPTION
## ✏️ Changes
  
We are trying to use the proxy when we push config to Auth0. It turns out that variable being used to try and do that is wrong. 

```
args.proxy_ul
```
is undefined, it looks like it should be 
```
params.proxy_url
```
So I have this PR in an attempt to not have to try and use a forked version of the library.