### PR TITLE
Strict formatting (props order) for yaml dump

### DIFF
--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { loadFile, keywordReplace, Auth0 } from 'auth0-source-control-extension-tools';
 
 import log from '../../logger';
-import { isFile, toConfigFn, stripIdentifiers } from '../../utils';
+import { isFile, toConfigFn, stripIdentifiers, formatResults } from '../../utils';
 import handlers from './handlers';
 import cleanAssets from '../../readonly';
 
@@ -90,7 +90,7 @@ export default class {
           log.info(`Exporting ${name}`);
           Object.entries(data)
             .forEach(([ k, v ]) => {
-              this.assets[k] = v;
+              this.assets[k] = Array.isArray(v) ? v.map(formatResults) : formatResults(v);
             });
         }
       } catch (err) {

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { loadFile, keywordReplace, Auth0 } from 'auth0-source-control-extension-tools';
 
 import log from '../../logger';
-import { isFile, toConfigFn, stripIdentifiers, formatResults } from '../../utils';
+import { isFile, toConfigFn, stripIdentifiers, formatResults, recordsSorter } from '../../utils';
 import handlers from './handlers';
 import cleanAssets from '../../readonly';
 
@@ -90,7 +90,7 @@ export default class {
           log.info(`Exporting ${name}`);
           Object.entries(data)
             .forEach(([ k, v ]) => {
-              this.assets[k] = Array.isArray(v) ? v.map(formatResults) : formatResults(v);
+              this.assets[k] = Array.isArray(v) ? v.map(formatResults).sort(recordsSorter) : formatResults(v);
             });
         }
       } catch (err) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,3 +95,29 @@ export function hoursAsInteger(property, hours) {
   if (Number.isInteger(hours)) return { [property]: hours };
   return { [`${property}_in_minutes`]: Math.round(hours * 60) };
 }
+
+
+export function formatResults(item) {
+  const importantFields = {
+    name: null,
+    client_id: null,
+    audience: null,
+    template: null,
+    identifier: null,
+    strategy: null,
+    script: null,
+    stage: null,
+    id: null
+  };
+  const result = { ...importantFields };
+
+  Object.entries(item).sort().forEach(([ key, value ]) => {
+    result[key] = value;
+  });
+
+  Object.keys(importantFields).forEach((key) => {
+    if (result[key] === null) delete result[key];
+  });
+
+  return result;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -121,3 +121,23 @@ export function formatResults(item) {
 
   return result;
 }
+
+
+export function recordsSorter(a, b) {
+  const importantFields = [
+    'name',
+    'key',
+    'client_id',
+    'template'
+  ];
+
+  for (let i = 0; i < importantFields.length; i += 1) {
+    const key = importantFields[i];
+
+    if (a[key] && b[key]) {
+      return a[key] > b[key] ? 1 : -1;
+    }
+  }
+
+  return 0;
+}

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -89,15 +89,15 @@ describe('#YAML context validation', () => {
       databases: [],
       emailProvider: {},
       emailTemplates: [
-        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
-        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
-        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' },
         { body: './emailTemplates/blocked_account.html', enabled: true, template: 'blocked_account' },
-        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
         { body: './emailTemplates/enrollment_email.html', enabled: true, template: 'enrollment_email' },
         { body: './emailTemplates/mfa_oob_code.html', enabled: true, template: 'mfa_oob_code' },
-        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
-        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' }
+        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' },
+        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
+        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' }
       ],
       pages: [
         { enabled: true, html: './pages/login.html', name: 'login' }
@@ -140,15 +140,15 @@ describe('#YAML context validation', () => {
       databases: [],
       emailProvider: {},
       emailTemplates: [
-        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
-        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
-        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' },
         { body: './emailTemplates/blocked_account.html', enabled: true, template: 'blocked_account' },
-        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
         { body: './emailTemplates/enrollment_email.html', enabled: true, template: 'enrollment_email' },
         { body: './emailTemplates/mfa_oob_code.html', enabled: true, template: 'mfa_oob_code' },
-        { body: './emailTemplates/change_password.html', enabled: true, template: 'change_password' },
-        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' }
+        { body: './emailTemplates/password_reset.html', enabled: true, template: 'password_reset' },
+        { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
+        { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
+        { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' }
       ],
       pages: [
         { enabled: true, html: './pages/login.html', name: 'login' }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -13,7 +13,9 @@ import {
   toConfigFn,
   stripIdentifiers,
   sanitize,
-  hoursAsInteger
+  hoursAsInteger,
+  formatResults,
+  recordsSorter
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -116,5 +118,51 @@ describe('#utils', function() {
     expect(hoursAsInteger('test', 1.23)).to.deep.equal({
       test_in_minutes: 74
     });
+  });
+
+  it('should format object', () => {
+    const result = formatResults({
+      b: 'Bravo',
+      id: 'Id',
+      d: 'Delta',
+      identifier: 'Identifier',
+      c: 'Charlie',
+      name: 'Name',
+      a: 'Alpha'
+    });
+    expect(Object.keys(result)).to.deep.equal([ 'name', 'identifier', 'id', 'a', 'b', 'c', 'd' ]);
+    expect(result).to.deep.equal({
+      name: 'Name',
+      identifier: 'Identifier',
+      id: 'Id',
+      a: 'Alpha',
+      b: 'Bravo',
+      c: 'Charlie',
+      d: 'Delta'
+    });
+  });
+
+  it('should sort records by name or template', () => {
+    const name = [
+      { name: 'b', id: 0 },
+      { name: 'a', id: 1 },
+      { name: 'c', id: 2 }
+    ];
+    const template = [
+      { template: 'b', id: 0 },
+      { template: 'a', id: 1 },
+      { template: 'c', id: 2 }
+    ];
+
+    expect(name.sort(recordsSorter)).to.deep.equal([
+      { name: 'a', id: 1 },
+      { name: 'b', id: 0 },
+      { name: 'c', id: 2 }
+    ]);
+    expect(template.sort(recordsSorter)).to.deep.equal([
+      { template: 'a', id: 1 },
+      { template: 'b', id: 0 },
+      { template: 'c', id: 2 }
+    ]);
   });
 });


### PR DESCRIPTION
## ✏️ Changes
Sorting assets by properties to make sure that order of those properties in yaml will be the same on each `dump` run.
Fixes #61  
Fixes #82 

## 🔗 References
Github issues: #61 and #82

## 🎯 Testing
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
