### PR TITLE
JIT parsing for AUTH0_KEYWORD_REPLACE_MAPPINGS

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -42,7 +42,15 @@ export default async function deploy(params) {
   nconf.overrides(overrides);
 
   // Setup context and load
-  const context = await setupContext(nconf.get());
+  const context = await setupContext(function parseMappings(obj) {
+    if (typeof obj.AUTH0_KEYWORD_REPLACE_MAPPINGS === 'string') {
+      try {
+        obj.AUTH0_KEYWORD_REPLACE_MAPPINGS = JSON.parse(obj.AUTH0_KEYWORD_REPLACE_MAPPINGS);
+      } catch (err) {}
+    }
+    return obj
+  }(nconf.get()));
+
   await context.load();
 
   const config = extTools.config();


### PR DESCRIPTION
## ✏️ Changes

> I'm trying to use this tool with yaml config and all configuration properties provided by environment variables instead of a config file. `nconf` seems to always load configs loaded from environment variables as strings. 

I'm wasn't quite sure of the best way to do this, but I have updated the import lib to parse `AUTH0_KEYWORD_REPLACE_MAPPINGS` when it contains valid JSON string right before it is passed to the format contexts.

## 🔗 References

> https://github.com/auth0/auth0-deploy-cli/issues/133

## 🎯 Testing

> 1. export tenant configuration as yaml.
> 2. modify tenant.yaml to use keyword mappings in email provider, pages, and applications sections.
> 3. import tenant config and confirm unparsed keywords have not made it into the tenant configuration on auth0.

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
