### PR TITLE
KEY-684: Export without secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2019-02-21
+## [2.3.0] - Unreleased
+### Added
+- `INCLUDED_PROPS` option has been added to the config. It allows user to export properties which are excluded by default (like `client_secret`).
+- `EXCLUDED_PROPS` option has been added to the config. It allows user to exclude any unwanted properties from exported objects.
+
 ### Changed
 - Empty arrays in the `tenant.yaml` (`clients: []`) will now lead to deleting all relevant records form the tenant.
+- `strip` option has been removed from `export` command. Now IDs will be stripped by default. Use `--export_ids` or `-e` to prevent that.
+
+### Fixed
+- Email provider export issue
 
 ## [2.2.0] - 2018-11-28
 ### Changed

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ dump({
   base_path: basePath,                          // Allow to override basepath, if not take from input_file
   config_file: configFile,                      // Option to a config json
   config: configObj,                            // Option to sent in json as object
-  strip,                                        // Strip the identifier field for each object type
+  export_ids: exportIds,                        // Export the identifier field for each object type
   secret                                        // Optionally pass in auth0 client secret seperate from config
 })
   .then(() => console.log('yey export was successful'))
@@ -189,8 +189,8 @@ Options:
   --proxy_url, -p  A url for proxying requests, only set this if you are behind a proxy.  [string]
 
 Examples:
-  a0deploy export -c config.json --strip -f yaml -o path/to/export       Dump Auth0 config to folder in YAML format
-  a0deploy export -c config.json --strip -f directory -o path/to/export  Dump Auth0 config to folder in directory format
+  a0deploy export -c config.json -f yaml -o path/to/export               Dump Auth0 config to folder in YAML format
+  a0deploy export -c config.json -f directory -o path/to/export          Dump Auth0 config to folder in directory format
   a0deploy import -c config.json -i tenant.yaml                          Deploy Auth0 via YAML
   a0deploy import -c config.json -i path/to/files                        Deploy Auth0 via Path
 

--- a/examples/directory/README.md
+++ b/examples/directory/README.md
@@ -62,9 +62,9 @@ repository =>
 ## Example Export
 You can export your current tenant configuration. For example the following command will export your tenant configuration.
 
-`a0deploy export -c config.json --strip -f directory -o path/to/export`
+`a0deploy export -c config.json -f directory -o path/to/export`
 
-> NOTE: The option --strip is used to remove the identifier fields from the Auth0 objects. This means when importing into another Auth0 Tenant new id's are generated otherwise the import will fail as the tool cannot find the existing objects by their id.
+> NOTE: The option --export_ids or -e can be used to export the identifier fields to the Auth0 objects. This means you won't be able to import these objects as the tool cannot find the existing objects by their id.
 
 > NOTE: Some of the settings cannot be exported for example emailProvider credentials, rulesConfigs values and others. After export you may need to update the `tenant.yaml` values if you experience schema errors on import.
 
@@ -107,7 +107,13 @@ Here is the example of a config.json:
   "AUTH0_EXCLUDED_RULES": [
     "rule-1-name",
     "rule-2-name"
-  ]
+  ],
+  "INCLUDED_PROPS": {
+    "clients": [ "client_secret" ]
+  },
+  "EXCLUDED_PROPS": {
+    "connections": [ "options.client_secret" ]
+  }
 }
 ```
 

--- a/examples/directory/config.json.example
+++ b/examples/directory/config.json.example
@@ -10,5 +10,11 @@
   "AUTH0_EXCLUDED_RULES": [
     "rule-1-name",
     "rule-2-name"
-  ]
+  ],
+  "INCLUDED_PROPS": {
+    "clients": [ "client_secret" ]
+  },
+  "EXCLUDED_PROPS": {
+    "connections": [ "options.client_secret" ]
+  }
 }

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -10,9 +10,9 @@ For more information on YAML please refer to [http://yaml.org/](http://yaml.org/
 ## Example Export
 You can export your current tenant configuration. For example the following command will export your tenant configuration.
 
-`a0deploy export -c config.json --strip -f yaml -o path/to/export`
+`a0deploy export -c config.json -f yaml -o path/to/export`
 
-> NOTE: The option --strip is used to remove the identifier fields from the Auth0 objects. This means when importing into another Auth0 Tenant new id's are generated otherwise the import will fail as the tool cannot find the existing objects by their id.
+> NOTE: The option --export_ids or -e can be used to export the identifier fields to the Auth0 objects. This means you won't be able to import these objects as the tool cannot find the existing objects by their id.
 
 > NOTE: Some of the settings cannot be exported for example emailProvider credentials, rulesConfigs values and others. After export you may need to update the `tenant.yaml` values if you experience schema errors on import.
 
@@ -50,6 +50,12 @@ Here is the example of a config.json:
       "https://somedomain.com"
     ],
     "YOUR_STRING_KEY": "some environment specific string"
+  },
+  "INCLUDED_PROPS": {
+    "clients": [ "client_secret" ]
+  },
+  "EXCLUDED_PROPS": {
+    "connections": [ "options.client_secret" ]
   }
 }
 ```

--- a/examples/yaml/config.json.example
+++ b/examples/yaml/config.json.example
@@ -10,5 +10,11 @@
   "AUTH0_EXCLUDED_RULES": [
     "rule-1-name",
     "rule-2-name"
-  ]
+  ],
+  "INCLUDED_PROPS": {
+    "clients": [ "client_secret" ]
+  },
+  "EXCLUDED_PROPS": {
+    "connections": [ "options.client_secret" ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -598,9 +598,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-3.2.0.tgz",
-      "integrity": "sha512-ikcB4o1FCz7ZDFQ9BZwZMS3zsW4tBOuySVubdYqIsxuSDrVf7Tb/fGW12qdPvd1pAIKd1pg0q10Ss5sdIq/3aA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-3.2.1.tgz",
+      "integrity": "sha512-bM4BGZzj+ncVMkMYptDEZlNgusuC+dhBYHD4vmI8mdsmew1UOB+mu8yQ1ya1DFsI2V1fjWbtcLxZXgibYz1kzg==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ajv": "^6.5.2",
     "auth0": "^2.14.0",
     "auth0-extension-tools": "^1.2.1",
-    "auth0-source-control-extension-tools": "^3.2.0",
+    "auth0-source-control-extension-tools": "^3.2.1",
     "dot-prop": "^4.2.0",
     "es6-template-strings": "^2.0.1",
     "fs-extra": "^7.0.0",

--- a/src/args.js
+++ b/src/args.js
@@ -58,20 +58,20 @@ export default yargs
       describe: 'The JSON configuration file.',
       type: 'string'
     },
-    strip: {
-      alias: 's',
-      describe: 'Strip the identifier field for each object type.',
-      type: 'boolean',
-      default: false
-    },
     secret: {
       alias: 'x',
       describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
       type: 'string'
+    },
+    export_ids: {
+      alias: 'e',
+      describe: 'Export identifier field for each object type.',
+      type: 'boolean',
+      default: false
     }
   })
-  .example('$0 export -c config.json --strip -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
-  .example('$0 export -c config.json --strip -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
+  .example('$0 export -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
+  .example('$0 export -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
   .example('$0 import -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
   .example('$0 import -c config.json -i path/to/files', 'Deploy Auth0 via Path')
   .epilogue('See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.')

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -12,7 +12,7 @@ export default async function deploy(params) {
     base_path: basePath,
     config_file: configFile,
     config: configObj,
-    strip,
+    export_ids: exportIds,
     secret
   } = params;
 
@@ -26,7 +26,7 @@ export default async function deploy(params) {
     AUTH0_INPUT_FILE: outputFolder,
     AUTH0_BASE_PATH: basePath,
     AUTH0_CONFIG_FILE: configFile,
-    AUTH0_STRIP_IDENTIFIERS: strip,
+    AUTH0_EXPORT_IDENTIFIERS: exportIds,
     ...configObj || {}
   };
 

--- a/src/context/directory/index.js
+++ b/src/context/directory/index.js
@@ -57,14 +57,14 @@ export default class {
     this.assets = auth0.assets;
 
     // Clean known read only fields
-    this.assets = cleanAssets(this.assets);
+    this.assets = cleanAssets(this.assets, this.config);
 
     // Copy clients to be used by handlers which require converting client_id to the name
-    // Must copy as the client_id will be stripped if AUTH0_STRIP_IDENTIFIERS is true
+    // Must copy as the client_id will be stripped if AUTH0_EXPORT_IDENTIFIERS is false
     this.assets.clientsOrig = [ ...this.assets.clients ];
 
     // Optionally Strip identifiers
-    if (this.config.AUTH0_STRIP_IDENTIFIERS) {
+    if (!this.config.AUTH0_EXPORT_IDENTIFIERS) {
       this.assets = stripIdentifiers(auth0, this.assets);
     }
 

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -99,13 +99,13 @@ export default class {
     }));
 
     // Clean known read only fields
-    let cleaned = cleanAssets(this.assets);
+    let cleaned = cleanAssets(this.assets, this.config);
 
     // Delete exclude as it's not part of the auth0 tenant config
     delete cleaned.exclude;
 
     // Optionally Strip identifiers
-    if (this.config.AUTH0_STRIP_IDENTIFIERS) {
+    if (!this.config.AUTH0_EXPORT_IDENTIFIERS) {
       cleaned = stripIdentifiers(auth0, cleaned);
     }
 

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -80,7 +80,6 @@ describe('#YAML context validation', () => {
       clientGrants: [],
       clients: [
         {
-          client_id: 'FMfcgxvzLDvPsgpRFKkLVrnKqGgkHhQV',
           custom_login_page: '<html>page</html>',
           custom_login_page_on: true,
           name: 'Global Client'
@@ -114,5 +113,77 @@ describe('#YAML context validation', () => {
         friendly_name: 'Test'
       }
     });
+  });
+
+  it('should dump tenant.yaml with INCLUDED and EXCLUDED props', async () => {
+    const dir = path.resolve(testDataDir, 'yaml', 'dump');
+    cleanThenMkdir(dir);
+    const tenantFile = path.join(dir, 'tenant.yml');
+    const config = {
+      AUTH0_INPUT_FILE: tenantFile,
+      INCLUDED_PROPS: { clients: [ 'client_secret' ] },
+      EXCLUDED_PROPS: { clients: [ 'name' ] }
+    };
+    const context = new Context(config, mockMgmtClient());
+    await context.dump();
+    const yaml = jsYaml.safeLoad(fs.readFileSync(tenantFile));
+    expect(yaml).to.deep.equal({
+      clientGrants: [],
+      clients: [
+        {
+          custom_login_page: '<html>page</html>',
+          custom_login_page_on: true,
+          client_secret: 'dummy_client_secret'
+        }
+      ],
+      connections: [],
+      databases: [],
+      emailProvider: {},
+      emailTemplates: [
+        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
+        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' },
+        { body: './emailTemplates/blocked_account.html', enabled: true, template: 'blocked_account' },
+        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/enrollment_email.html', enabled: true, template: 'enrollment_email' },
+        { body: './emailTemplates/mfa_oob_code.html', enabled: true, template: 'mfa_oob_code' },
+        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
+        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' }
+      ],
+      pages: [
+        { enabled: true, html: './pages/login.html', name: 'login' }
+      ],
+      guardianFactors: [],
+      guardianFactorProviders: [],
+      guardianFactorTemplates: [],
+      resourceServers: [],
+      rules: [],
+      rulesConfigs: [],
+      tenant: {
+        default_directory: 'users',
+        friendly_name: 'Test'
+      }
+    });
+  });
+
+  it('should throw error if INCLUDED and EXCLUDED props have intersections', async () => {
+    const dir = path.resolve(testDataDir, 'yaml', 'dump');
+    cleanThenMkdir(dir);
+    const tenantFile = path.join(dir, 'tenant.yml');
+    const config = {
+      AUTH0_INPUT_FILE: tenantFile,
+      INCLUDED_PROPS: { clients: [ 'client_secret', 'name' ] },
+      EXCLUDED_PROPS: { clients: [ 'client_secret', 'name' ] }
+    };
+    const context = new Context(config, mockMgmtClient());
+    let err;
+
+    try {
+      await context.dump();
+    } catch (e) {
+      err = e.message;
+    }
+
+    expect(err).to.equal('EXCLUDED_PROPS should NOT have any intersections with INCLUDED_PROPS. Intersections found: clients: client_secret, name');
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -38,7 +38,7 @@ export function mockMgmtClient() {
     clients: {
       getAll: () => [
         {
-          name: 'Global Client', client_id: 'FMfcgxvzLDvPsgpRFKkLVrnKqGgkHhQV', custom_login_page_on: true, custom_login_page: '<html>page</html>'
+          name: 'Global Client', client_id: 'FMfcgxvzLDvPsgpRFKkLVrnKqGgkHhQV', client_secret: 'dummy_client_secret', custom_login_page_on: true, custom_login_page: '<html>page</html>'
         }
       ]
     },


### PR DESCRIPTION
## ✏️ Changes
Fixes #72 
- `strip` option is replaced by `export_ids`. It's false by default, which means that IDs will be removed from exported object.
- `INCLUDED_PROPS` and `EXCLUDED_PROPS` are added to the config. Those can be used for flexible tweak of what properties should be included into exported objects.

## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/KEY-684
  Github: #72
  
## 🎯 Testing 
✅ This change has been tested locally
✅ This change has unit test coverage
