### PR TITLE
Do not export secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Secrets (`rules configs` and databases `options.configuration`) can no longer be exported
+
 ## [3.1.2] - 2019-03-22
 ### Added
 - Consistent property sorting for yaml dump #108 #61 #82

--- a/src/context/directory/handlers/rulesConfigs.js
+++ b/src/context/directory/handlers/rulesConfigs.js
@@ -1,9 +1,7 @@
-import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
-import log from '../../../logger';
+import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const rulesConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);
@@ -20,22 +18,9 @@ function parse(context) {
 }
 
 
-async function dump(context) {
-  const { rulesConfigs } = context.assets;
-
-  if (!rulesConfigs) return; // Skip, nothing to dump
-
-  const ruleConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);
-  fs.ensureDirSync(ruleConfigsFolder);
-
-  rulesConfigs.forEach((rulesConfig) => {
-    const ruleConfigFile = path.join(ruleConfigsFolder, sanitize(`${rulesConfig.key}.json`));
-    log.info(`Writing ${ruleConfigFile}`);
-    fs.writeFileSync(ruleConfigFile, JSON.stringify({
-      value: '******',
-      ...rulesConfig
-    }, null, 2));
-  });
+async function dump() {
+  // do not export rulesConfigs as its values cannot be extracted
+  return null;
 }
 
 

--- a/src/context/yaml/handlers/rulesConfigs.js
+++ b/src/context/yaml/handlers/rulesConfigs.js
@@ -6,13 +6,10 @@ async function parse(context) {
   };
 }
 
-async function dump(context) {
-  const rulesConfigs = context.assets.rulesConfigs || [];
+async function dump() {
+  // do not export rulesConfigs as its values cannot be extracted
   return {
-    rulesConfigs: rulesConfigs.map(r => ({
-      ...r,
-      value: '*******'
-    }))
+    rulesConfigs: []
   };
 }
 

--- a/src/readonly.js
+++ b/src/readonly.js
@@ -9,6 +9,9 @@ const readOnly = {
     'provisioning_ticket_url',
     'realms'
   ],
+  databases: [
+    'options.configuration'
+  ],
   tenant: [
     'sandbox_version',
     'sandbox_versions_available',

--- a/test/context/directory/rulesConfigs.js
+++ b/test/context/directory/rulesConfigs.js
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/rulesConfigs';
-import { loadJSON } from '../../../src/utils';
 import { cleanThenMkdir, testDataDir, createDir, mockMgmtClient } from '../../utils';
 
 
@@ -70,7 +69,7 @@ describe('#directory context rulesConfigs', () => {
       .and.have.property('message', errorMessage);
   });
 
-  it('should dump rules configs', async () => {
+  it('should not dump rules configs', async () => {
     const dir = path.join(testDataDir, 'directory', 'rulesConfigsDump');
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
@@ -81,20 +80,7 @@ describe('#directory context rulesConfigs', () => {
 
     await handler.dump(context);
     const rulesConfigsFolder = path.join(dir, constants.RULES_CONFIGS_DIRECTORY);
-    expect(loadJSON(path.join(rulesConfigsFolder, 'SOME_SECRET.json'))).to.deep.equal(context.assets.rulesConfigs[0]);
-  });
-
-  it('should dump rules configs sanitized', async () => {
-    const dir = path.join(testDataDir, 'directory', 'rulesConfigsDump');
-    cleanThenMkdir(dir);
-    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
-
-    context.assets.rulesConfigs = [
-      { key: 'SOME_SECRET/test', value: 'some_key' }
-    ];
-
-    await handler.dump(context);
-    const rulesConfigsFolder = path.join(dir, constants.RULES_CONFIGS_DIRECTORY);
-    expect(loadJSON(path.join(rulesConfigsFolder, 'SOME_SECRET-test.json'))).to.deep.equal(context.assets.rulesConfigs[0]);
+    const exists = await fs.pathExists(path.join(rulesConfigsFolder, 'SOME_SECRET.json'));
+    expect(exists).to.equal(false);
   });
 });

--- a/test/context/yaml/rulesConfigs.test.js
+++ b/test/context/yaml/rulesConfigs.test.js
@@ -39,10 +39,6 @@ describe('#YAML context rules configs', () => {
     context.assets.rulesConfigs = rulesConfigs;
 
     const dumped = await handler.dump(context);
-    expect(dumped).to.deep.equal({
-      rulesConfigs: [
-        { key: 'SOME_SECRET', value: '*******' }
-      ]
-    });
+    expect(dumped).to.deep.equal({ rulesConfigs: [] });
   });
 });

--- a/test/readonly.test.js
+++ b/test/readonly.test.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+
+import cleanAssets from '../src/readonly';
+
+describe('#readonly', function() {
+  it('should clear databases of options.configuration', () => {
+    const assets = {
+      databases: [
+        {
+          name: 'db1',
+          strategy: 'auth0',
+          options: {
+            configuration: {
+              secret: 'i am actually a goose'
+            },
+            requires_username: true
+          }
+        }
+      ]
+    };
+    const target = {
+      name: 'db1',
+      strategy: 'auth0',
+      options: {
+        requires_username: true
+      }
+    };
+    const clear = cleanAssets(assets, {});
+    expect(clear.databases).is.deep.equal([ target ]);
+  });
+});


### PR DESCRIPTION
## ✏️ Changes
Deploy CLI can export `rules configs`, but it cannot extract values, which is leading to saving secrets as `"key": "******"`. Database connection secrets (`options.configuration`) can be extracted, but only as encrypted values. Importing these secrets without editing will override current values with new  encrypted values and can potentially break rules or db-scripts.
Proposed solution is to avoid exporting these secrets.

## 🔗 References
Jira SD: https://auth0team.atlassian.net/projects/ESD/queues/custom/321/ESD-82

## 🎯 Testing
✅This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
