### PR TITLE
Fix export failing if roles is empty

### DIFF
--- a/src/context/directory/handlers/roles.js
+++ b/src/context/directory/handlers/roles.js
@@ -24,7 +24,9 @@ function parse(context) {
 
 async function dump(context) {
   const { roles } = context.assets;
-  if (!roles) return; // Skip, nothing to dump
+
+  // API returns an empty object if no grants are present
+  if (!roles || roles.constructor === Object) return; // Skip, nothing to dump
 
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);
   fs.ensureDirSync(rolesFolder);

--- a/test/context/directory/roles.test.js
+++ b/test/context/directory/roles.test.js
@@ -88,6 +88,21 @@ describe('#directory context roles', () => {
     expect(context.assets.roles).to.deep.equal(target);
   });
 
+  it('should ignore objects', async () => {
+    const dir = path.join(testDataDir, 'directory', 'rolesDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    // API will return an empty object if there are no roles
+    context.assets.roles = {};
+
+    await handler.dump(context);
+
+    // folder should not be there
+    const roleFolder = path.join(dir, constants.ROLES_DIRECTORY);
+    expect(fs.existsSync(roleFolder)).is.equal(false);
+  });
+
   it('should ignore bad roles directory', async () => {
     const repoDir = path.join(testDataDir, 'directory', 'roles3');
     cleanThenMkdir(repoDir);


### PR DESCRIPTION
## ✏️ Changes

The roles API will return an empty object if there are no roles set up in the tenant. The expected return value is an array.

With these changes, the empty object will be ignored. Without these changes, the code continues and an exception is thrown:

```
TypeError: roles.forEach is not a function
   at Object.dump (/my_project/node_modules/auth0-deploy-cli/lib/context/directory/handlers/roles.js:51:9)
```

## 🔗 References

This fixes https://github.com/auth0/auth0-deploy-cli/issues/182

## 🎯 Testing

This can be tested by doing a dump against a tenant without any roles.

✅ This change has unit test coverage

🚫 This change has integration test coverage
(are there integration tests for this package?)

✅ This change has been tested for performance
