### PR TITLE
Add dump and deploy commands

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -70,7 +70,7 @@ export default yargs
       default: false
     }
   })
-.command('deploy', 'Deploy Configuration', {
+  .command('deploy', 'Deploy Configuration', {
     input_file: {
       alias: 'i',
       describe: 'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
@@ -95,7 +95,7 @@ export default yargs
       type: 'string'
     }
   })
-.command('dump', 'Dump Auth0 Tenant Configuration', {
+  .command('dump', 'Dump Auth0 Tenant Configuration', {
     output_folder: {
       alias: 'o',
       describe: 'The output directory.',

--- a/src/args.js
+++ b/src/args.js
@@ -70,9 +70,69 @@ export default yargs
       default: false
     }
   })
+.command('deploy', 'Deploy Configuration', {
+    input_file: {
+      alias: 'i',
+      describe: 'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
+      type: 'string',
+      demandOption: true
+    },
+    config_file: {
+      alias: 'c',
+      describe: 'The JSON configuration file.',
+      type: 'string'
+    },
+    env: {
+      alias: 'e',
+      describe: 'Override the mappings in config with process.env environment variables.',
+      type: 'string',
+      boolean: true,
+      default: true
+    },
+    secret: {
+      alias: 'x',
+      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+      type: 'string'
+    }
+  })
+.command('dump', 'Dump Auth0 Tenant Configuration', {
+    output_folder: {
+      alias: 'o',
+      describe: 'The output directory.',
+      type: 'string',
+      demandOption: true
+    },
+    format: {
+      alias: 'f',
+      describe: 'The output format.',
+      type: 'string',
+      choices: [ 'yaml', 'directory' ],
+      demandOption: true
+    },
+    config_file: {
+      alias: 'c',
+      describe: 'The JSON configuration file.',
+      type: 'string'
+    },
+    secret: {
+      alias: 'x',
+      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+      type: 'string'
+    },
+    export_ids: {
+      alias: 'e',
+      describe: 'Export identifier field for each object type.',
+      type: 'boolean',
+      default: false
+    }
+  })
   .example('$0 export -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
   .example('$0 export -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
   .example('$0 import -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
   .example('$0 import -c config.json -i path/to/files', 'Deploy Auth0 via Path')
+  .example('$0 dump -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
+  .example('$0 dump -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
+  .example('$0 deploy -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
+  .example('$0 deploy -c config.json -i path/to/files', 'Deploy Auth0 via Path')
   .epilogue('See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.')
   .wrap(null);


### PR DESCRIPTION
## ✏️ Changes

`Import` and `export` are ambiguous commands as someone might think that import might be importing auth0's settings to your local machine, while export might be exporting to auth0. Dump and deploy are better names for what the actions actually do.

## 🎯 Testing

It is the same functionality as import and export and doesn't need to be tested 

