### PR TITLE
DXEX-328: sanitize hooks names on import

### DIFF
--- a/src/context/directory/handlers/hooks.js
+++ b/src/context/directory/handlers/hooks.js
@@ -17,6 +17,9 @@ function parse(context) {
     if (hook.code) {
       hook.code = context.loadFile(hook.code, constants.HOOKS_DIRECTORY);
     }
+
+    hook.name = hook.name.toLowerCase().replace(/\s/g, '-');
+
     return hook;
   });
 

--- a/src/context/yaml/handlers/hooks.js
+++ b/src/context/yaml/handlers/hooks.js
@@ -15,6 +15,9 @@ async function parse(context) {
         if (hook.code) {
           hook.code = context.loadFile(hook.code, constants.HOOKS_DIRECTORY);
         }
+
+        hook.name = hook.name.toLowerCase().replace(/\s/g, '-');
+
         return { ...hook };
       })
     ]

--- a/test/context/directory/hooks.test.js
+++ b/test/context/directory/hooks.test.js
@@ -10,20 +10,20 @@ import { loadJSON } from '../../../src/utils';
 import { cleanThenMkdir, testDataDir, createDir, mockMgmtClient } from '../../utils';
 
 const hooks = {
-  'somehook.js': 'function someHook() { var hello = @@hello@@; }',
-  'somehook.json': '{ "name": "somehook", "active": true, "code": "somehook.js", "triggerId": "credentials-exchange" }',
-  'otherhook.js': 'function someHook() { var hello = @@hello@@; }',
-  'otherhook.json': '{ "name": "otherhook", "code": "otherhook.js", "triggerId": "credentials-exchange" }'
+  'some-hook.js': 'function someHook() { var hello = @@hello@@; }',
+  'some-hook.json': '{ "name": "Some Hook", "active": true, "code": "some-hook.js", "triggerId": "credentials-exchange" }',
+  'other-hook.js': 'function someHook() { var hello = @@hello@@; }',
+  'other-hook.json': '{ "name": "Other Hook", "code": "other-hook.js", "triggerId": "credentials-exchange" }'
 };
 
 const hooksTarget = [
   {
-    name: 'otherhook',
+    name: 'other-hook',
     code: 'function someHook() { var hello = "goodbye"; }',
     triggerId: 'credentials-exchange'
   },
   {
-    name: 'somehook',
+    name: 'some-hook',
     active: true,
     code: 'function someHook() { var hello = "goodbye"; }',
     triggerId: 'credentials-exchange'

--- a/test/context/yaml/hooks.js
+++ b/test/context/yaml/hooks.js
@@ -18,7 +18,7 @@ describe('#YAML context hooks', () => {
 
     const yaml = `
     hooks:
-      - name: "someHook"
+      - name: "Some Hook"
         code: "${codeFile}"
         triggerId: "credentials-exchange"
     `;
@@ -28,7 +28,7 @@ describe('#YAML context hooks', () => {
     const target = [
       {
         active: false,
-        name: 'someHook',
+        name: 'some-hook',
         dependencies: {},
         secrets: {},
         code: 'function someHook() { var hello = "test"; }',


### PR DESCRIPTION
## ✏️ Changes
Sanitize (lowercase and no spaces) hooks names on import to avoid duplications. 

## 🔗 References
Jira: https://auth0team.atlassian.net/browse/DXEX-328

## 🎯 Testing
Tests have been updated accordingly. 

✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
