### PR TITLE
allow users to exclude properties on export

### DIFF
--- a/examples/directory/config.json.example
+++ b/examples/directory/config.json.example
@@ -10,5 +10,10 @@
   "AUTH0_EXCLUDED_RULES": [
     "rule-1-name",
     "rule-2-name"
-  ]
+  ],
+  "IGNORED_PROPERTIES": {
+    "clients": [
+      "client_secret"
+    ]
+  }
 }

--- a/examples/yaml/config.json.example
+++ b/examples/yaml/config.json.example
@@ -10,5 +10,10 @@
   "AUTH0_EXCLUDED_RULES": [
     "rule-1-name",
     "rule-2-name"
-  ]
+  ],
+  "IGNORED_PROPERTIES": {
+    "clients": [
+      "client_secret"
+    ]
+  }
 }

--- a/src/context/directory/index.js
+++ b/src/context/directory/index.js
@@ -57,7 +57,7 @@ export default class {
     this.assets = auth0.assets;
 
     // Clean known read only fields
-    this.assets = cleanAssets(this.assets);
+    this.assets = cleanAssets(this.assets, this.config.IGNORED_PROPERTIES);
 
     // Copy clients to be used by handlers which require converting client_id to the name
     // Must copy as the client_id will be stripped if AUTH0_STRIP_IDENTIFIERS is true

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -99,7 +99,7 @@ export default class {
     }));
 
     // Clean known read only fields
-    let cleaned = cleanAssets(this.assets);
+    let cleaned = cleanAssets(this.assets, this.config.IGNORED_PROPERTIES);
 
     // Delete exclude as it's not part of the auth0 tenant config
     delete cleaned.exclude;

--- a/src/readonly.js
+++ b/src/readonly.js
@@ -33,9 +33,10 @@ function deleteKeys(obj, keys) {
 
 export default function cleanAssets(assets, ignoredProps) {
   const cleaned = { ...assets };
-
   if (typeof ignoredProps === 'object') {
-    Object.entries(ignoredProps).forEach(([ name, fields ]) => readOnly[name].concat[fields]);
+    Object.entries(ignoredProps).forEach(([ name, fields ]) => {
+      readOnly[name] = (readOnly[name] || []).concat(fields);
+    });
   }
 
   Object.entries(readOnly).forEach(([ name, fields ]) => {

--- a/src/readonly.js
+++ b/src/readonly.js
@@ -31,8 +31,12 @@ function deleteKeys(obj, keys) {
   return newObj;
 }
 
-export default function cleanAssets(assets) {
+export default function cleanAssets(assets, ignoredProps) {
   const cleaned = { ...assets };
+
+  if (typeof ignoredProps === 'object') {
+    Object.entries(ignoredProps).forEach(([ name, fields ]) => readOnly[name].concat[fields]);
+  }
 
   Object.entries(readOnly).forEach(([ name, fields ]) => {
     const obj = cleaned[name];

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -112,4 +112,56 @@ describe('#YAML context validation', () => {
       }
     });
   });
+
+  it('should dump tenant.yaml with IGNORED_PROPERTIES', async () => {
+    const dir = path.resolve(testDataDir, 'yaml', 'dump');
+    cleanThenMkdir(dir);
+    const tenantFile = path.join(dir, 'tenant.yml');
+    const config = {
+      AUTH0_INPUT_FILE: tenantFile,
+      IGNORED_PROPERTIES: {
+        clients: [ 'client_id' ],
+        tenant: [ 'friendly_name' ]
+      }
+    };
+    const context = new Context(config, mockMgmtClient());
+    await context.dump();
+    const yaml = jsYaml.safeLoad(fs.readFileSync(tenantFile));
+    expect(yaml).to.deep.equal({
+      clientGrants: [],
+      clients: [
+        {
+          custom_login_page: '<html>page</html>',
+          custom_login_page_on: true,
+          name: 'Global Client'
+        }
+      ],
+      connections: [],
+      databases: [],
+      emailProvider: {},
+      emailTemplates: [
+        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
+        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' },
+        { body: './emailTemplates/blocked_account.html', enabled: true, template: 'blocked_account' },
+        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/enrollment_email.html', enabled: true, template: 'enrollment_email' },
+        { body: './emailTemplates/mfa_oob_code.html', enabled: true, template: 'mfa_oob_code' },
+        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
+        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' }
+      ],
+      pages: [
+        { enabled: true, html: './pages/login.html', name: 'login' }
+      ],
+      guardianFactors: [],
+      guardianFactorProviders: [],
+      guardianFactorTemplates: [],
+      resourceServers: [],
+      rules: [],
+      rulesConfigs: [],
+      tenant: {
+        default_directory: 'users'
+      }
+    });
+  });
 });


### PR DESCRIPTION
## ✏️ Changes
  New `IGNORED_PROPERTIES` property added to config. It should allow customers to exclude certain props (such as `client_secret`) during export. 

Example:
```
"IGNORED_PROPERTIES": {
  "clients": [
    "client_secret"
  ]
}
```
  
## 🔗 References
  Github: #72 
  Slack: https://auth0.slack.com/archives/C9170558S/p1550745653014100
  
## 🎯 Testing
✅ This change has been tested locally
✅ This change has unit test coverage
 