### PR TITLE
link to main README from YAML README went back to itself.  Fixed.

### DIFF
--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -1,6 +1,6 @@
 # Auth0 Deploy CLI using YAML
 
-This README will document how to use the YAML Option of the Auth0-deploy-cli tool. Please refer to the [README.md](README.md) for more information on the Auth0 Deploy CLI.
+This README will document how to use the YAML Option of the Auth0-deploy-cli tool. Please refer to the main project [README.md](../../README.md) for more information on the Auth0 Deploy CLI.
 
 # Overview
 The YAML option supports exporting and importing the Auth0 tenant configuration via a YAML file.


### PR DESCRIPTION
## ✏️ Changes

Fixing a broken link in the yaml README (it went back to itself).  

## 🔗 References

None

## 🎯 Testing

I tested the link in preview and it appears to do what it should do.  
