### PR TITLE
ESD-3305: convert env strings to config objects

### DIFF
--- a/src/context/index.js
+++ b/src/context/index.js
@@ -4,6 +4,18 @@ import YAMLContext from './yaml';
 import DirectoryContext from './directory';
 
 import { isDirectory } from '../utils';
+import log from '../logger';
+
+const nonPrimitiveProps = [
+  'AUTH0_KEYWORD_REPLACE_MAPPINGS',
+  'AUTH0_EXCLUDED_RULES',
+  'AUTH0_EXCLUDED_CLIENTS',
+  'AUTH0_EXCLUDED_DATABASES',
+  'AUTH0_EXCLUDED_CONNECTIONS',
+  'AUTH0_EXCLUDED_RESOURCE_SERVERS',
+  'EXCLUDED_PROPS',
+  'INCLUDED_PROPS'
+];
 
 export default async function(config) {
   // Validate config
@@ -39,6 +51,25 @@ export default async function(config) {
   });
 
   const inputFile = config.AUTH0_INPUT_FILE;
+
+  const ensureObject = (key, value) => {
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch (e) {
+        log.debug(`Cannot convert config.${key} to an object. Error: ${e.message}`);
+        return value;
+      }
+    }
+
+    return value;
+  };
+
+  nonPrimitiveProps.forEach((key) => {
+    if (config[key]) {
+      config[key] = ensureObject(key, config[key]);
+    }
+  });
 
   if (typeof inputFile === 'object') {
     return new YAMLContext(config, mgmtClient);


### PR DESCRIPTION
## ✏️ Changes
Deploy CLI cannot consume certain parameters from env vars, cuz those are represented as `string` and the CLI is expecting `object`. We have to check and convert those params.

## 🔗 References
Jira: https://auth0team.atlassian.net/browse/ESD-3305

## 🎯 Testing
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
