### PR TITLE
Hooks management by API2

### DIFF
--- a/src/context/directory/handlers/hooks.js
+++ b/src/context/directory/handlers/hooks.js
@@ -14,8 +14,8 @@ function parse(context) {
 
   const hooks = files.map((f) => {
     const hook = { ...loadJSON(f, context.mappings) };
-    if (hook.code) {
-      hook.code = context.loadFile(hook.code, constants.HOOKS_DIRECTORY);
+    if (hook.script) {
+      hook.script = context.loadFile(hook.script, constants.HOOKS_DIRECTORY);
     }
 
     hook.name = hook.name.toLowerCase().replace(/\s/g, '-');
@@ -43,12 +43,12 @@ async function dump(context) {
     const name = sanitize(hook.name);
     const hookCode = path.join(hooksFolder, `${name}.js`);
     log.info(`Writing ${hookCode}`);
-    fs.writeFileSync(hookCode, hook.code);
+    fs.writeFileSync(hookCode, hook.script);
 
     // Dump template metadata
     const hookFile = path.join(hooksFolder, `${name}.json`);
     log.info(`Writing ${hookFile}`);
-    fs.writeFileSync(hookFile, JSON.stringify({ ...hook, code: `./${name}.js` }, null, 2));
+    fs.writeFileSync(hookFile, JSON.stringify({ ...hook, script: `./${name}.js` }, null, 2));
   });
 }
 

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -9,12 +9,6 @@ export default async function(config) {
   // Validate config
   const errors = [];
 
-  if (!config.WEBTASK_API_TOKEN) errors.push('WEBTASK_API_TOKEN');
-  if (!config.WEBTASK_API_URL) errors.push('WEBTASK_API_URL');
-
-  process.env.WEBTASK_API_TOKEN = config.WEBTASK_API_TOKEN;
-  process.env.WEBTASK_API_URL = config.WEBTASK_API_URL;
-
   if (!config.AUTH0_DOMAIN) errors.push('AUTH0_DOMAIN');
   if (!config.AUTH0_ACCESS_TOKEN) {
     if (!config.AUTH0_CLIENT_ID) errors.push('AUTH0_CLIENT_ID');

--- a/src/context/yaml/handlers/hooks.js
+++ b/src/context/yaml/handlers/hooks.js
@@ -12,8 +12,8 @@ async function parse(context) {
   return {
     hooks: [
       ...context.assets.hooks.map((hook) => {
-        if (hook.code) {
-          hook.code = context.loadFile(hook.code, constants.HOOKS_DIRECTORY);
+        if (hook.script) {
+          hook.script = context.loadFile(hook.script, constants.HOOKS_DIRECTORY);
         }
 
         hook.name = hook.name.toLowerCase().replace(/\s/g, '-');
@@ -40,9 +40,9 @@ async function dump(context) {
       const codeName = sanitize(`${hook.name}.js`);
       const codeFile = path.join(hooksFolder, codeName);
       log.info(`Writing ${codeFile}`);
-      fs.writeFileSync(codeFile, hook.code);
+      fs.writeFileSync(codeFile, hook.script);
 
-      return { ...hook, code: `./hooks/${codeName}` };
+      return { ...hook, script: `./hooks/${codeName}` };
     });
   }
 

--- a/test/context/directory/hooks.test.js
+++ b/test/context/directory/hooks.test.js
@@ -11,21 +11,21 @@ import { cleanThenMkdir, testDataDir, createDir, mockMgmtClient } from '../../ut
 
 const hooks = {
   'some-hook.js': 'function someHook() { var hello = @@hello@@; }',
-  'some-hook.json': '{ "name": "Some Hook", "active": true, "code": "some-hook.js", "triggerId": "credentials-exchange" }',
+  'some-hook.json': '{ "name": "Some Hook", "enabled": true, "script": "some-hook.js", "triggerId": "credentials-exchange" }',
   'other-hook.js': 'function someHook() { var hello = @@hello@@; }',
-  'other-hook.json': '{ "name": "Other Hook", "code": "other-hook.js", "triggerId": "credentials-exchange" }'
+  'other-hook.json': '{ "name": "Other Hook", "script": "other-hook.js", "triggerId": "credentials-exchange" }'
 };
 
 const hooksTarget = [
   {
     name: 'other-hook',
-    code: 'function someHook() { var hello = "goodbye"; }',
+    script: 'function someHook() { var hello = "goodbye"; }',
     triggerId: 'credentials-exchange'
   },
   {
     name: 'some-hook',
-    active: true,
-    code: 'function someHook() { var hello = "goodbye"; }',
+    enabled: true,
+    script: 'function someHook() { var hello = "goodbye"; }',
     triggerId: 'credentials-exchange'
   }
 ];
@@ -79,12 +79,12 @@ describe('#directory context hooks', () => {
       {
         id: '1',
         name: 'someHook',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       },
       {
         id: 'unnamedHook',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       }
     ];
@@ -96,13 +96,13 @@ describe('#directory context hooks', () => {
     expect(loadJSON(path.join(hooksFolder, 'someHook.json'))).to.deep.equal({
       id: '1',
       name: 'someHook',
-      code: './someHook.js',
+      script: './someHook.js',
       triggerId: 'credentials-exchange'
     });
     expect(loadJSON(path.join(hooksFolder, 'unnamedHook.json'))).to.deep.equal({
       id: 'unnamedHook',
       name: 'unnamedHook',
-      code: './unnamedHook.js',
+      script: './unnamedHook.js',
       triggerId: 'credentials-exchange'
     });
     expect(fs.readFileSync(path.join(hooksFolder, 'someHook.js'), 'utf8')).to.deep.equal(codeValidation);
@@ -118,7 +118,7 @@ describe('#directory context hooks', () => {
     context.assets.hooks = [
       {
         name: 'some/Hook',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       }
     ];
@@ -129,7 +129,7 @@ describe('#directory context hooks', () => {
 
     expect(loadJSON(path.join(hooksFolder, 'some-Hook.json'))).to.deep.equal({
       name: 'some/Hook',
-      code: './some-Hook.js',
+      script: './some-Hook.js',
       triggerId: 'credentials-exchange'
     });
     expect(fs.readFileSync(path.join(hooksFolder, 'some-Hook.js'), 'utf8')).to.deep.equal(codeValidation);

--- a/test/context/yaml/hooks.js
+++ b/test/context/yaml/hooks.js
@@ -19,7 +19,7 @@ describe('#YAML context hooks', () => {
     const yaml = `
     hooks:
       - name: "Some Hook"
-        code: "${codeFile}"
+        script: "${codeFile}"
         triggerId: "credentials-exchange"
     `;
     const yamlFile = path.join(dir, 'hook1.yaml');
@@ -27,11 +27,11 @@ describe('#YAML context hooks', () => {
 
     const target = [
       {
-        active: false,
+        enabled: false,
         name: 'some-hook',
         dependencies: {},
         secrets: {},
-        code: 'function someHook() { var hello = "test"; }',
+        script: 'function someHook() { var hello = "test"; }',
         triggerId: 'credentials-exchange'
       }
     ];
@@ -53,12 +53,12 @@ describe('#YAML context hooks', () => {
       {
         id: '1',
         name: 'someHook',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       },
       {
         id: 'unnamedHook',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       }
     ];
@@ -69,13 +69,13 @@ describe('#YAML context hooks', () => {
         {
           id: '1',
           name: 'someHook',
-          code: './hooks/someHook.js',
+          script: './hooks/someHook.js',
           triggerId: 'credentials-exchange'
         },
         {
           id: 'unnamedHook',
           name: 'unnamedHook',
-          code: './hooks/unnamedHook.js',
+          script: './hooks/unnamedHook.js',
           triggerId: 'credentials-exchange'
         }
       ]
@@ -94,7 +94,7 @@ describe('#YAML context hooks', () => {
     context.assets.hooks = [
       {
         name: 'someHook / test',
-        code: codeValidation,
+        script: codeValidation,
         triggerId: 'credentials-exchange'
       }
     ];
@@ -104,7 +104,7 @@ describe('#YAML context hooks', () => {
       hooks: [
         {
           name: 'someHook / test',
-          code: './hooks/someHook - test.js',
+          script: './hooks/someHook - test.js',
           triggerId: 'credentials-exchange'
         }
       ]


### PR DESCRIPTION
## ✏️ Changes
Updated hook props names (`code` => `script`, `active` => `enabled`), removed `WEBTASK_API_TOKEN` and `WEBTASK_API_URL` from config.

`auth0` and `auth0-source-control-extension-tools` modules have to be updated before merging this one.