### PR TITLE
Mark `enable_sso` and `sandbox_version` as readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - Unreleased
+### Changed
+- set `enable_sso` and `sandbox_version` as readonly properties
+- alias `export = dump` and `import = deploy` for programmatic usage
+
 ## [2.3.1] - 2019-02-27
 ### Changed
 - convert non-integer `session_lifetime` to minutes #95

--- a/src/index.js
+++ b/src/index.js
@@ -77,9 +77,9 @@ if (require.main === module) {
 
 
 // Export commands to be used programmatically
-export const deploy = commands.import;
-export const dump = commands.export;
-export default {
+module.exports = {
   deploy: commands.import,
-  dump: commands.export
+  dump: commands.export,
+  import: commands.import,
+  export: commands.export
 };

--- a/src/readonly.js
+++ b/src/readonly.js
@@ -10,6 +10,8 @@ const readOnly = {
     'realms'
   ],
   tenant: [
+    'enable_sso',
+    'sandbox_version',
     'sandbox_versions_available',
     'flags.allow_changing_enable_sso',
     'flags.disable_impersonation'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+
+const a0deploy = require('../src');
+
+describe('#index exports', () => {
+  it('should expose functions for deploy, dump, import, and export', () => {
+    expect(Object.keys(a0deploy)).to.have.all.members([ 'deploy', 'dump', 'import', 'export' ]);
+  });
+});


### PR DESCRIPTION
## ✏️ Changes

- Mark `enable_sso` and `sandbox_version` as readonly
- Alias `deploy` = `import` and `dump` = `export` for naming consistency on programmatic usage

## 🔗 References

Fix #57
Fix #69

## 🎯 Testing

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
