### PR TITLE
Variable injection explanation does not match behavior

### DIFF
--- a/examples/directory/README.md
+++ b/examples/directory/README.md
@@ -124,9 +124,9 @@ Environment variables can be set on the terminal and within the `config.json`. A
 
 There are two ways to use the keyword mappings in your Auth0 Tenant configuration files. You can inject values using `@@key@@` or `##key##`.
 
-If you use the `@` symbols, it will do a JSON.stringify on your value before replacing it. So if it is a string it will add quotes, if it is an array or object it will add braces.
+Use the `@` symbols to inject the full, literal value regardless of type (string, number, object, array).
 
-If you use the `#` symbol instead, it will do a literal replacement. It will not add quotes or brackets.
+Use the `#` symbols for string interpolation.
 
 For example, you could specify a different JWT timeout in your dev environment then prod for testing and a different environment URL:
 


### PR DESCRIPTION
This example states...

>If you use the @ symbols, it will do a JSON.stringify on your value before replacing it. So if it is a string it will add quotes, if it is an array or object it will add braces.
>
>If you use the # symbol instead, it will do a literal replacement. It will not add quotes or brackets.

However, this is not accurate. For example, if you have the following...

`"myArray" : [
    "value1",
    "value2"
]`

...based on the doc excerpt above, one would expect to use `"field": ##myArray##` to get the literal array. But that results in something like...

`error: Error parsing JSON from metadata file: myTenant/clients/my-android-app.json, because: Unexpected token : in JSON at position 640`

Instead, using `"field": @@myArray@@` works. Which of course is not JSON.stringifying the array into a string (as the doc states it would), but literally injecting the array without any transformation.

In testing this, it appears that `@` should be used when injecting the full, literal value regardless of type (object, array, string, number), and `#` should be used for string interpolation. 

Examples:

`"GRANT_TYPES" : ["authorization_code", "refresh_token"]`
    - Usage: `"grant_types" : @@GRANT_TYPES@@`

`"JWT_CONFIG" : {"lifetime_in_seconds": 3600, "alg": "RS256"}`
    - Usage: `"jwt_configuration" : @@JWT_CFG@@`

`"JWT_TIMEOUT" : 3600`
        - Usage: `"lifetime_in_seconds" : @@JWT_TIMEOUT@@`

`"ANDROID_PACKAGE" : "com.myorg.app-beta"`
    - Usage: `"app_package_name" : @@ANDROID_PACKAGE@@`

`"ANDROID_PACKAGE_ENV" : "prod"`
    - Usage: `"app_package_name" : "com.myorg.app-##ANDROID_PACKAGE_ENV##"`

