### PR TITLE
ESD-2006: Remove non-functioning --verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Commands:
 Options:
   --help           Show help  [boolean]
   --version        Show version number  [boolean]
-  --verbose, -v    Dump extra debug information.  [string] [default: false]
+  --debug, -d    Dump extra debug information.  [string] [default: false]
   --proxy_url, -p  A url for proxying requests, only set this if you are behind a proxy.  [string]
 
 Examples:

--- a/src/args.js
+++ b/src/args.js
@@ -2,8 +2,8 @@ import yargs from 'yargs';
 
 export default yargs
   .usage('Auth0 Deploy CLI')
-  .option('verbose', {
-    alias: 'v',
+  .option('debug', {
+    alias: 'd',
     describe: 'Dump extra debug information.',
     type: 'string',
     boolean: true,

--- a/src/args.js
+++ b/src/args.js
@@ -5,8 +5,7 @@ export default yargs
   .option('debug', {
     alias: 'd',
     describe: 'Dump extra debug information.',
-    type: 'string',
-    boolean: true,
+    type: 'boolean',
     default: false
   })
   .option('proxy_url', {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import HttpsProxyAgent from 'https-proxy-agent';
 import HttpProxyAgent from 'http-proxy-agent';
 import superagent from 'superagent';
+import { argv } from 'yargs';
 
 import args from './args';
 import commands from './commands';
@@ -14,7 +15,7 @@ log.debug('Starting Auth0 Deploy CLI Tool');
 
 // Set log level
 log.transports.console.level = params.level;
-if (params.debug) {
+if (argv.debug) {
   log.transports.console.level = 'debug';
   // Set for auth0-source-control-ext-tools
   process.env.AUTH0_DEBUG = 'true';


### PR DESCRIPTION
## ✏️ Changes

Remove `--verbose flag`, since it has no functionality. Update docs to show support for `--debug`

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-2006

## 🎯 Testing

Manually test via `a0deploy --help`