### PR TITLE
Fixed unhandled rejection issue (exit status on error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - Unreleased
+## [3.1.1] - Unreleased
+### Fixed
+- Exit status code on error
+
+## [3.1.0] - 2019-03-14
 ### Added
 - `AUTH0_EXCLUDED_CLIENTS` option has been added to the config. Works similar to `AUTH0_EXCLUDED_RULES` and `AUTH0_EXCLUDED_RESOURCE_SERVERS`. #102
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ if (require.main === module) {
         log.debug(error.stack);
       }
 
-      if (msg.includes('Payload validation error')) {
+      if (typeof msg === 'string' && msg.includes('Payload validation error')) {
         log.info('Please see https://github.com/auth0/auth0-deploy-cli#troubleshooting for common issues');
       }
       process.exit(1);


### PR DESCRIPTION
## ✏️ Changes
In some cases app crashed on `msg.includes()`, leading to unhandled rejection and exit with code 0. Added `msg` check to avoid that. Fixes #2 and #106 

## 🔗 References
Github issues: #2, #106 

## 🎯 Testing
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
