### PR TITLE
DXEX-98: fix default-app client props on export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - Unreleased
+### Fixed
+- `allowed_clients`, `allowed_logout_urls`, `allowed_origins` and `callbacks` properties of the `client` can no longer be exported as `null`
+
 ## [3.2.0] - 2019-04-12
 ### Changed
 - Secrets (`rules configs` and databases `options.configuration`) can no longer be exported

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, loadJSON, sanitize, clearClientArrays } from '../../../utils';
 
 function parse(context) {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
@@ -31,7 +31,7 @@ async function dump(context) {
   clients.forEach((client) => {
     const clientFile = path.join(clientsFolder, sanitize(`${client.name}.json`));
     log.info(`Writing ${clientFile}`);
-    fs.writeFileSync(clientFile, JSON.stringify(client, null, 2));
+    fs.writeFileSync(clientFile, JSON.stringify(clearClientArrays(client), null, 2));
   });
 }
 

--- a/src/context/yaml/handlers/clients.js
+++ b/src/context/yaml/handlers/clients.js
@@ -1,3 +1,4 @@
+import { clearClientArrays } from '../../../utils';
 
 async function parse(context) {
   // nothing to do, set default empty
@@ -7,9 +8,9 @@ async function parse(context) {
 }
 
 async function dump(context) {
-  // nothing to do, set default empty
+  const clients = context.assets.clients || [];
   return {
-    clients: [ ...context.assets.clients || [] ]
+    clients: clients.map(clearClientArrays)
   };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,3 +148,15 @@ export function clearTenantFlags(tenant) {
     delete tenant.flags;
   }
 }
+
+
+export function clearClientArrays(client) {
+  const propsToClear = [ 'allowed_clients', 'allowed_logout_urls', 'allowed_origins', 'callbacks' ];
+  Object.keys(client).forEach((prop) => {
+    if (propsToClear.indexOf(prop) >= 0 && !client[prop]) {
+      client[prop] = [];
+    }
+  });
+
+  return client;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -15,7 +15,8 @@ import {
   sanitize,
   hoursAsInteger,
   formatResults,
-  recordsSorter
+  recordsSorter,
+  clearClientArrays
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -164,5 +165,41 @@ describe('#utils', function() {
       { template: 'b', id: 0 },
       { template: 'c', id: 2 }
     ]);
+  });
+
+  it('should clear clients arrays', () => {
+    const client = {
+      name: 'Default App',
+      callbacks: null,
+      allowed_clients: null,
+      allowed_logout_urls: null,
+      is_first_party: true,
+      oidc_conformant: false,
+      allowed_origins: null
+    };
+
+    expect(clearClientArrays(client)).to.deep.equal({
+      name: 'Default App',
+      callbacks: [],
+      allowed_clients: [],
+      allowed_logout_urls: [],
+      is_first_party: true,
+      oidc_conformant: false,
+      allowed_origins: []
+    });
+  });
+
+  it('should not touch correct client arrays', () => {
+    const client = {
+      name: 'Default App',
+      callbacks: [ 'callback' ],
+      allowed_clients: [],
+      allowed_logout_urls: [ 'url', 'url' ],
+      is_first_party: true,
+      oidc_conformant: false,
+      allowed_origins: [ 'origin' ]
+    };
+
+    expect(clearClientArrays(client)).to.deep.equal(client);
   });
 });


### PR DESCRIPTION
## ✏️ Changes
`allowed_clients`, `allowed_logout_urls`, `allowed_origins` and `callbacks` properties of `client` cannot be imported as `null`. But for some reason the `Default App` client has all those defined as `null`. We can check those props and replace them with `[]` during export.

## 🔗 References
Jira: https://auth0team.atlassian.net/browse/DXEX-98

## 🎯 Testing
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
