### PR TITLE
[DXEX-455] Include Deploy CLI tool in the User-agent header.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,8 +233,8 @@
     },
     "@types/express-jwt": {
       "version": "0.0.42",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.42.tgz",
-      "integrity": "sha1-TwTh+t+dGHJZUNwEGAikpK339a4=",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
       "requires": {
         "@types/express": "*",
         "@types/express-unless": "*"
@@ -540,14 +540,14 @@
       "optional": true
     },
     "auth0": {
-      "version": "2.22.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0/-/auth0-2.22.0.tgz",
-      "integrity": "sha1-1DxaPjodXPbckP3s9Ud+vHj0FRY=",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.23.0.tgz",
+      "integrity": "sha512-g2JoVorNMEK3pC9RV7wva86Nr8W3em2NP0A3yjVKfblx67C0rJNSZe2uDL6DOTXnO1XwMfExhVRIp4Hou7w+mw==",
       "requires": {
         "bluebird": "^3.5.5",
         "jsonwebtoken": "^8.5.1",
-        "jwks-rsa": "^1.6.0",
-        "lru-memoizer": "^2.0.1",
+        "jwks-rsa": "^1.7.0",
+        "lru-memoizer": "^2.1.0",
         "object.assign": "^4.1.0",
         "request": "^2.88.0",
         "rest-facade": "^1.12.0",
@@ -5003,9 +5003,9 @@
       }
     },
     "jwks-rsa": {
-      "version": "1.6.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.6.2.tgz",
-      "integrity": "sha1-CHBYjbcM/6H04jPwmuI0rntOoBI=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.7.0.tgz",
+      "integrity": "sha512-tq7DVJt9J6wTvl9+AQfwZIiPSuY2Vf0F+MovfRTFuBqLB1xgDVhegD33ChEAQ6yBv9zFvUIyj4aiwrSA5VehUw==",
       "requires": {
         "@types/express-jwt": "0.0.42",
         "debug": "^4.1.0",
@@ -5172,9 +5172,9 @@
       }
     },
     "lru-memoizer": {
-      "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-2.0.1.tgz",
-      "integrity": "sha1-8h4BW7aFZIP1dAcL4RyhawwBBpM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.0.tgz",
+      "integrity": "sha512-oKjxgJhL+m1wfEkez7/a6iyRZUdohej+2u04qCaAQ7BBfx/qD4RH3jOQhPsd8Y3pcm7IhcNtE3kCEIDCMPiJFQ==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/auth0/auth0-deploy-cli#readme",
   "dependencies": {
     "ajv": "^6.5.2",
-    "auth0": "^2.22.0",
+    "auth0": "^2.23.0",
     "auth0-extension-tools": "^1.4.4",
     "auth0-source-control-extension-tools": "^4.0.2",
     "dot-prop": "^4.2.0",

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -4,6 +4,7 @@ import YAMLContext from './yaml';
 import DirectoryContext from './directory';
 
 import { isDirectory } from '../utils';
+import { version as packageVersion } from '../../package.json';
 import log from '../logger';
 
 const nonPrimitiveProps = [
@@ -49,7 +50,10 @@ export default async function(config) {
   const mgmtClient = new ManagementClient({
     domain: config.AUTH0_DOMAIN,
     token: accessToken,
-    retry: { maxRetries: config.AUTH0_API_MAX_RETRIES || 10 }
+    retry: { maxRetries: config.AUTH0_API_MAX_RETRIES || 10 },
+    headers: {
+      'User-agent': `deploy-cli/${packageVersion} (node.js/${process.version.replace('v', '')})`
+    }
   });
 
   const inputFile = config.AUTH0_INPUT_FILE;

--- a/test/context/context.test.js
+++ b/test/context/context.test.js
@@ -41,4 +41,21 @@ describe('#context loader validation', async () => {
     const loaded2 = await context({ ...config, AUTH0_INPUT_FILE: yml });
     expect(loaded2).to.be.an.instanceof(yamlContext);
   });
+
+  it('should include the deploy cli version in the user agent header', async () => {
+    /* Create empty directory */
+    const dir = path.resolve(testDataDir, 'context');
+    cleanThenMkdir(dir);
+
+    const yaml = path.join(dir, 'empty.yaml');
+    fs.writeFileSync(yaml, '');
+
+    const loaded = await context({ ...config, AUTH0_INPUT_FILE: yaml });
+    expect(loaded).to.be.an.instanceof(yamlContext);
+
+    const userAgent = loaded.mgmtClient.rules.resource.restClient.restClient.options.headers['User-agent'];
+
+    expect(userAgent).to.contain('deploy-cli');
+    expect(userAgent).to.contain('node.js');
+  });
 });


### PR DESCRIPTION
## ✏️ Changes

node-auth0 now supports the ability to customize the outgoing headers when it makes calls to the
Auth0 api. Chip would like the Deploy CLI version included in the headers so that he can know which
versions of the Deploy CLI are in use by our customers.

## 🔗 References

https://auth0team.atlassian.net/browse/DXEX-455

## 🎯 Testing

I added a unit test for this, and I also exported a tenant using this code and verified that the correct user-agent showed up in [Chip's custom Kibana dashboard](https://applogs.auth0.com/_plugin/kibana/app/kibana#/dashboard/5e1024e0-4de4-11ea-8da5-1ddf4ae3f3a8?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-30d,mode:quick,to:now))&_a=(description:'Hooks%20API%20usage%20over%20time',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'80224b80-b9d3-11e9-a4e9-2905eea990a9',key:req.headers.user-agent,negate:!f,params:(query:deploy-cli,type:phrase),type:phrase,value:deploy-cli),query:(match:(req.headers.user-agent:(query:deploy-cli,type:phrase))))),fullScreenMode:!f,options:(darkTheme:!f,hidePanelTitles:!f,useMargins:!t),panels:!((embeddableConfig:(vis:(params:(sort:(columnIndex:1,direction:desc)))),gridData:(h:29,i:'1',w:19,x:0,y:16),id:f82e9e10-4ddc-11ea-8677-45503c2662f7,panelIndex:'1',type:visualization,version:'6.8.0'),(embeddableConfig:(),gridData:(h:15,i:'2',w:24,x:19,y:15),id:'26c55410-4de4-11ea-829b-8bc4d1b11f9d',panelIndex:'2',title:'Requests%20with%20method',type:visualization,version:'6.8.0'),(embeddableConfig:(vis:(legendOpen:!t)),gridData:(h:15,i:'3',w:24,x:19,y:0),id:'2f975aa0-4eef-11ea-92ef-df6563ceed5d',panelIndex:'3',type:visualization,version:'6.8.0'),(embeddableConfig:(),gridData:(h:7,i:'4',w:9,x:0,y:0),id:d2e98110-4eef-11ea-99d9-0f5dcea21e39,panelIndex:'4',title:'Total%20Requests',type:visualization,version:'6.8.0'),(embeddableConfig:(),gridData:(h:15,i:'5',w:24,x:19,y:30),id:aac518f0-4ef1-11ea-8792-75bb4c112f83,panelIndex:'5',type:visualization,version:'6.8.0'),(embeddableConfig:(vis:(legendOpen:!t)),gridData:(h:9,i:'6',w:19,x:0,y:7),id:ee0f1740-4ef2-11ea-be8f-5118a8b16cd2,panelIndex:'6',title:'Free%20vs%20Paid',type:visualization,version:'6.8.0'),(embeddableConfig:(),gridData:(h:7,i:'7',w:10,x:9,y:0),id:'03325b40-4ef4-11ea-b2e9-674b165bd462',panelIndex:'7',title:'Average%20Latency',type:visualization,version:'6.8.0')),query:(language:lucene,query:'(req.path:%22%2Fapi%2Fv2%2Fhooks%22%20OR%20req.path:%22%2Fapi%2Fv2%2Fhooks%2F%7Bid%7D%22%20OR%20req.path:%22%2Fapi%2Fv2%2Fhooks%2F%7Bid%7D%2Fsecrets%22)%20AND%20log_type:response'),timeRestore:!f,title:'%5BDX-Extensibility%5D%20Hooks%20API%20Overview',viewMode:view))

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
