### PR TITLE
convert non-integer `session_lifetime` to minutes

### DIFF
--- a/src/context/directory/handlers/tenant.js
+++ b/src/context/directory/handlers/tenant.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import log from '../../../logger';
-import { existsMustBeDir, isFile, loadJSON } from '../../../utils';
+import { existsMustBeDir, isFile, loadJSON, hoursAsInteger } from '../../../utils';
 
 function parse(context) {
   const baseFolder = path.join(context.filePath);
@@ -11,9 +11,21 @@ function parse(context) {
   const tenantFile = path.join(baseFolder, 'tenant.json');
 
   if (isFile(tenantFile)) {
+    /* eslint-disable camelcase */
+    const {
+      session_lifetime,
+      idle_session_lifetime,
+      ...tenant
+    } = loadJSON(tenantFile, context.mappings);
+
     return {
-      tenant: loadJSON(tenantFile, context.mappings)
+      tenant: Object.assign(
+        tenant,
+        session_lifetime && hoursAsInteger('session_lifetime', session_lifetime),
+        idle_session_lifetime && hoursAsInteger('idle_session_lifetime', idle_session_lifetime)
+      )
     };
+    /* eslint-enable camelcase */
   }
 
   return {};

--- a/src/context/yaml/handlers/tenant.js
+++ b/src/context/yaml/handlers/tenant.js
@@ -1,8 +1,24 @@
+import { hoursAsInteger } from '../../../utils';
+
 async function parse(context) {
-  // nothing to do, set default if empty
+  // Nothing to do
+  if (!context.assets.tenant) return {};
+
+  /* eslint-disable camelcase */
+  const {
+    session_lifetime,
+    idle_session_lifetime,
+    ...tenant
+  } = context.assets.tenant;
+
   return {
-    tenant: { ...context.assets.tenant || {} }
+    tenant: Object.assign(
+      tenant,
+      session_lifetime && hoursAsInteger('session_lifetime', session_lifetime),
+      idle_session_lifetime && hoursAsInteger('idle_session_lifetime', idle_session_lifetime)
+    )
   };
+  /* eslint-enable camelcase */
 }
 
 async function dump(context) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,3 +89,9 @@ export function stripIdentifiers(auth0, assets) {
 export function sanitize(str) {
   return sanitizeName(str, { replacement: '-' });
 }
+
+
+export function hoursAsInteger(property, hours) {
+  if (Number.isInteger(hours)) return { [property]: hours };
+  return { [`${property}_in_minutes`]: Math.round(hours * 60) };
+}

--- a/test/context/directory/tenant.test.js
+++ b/test/context/directory/tenant.test.js
@@ -10,14 +10,16 @@ const tenantTest = {
   'tenant.json': `{
     "friendly_name": "Auth0 ##env##",
     "default_directory": "users",
-    "idle_session_lifetime": 72
+    "session_lifetime": 1.48394893,
+    "idle_session_lifetime": 123.4
   }`
 };
 
 const tenantTarget = {
   friendly_name: 'Auth0 test',
   default_directory: 'users',
-  idle_session_lifetime: 72
+  session_lifetime_in_minutes: 89,
+  idle_session_lifetime_in_minutes: 7404
 };
 
 describe('#directory context tenant', () => {
@@ -44,6 +46,8 @@ describe('#directory context tenant', () => {
     };
 
     await handler.dump(context);
-    expect(loadJSON(path.join(dir, 'tenant.json'))).to.deep.equal(context.assets.tenant);
+    const dumped = loadJSON(path.join(dir, 'tenant.json'));
+
+    expect(dumped).to.deep.equal(context.assets.tenant);
   });
 });

--- a/test/context/yaml/tenant.test.js
+++ b/test/context/yaml/tenant.test.js
@@ -15,14 +15,19 @@ describe('#YAML context tenant settings', () => {
     const yaml = `
     tenant:
       friendly_name: 'Auth0 ##ENV##'
+      default_directory: "users"
+      session_lifetime: 1.48394893
+      idle_session_lifetime: 123.4
     `;
     const yamlFile = path.join(dir, 'config.yaml');
     fs.writeFileSync(yamlFile, yaml);
 
     const target = {
-      friendly_name: 'Auth0 test'
+      friendly_name: 'Auth0 test',
+      default_directory: 'users',
+      session_lifetime_in_minutes: 89,
+      idle_session_lifetime_in_minutes: 7404
     };
-
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,7 +12,8 @@ import {
   existsMustBeDir,
   toConfigFn,
   stripIdentifiers,
-  sanitize
+  sanitize,
+  hoursAsInteger
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -104,6 +105,16 @@ describe('#utils', function() {
           value: 'test'
         }
       ]
+    });
+  });
+
+  it('should convert value to integer', () => {
+    expect(hoursAsInteger('test', 72)).to.deep.equal({
+      test: 72
+    });
+
+    expect(hoursAsInteger('test', 1.23)).to.deep.equal({
+      test_in_minutes: 74
     });
   });
 });


### PR DESCRIPTION
Auth0 Deploy CLI exports and imports are throwing an error when they configure a non whole hour value for `idle_session_lifetime` and `session_lifetime` in the Dashboard.

Err message looks like:

```
2019-02-18T19:13:37.297Z - error: Problem running command import during stage processChanges when processing type tenant
2019-02-18T19:13:37.297Z - error: Payload validation error: 'Expected type integer but found type number' on property idle_session_lifetime (Force a user to login after they have been inactive for the specified number (unit: hours)).
```
and
```
Payload validation error: 'Expected type integer but found type number' on property session_lifetime 
(Login session lifetime, how long the session will stay valid (unit: hours)).
```

## ✏️ Changes

Allow deploy-cli users to account for non-integer values for `session_lifetime` and `idle_session_lifetime` in the form of `session_lifetime_in_minutes` and `idle_session_lifetime_in_minutes`.
  
## 🔗 References
  
Slack:
- https://auth0.slack.com/archives/C9170558S/p1550518374059300
- https://auth0.slack.com/archives/CELNVJVH7/p1550235309035600
  
## 🎯 Testing
  
1. Set up Auth0 Deploy CLI
2. Configure tenant’s  “session_lifetime: 61” and “idle_session_lifetime: 61" (input a value NOT in whole hours(60/120/180))
3. a0deploy export -c config.json -f yaml -o ~/auth0cli.yaml
4. a0deploy import -c config.json -i tenant.yaml

✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  