### PR TITLE
DXEX-319: Unnamed hooks dump fix

### DIFF
--- a/src/context/directory/handlers/hooks.js
+++ b/src/context/directory/handlers/hooks.js
@@ -35,6 +35,8 @@ async function dump(context) {
   fs.ensureDirSync(hooksFolder);
   hooks.forEach((hook) => {
     // Dump script to file
+    // For cases when hook does not have `meta['hook-name']`
+    hook.name = hook.name || hook.id;
     const name = sanitize(hook.name);
     const hookCode = path.join(hooksFolder, `${name}.js`);
     log.info(`Writing ${hookCode}`);

--- a/src/context/yaml/handlers/hooks.js
+++ b/src/context/yaml/handlers/hooks.js
@@ -32,6 +32,8 @@ async function dump(context) {
 
     hooks = hooks.map((hook) => {
       // Dump hook code to file
+      // For cases when hook does not have `meta['hook-name']`
+      hook.name = hook.name || hook.id;
       const codeName = sanitize(`${hook.name}.js`);
       const codeFile = path.join(hooksFolder, codeName);
       log.info(`Writing ${codeFile}`);

--- a/test/context/directory/hooks.test.js
+++ b/test/context/directory/hooks.test.js
@@ -77,7 +77,13 @@ describe('#directory context hooks', () => {
 
     context.assets.hooks = [
       {
+        id: '1',
         name: 'someHook',
+        code: codeValidation,
+        triggerId: 'credentials-exchange'
+      },
+      {
+        id: 'unnamedHook',
         code: codeValidation,
         triggerId: 'credentials-exchange'
       }
@@ -88,11 +94,19 @@ describe('#directory context hooks', () => {
     const hooksFolder = path.join(dir, constants.HOOKS_DIRECTORY);
 
     expect(loadJSON(path.join(hooksFolder, 'someHook.json'))).to.deep.equal({
+      id: '1',
       name: 'someHook',
       code: './someHook.js',
       triggerId: 'credentials-exchange'
     });
+    expect(loadJSON(path.join(hooksFolder, 'unnamedHook.json'))).to.deep.equal({
+      id: 'unnamedHook',
+      name: 'unnamedHook',
+      code: './unnamedHook.js',
+      triggerId: 'credentials-exchange'
+    });
     expect(fs.readFileSync(path.join(hooksFolder, 'someHook.js'), 'utf8')).to.deep.equal(codeValidation);
+    expect(fs.readFileSync(path.join(hooksFolder, 'unnamedHook.js'), 'utf8')).to.deep.equal(codeValidation);
   });
 
   it('should dump hooks sanitized', async () => {

--- a/test/context/yaml/hooks.js
+++ b/test/context/yaml/hooks.js
@@ -51,7 +51,13 @@ describe('#YAML context hooks', () => {
 
     context.assets.hooks = [
       {
+        id: '1',
         name: 'someHook',
+        code: codeValidation,
+        triggerId: 'credentials-exchange'
+      },
+      {
+        id: 'unnamedHook',
         code: codeValidation,
         triggerId: 'credentials-exchange'
       }
@@ -61,8 +67,15 @@ describe('#YAML context hooks', () => {
     expect(dumped).to.deep.equal({
       hooks: [
         {
+          id: '1',
           name: 'someHook',
           code: './hooks/someHook.js',
+          triggerId: 'credentials-exchange'
+        },
+        {
+          id: 'unnamedHook',
+          name: 'unnamedHook',
+          code: './hooks/unnamedHook.js',
           triggerId: 'credentials-exchange'
         }
       ]


### PR DESCRIPTION
## ✏️ Changes
Hooks that been created without `meta['hook-name']` cannot be exported properly. To fix that we should check `hook.name` and fall back to `hook.id` if name is undefined.

## 🔗 References
Jira: https://auth0team.atlassian.net/browse/DXEX-319

## 🎯 Testing
New version of hooks UI creates hooks with `meta['hook-name']`. To test these changes you'll have to remove the meta prop manually (using webtask editor).

✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
