### PR TITLE
Key 686: process empty arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2019-02-21
+### Changed
+- Empty arrays in the `tenant.yaml` (`clients: []`) will now lead to deleting all relevant records form the tenant.
+
 ## [2.2.0] - 2018-11-28
 ### Changed
 - Update package dependency which contains security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -598,9 +598,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-3.1.4.tgz",
-      "integrity": "sha512-M6TM2Y/gC7xu0BHzj/6whNbOHWrD0R9w6Bm+W0yW3Tflejm2NFRTREHuof3TxmgSY0N/6jsLLnkV79JEz3NNSw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-3.2.0.tgz",
+      "integrity": "sha512-ikcB4o1FCz7ZDFQ9BZwZMS3zsW4tBOuySVubdYqIsxuSDrVf7Tb/fGW12qdPvd1pAIKd1pg0q10Ss5sdIq/3aA==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.3.1",
@@ -7194,18 +7194,18 @@
       }
     },
     "promise-batcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-batcher/-/promise-batcher-1.0.1.tgz",
-      "integrity": "sha512-pQngyWJjGewna0x74+OC7UiMoKBXb4PLa2NRolo6PQgJJ4zJ+xMKnvaDSQm6t4LR9jDHuhHd/Akq4bbtpnGGzQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise-batcher/-/promise-batcher-1.0.2.tgz",
+      "integrity": "sha512-rIy53dWwsEKb7ps3Phbr+CkSe++AZ5gjXKKUiZNln06GpHKSqH1RafdffSPtN9d9FxxgRgMC6zO3w7JYjZR/ew==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "p-defer": "^1.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {
@@ -29,7 +29,7 @@
     "ajv": "^6.5.2",
     "auth0": "^2.14.0",
     "auth0-extension-tools": "^1.2.1",
-    "auth0-source-control-extension-tools": "^3.1.4",
+    "auth0-source-control-extension-tools": "^3.2.0",
     "dot-prop": "^4.2.0",
     "es6-template-strings": "^2.0.1",
     "fs-extra": "^7.0.0",

--- a/src/context/yaml/handlers/clientGrants.js
+++ b/src/context/yaml/handlers/clientGrants.js
@@ -2,7 +2,7 @@
 async function parse(context) {
   // nothing to do, set default empty
   return {
-    clientGrants: [ ...context.assets.clientGrants || [] ]
+    clientGrants: context.assets.clientGrants
   };
 }
 

--- a/src/context/yaml/handlers/clients.js
+++ b/src/context/yaml/handlers/clients.js
@@ -2,7 +2,7 @@
 async function parse(context) {
   // nothing to do, set default empty
   return {
-    clients: [ ...context.assets.clients || [] ]
+    clients: context.assets.clients
   };
 }
 

--- a/src/context/yaml/handlers/connections.js
+++ b/src/context/yaml/handlers/connections.js
@@ -1,7 +1,7 @@
 async function parse(context) {
   // nothing to do, set default if empty
   return {
-    connections: [ ...context.assets.connections || [] ]
+    connections: context.assets.connections
   };
 }
 

--- a/src/context/yaml/handlers/databases.js
+++ b/src/context/yaml/handlers/databases.js
@@ -6,10 +6,11 @@ import log from '../../../logger';
 
 async function parse(context) {
   // Load the script file for custom db
-  const databases = context.assets.databases || [];
+  if (!context.assets.databases) return {};
+
   return {
     databases: [
-      ...databases.map(database => ({
+      ...context.assets.databases.map(database => ({
         ...database,
         options: {
           ...database.options,

--- a/src/context/yaml/handlers/pages.js
+++ b/src/context/yaml/handlers/pages.js
@@ -6,11 +6,11 @@ import log from '../../../logger';
 async function parse(context) {
   // Load the HTML file for each page
 
-  const pages = context.assets.pages || [];
+  if (!context.assets.pages) return {};
 
   return {
     pages: [
-      ...pages.map(page => ({
+      ...context.assets.pages.map(page => ({
         ...page,
         html: context.loadFile(page.html)
       }))

--- a/src/context/yaml/handlers/resourceServers.js
+++ b/src/context/yaml/handlers/resourceServers.js
@@ -1,7 +1,7 @@
 async function parse(context) {
   // nothing to do, set default if empty
   return {
-    resourceServers: [ ...context.assets.resourceServers || [] ]
+    resourceServers: context.assets.resourceServers
   };
 }
 

--- a/src/context/yaml/handlers/rules.js
+++ b/src/context/yaml/handlers/rules.js
@@ -5,11 +5,11 @@ import log from '../../../logger';
 
 async function parse(context) {
   // Load the script file for each rule
-  const rules = context.assets.rules || [];
+  if (!context.assets.rules) return {};
 
   return {
     rules: [
-      ...rules.map(rule => ({
+      ...context.assets.rules.map(rule => ({
         ...rule,
         script: context.loadFile(rule.script)
       }))

--- a/src/context/yaml/handlers/rulesConfigs.js
+++ b/src/context/yaml/handlers/rulesConfigs.js
@@ -2,7 +2,7 @@
 async function parse(context) {
   // nothing to do, set default if empty
   return {
-    rulesConfigs: [ ...context.assets.rulesConfigs || [] ]
+    rulesConfigs: context.assets.rulesConfigs
   };
 }
 

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -18,11 +18,11 @@ describe('#YAML context validation', () => {
     const context = new Context(config, mockMgmtClient());
     await context.load();
 
-    expect(context.assets.rules).to.deep.equal([]);
-    expect(context.assets.databases).to.deep.equal([]);
-    expect(context.assets.pages).to.deep.equal([]);
-    expect(context.assets.clients).to.deep.equal([]);
-    expect(context.assets.resourceServers).to.deep.equal([]);
+    expect(context.assets.rules).to.deep.equal(undefined);
+    expect(context.assets.databases).to.deep.equal(undefined);
+    expect(context.assets.pages).to.deep.equal(undefined);
+    expect(context.assets.clients).to.deep.equal(undefined);
+    expect(context.assets.resourceServers).to.deep.equal(undefined);
   });
 
   it('should error invalid schema', async () => {

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -23,6 +23,9 @@ describe('#YAML context validation', () => {
     expect(context.assets.pages).to.deep.equal(undefined);
     expect(context.assets.clients).to.deep.equal(undefined);
     expect(context.assets.resourceServers).to.deep.equal(undefined);
+    expect(context.assets.clientGrants).to.deep.equal(undefined);
+    expect(context.assets.connections).to.deep.equal(undefined);
+    expect(context.assets.rulesConfigs).to.deep.equal(undefined);
   });
 
   it('should error invalid schema', async () => {


### PR DESCRIPTION
## ✏️ Changes
 `auth0-source-control-extension-tools` updated to v3.2.0, which allows to process empty arrays t oremove records form the tenant. Allow passing `undefined` assets instead of converting them into empty arrays to be able to ignore items.
  
## 🔗 References
  Github issue: #74 
  
## 🎯 Testing
✅ This change has been tested locally
✅ This change has unit test coverage
  