### PR TITLE
add readonly flag remove_stale_idp_attributes

### DIFF
--- a/src/readonly.js
+++ b/src/readonly.js
@@ -17,7 +17,8 @@ const readOnly = {
     'sandbox_versions_available',
     'flags.allow_changing_enable_sso',
     'flags.enable_sso',
-    'flags.disable_impersonation'
+    'flags.disable_impersonation',
+    'flags.remove_stale_idp_attributes'
   ],
   clients: [
     'client_secret',


### PR DESCRIPTION
## ✏️ Changes

The tenant flag `remove_stale_idp_attributes` exists in some tenants and gets exported. This shouldn't be imported back since that would result in error 'Updating the remove_stale_idp_attributes flag is not allowed. Please contact us if you need additional information.'

## 🔗 References

SF ticket: 00444152

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
