### PR TITLE
Updated YAML handler to fix issue with enabled clients

### DIFF
--- a/src/context/yaml/handlers/connections.js
+++ b/src/context/yaml/handlers/connections.js
@@ -41,19 +41,18 @@ async function dump(context) {
 
   const clients = context.assets.clients || [];
 
-  // nothing to do, set default if empty
   return {
     connections: connections.map((connection) => {
-      const dumpedConnection = {
-        ...connection,
-        enabled_clients: [
-          ...(connection.enabled_clients || []).map((clientId) => {
-            const found = clients.find(c => c.client_id === clientId);
-            if (found) return found.name;
-            return clientId;
-          })
-        ]
-      };
+      const enabledClients = (connection.enabled_clients || []).map((clientId) => {
+        const found = clients.find(c => c.client_id === clientId);
+        if (found) return found.name;
+        return clientId;
+      });
+
+      const dumpedConnection = Object.assign(
+        connection,
+        enabledClients.length === 0 ? null : { enabled_clients: enabledClients }
+      );
 
       if (dumpedConnection.strategy === 'email') {
         ensureProp(connection, 'options.email.body');

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -79,21 +79,19 @@ describe('#YAML context connections', () => {
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: path.join(dir, './test.yml') }, mockMgmtClient());
     const connections = [
-      { name: 'test-waad', strategy: 'waad', enabled_clients: [] },
+      { name: 'test-waad', strategy: 'waad' },
       {
         name: 'email',
         strategy: 'email',
-        enabled_clients: [],
         options: { email: { body: 'html code' } }
       }
     ];
 
     const target = [
-      { name: 'test-waad', strategy: 'waad', enabled_clients: [] },
+      { name: 'test-waad', strategy: 'waad' },
       {
         name: 'email',
         strategy: 'email',
-        enabled_clients: [],
         options: { email: { body: './email.html' } }
       }
     ];


### PR DESCRIPTION
## ✏️ Changes

Fixed an issue where an empty enabled_clients node would wipe out configured clients.

I changed the projected enabled_clients to a separate object, and merged it with Object.assign. I needed to use Object.assign so that the key would not exist in the final object. This should not be a breaking change, as it only serves to keep what's in the management API, not change it.

## 🔗 References

This is in reference to https://github.com/auth0/auth0-deploy-cli/issues/207.

## 🎯 Testing

I have updated the unit tests to confirm the change in the code. I didn't see any integration tests, so I apologize for not running them. I also confirmed the linter was happy with the changes.
