### PR TITLE
feat(chore): show up help if no args passed

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -1,6 +1,7 @@
 import yargs from 'yargs';
 
 export default yargs
+  .demandCommand(1, 'A command is required')
   .usage('Auth0 Deploy CLI')
   .option('debug', {
     alias: 'd',

--- a/src/index.js
+++ b/src/index.js
@@ -24,13 +24,6 @@ async function run() {
   // Run command
   const cmd = commands[params._[0]];
 
-  // TODO: Prob a native/better way to enforce command choices in yargs.
-  if (!cmd) {
-    log.error(`Command ${params._[0]} not supported\n`);
-    args.showHelp();
-    process.exit(1);
-  }
-
   // Monkey Patch the superagent for proxy use
   const proxy = params.proxy_url;
   if (proxy) {


### PR DESCRIPTION
Use `yargs` API to show up help by default when no arguments were passed in.