### PR TITLE
issue 176: Refactors param logic to prevent execution when use as library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,73 +7,72 @@ import args from './args';
 import commands from './commands';
 import log from './logger';
 
-
 async function run(params) {
- // Run command
- const cmd = commands[params._[0]];
+  // Run command
+  const cmd = commands[params._[0]];
 
- // Monkey Patch the superagent for proxy use
- const proxy = params.proxy_url;
- if (proxy) {
- const proxyAgent = new HttpProxyAgent(proxy);
- const proxyAgentSsl = new HttpsProxyAgent(proxy);
- const OrigRequest = superagent.Request;
- superagent.Request = function RequestWithAgent(method, url) {
- const req = new OrigRequest(method, url);
- log.info(`Setting proxy for ${method} to ${url}`);
- if (url.startsWith('https')) return req.agent(proxyAgentSsl);
- return req.agent(proxyAgent);
- };
- }
+  // Monkey Patch the superagent for proxy use
+  const proxy = params.proxy_url;
+  if (proxy) {
+    const proxyAgent = new HttpProxyAgent(proxy);
+    const proxyAgentSsl = new HttpsProxyAgent(proxy);
+    const OrigRequest = superagent.Request;
+    superagent.Request = function RequestWithAgent(method, url) {
+      const req = new OrigRequest(method, url);
+      log.info(`Setting proxy for ${method} to ${url}`);
+      if (url.startsWith('https')) return req.agent(proxyAgentSsl);
+      return req.agent(proxyAgent);
+    };
+  }
 
- log.debug(`Start command ${params._[0]}`);
- await cmd(params);
- log.debug(`Finished command ${params._[0]}`);
+  log.debug(`Start command ${params._[0]}`);
+  await cmd(params);
+  log.debug(`Finished command ${params._[0]}`);
 }
 
 // Only run if from command line
 if (require.main === module) {
- // Load cli params
- const params = args.argv;
+  // Load cli params
+  const params = args.argv;
 
- log.debug('Starting Auth0 Deploy CLI Tool');
+  log.debug('Starting Auth0 Deploy CLI Tool');
 
- // Set log level
- log.transports.console.level = params.level;
- if (params.debug) {
- log.transports.console.level = 'debug';
- // Set for auth0-source-control-ext-tools
- process.env.AUTH0_DEBUG = 'true';
- }
+  // Set log level
+  log.transports.console.level = params.level;
+  if (params.debug) {
+    log.transports.console.level = 'debug';
+    // Set for auth0-source-control-ext-tools
+    process.env.AUTH0_DEBUG = 'true';
+  }
 
- run(params)
- .then(() => process.exit(0))
- .catch((error) => {
- if (error.type || error.stage) {
- log.error(`Problem running command ${params._[0]} during stage ${error.stage} when processing type ${error.type}`);
- } else {
- log.error(`Problem running command ${params._[0]}`);
- }
+  run(params)
+    .then(() => process.exit(0))
+    .catch((error) => {
+      if (error.type || error.stage) {
+        log.error(`Problem running command ${params._[0]} during stage ${error.stage} when processing type ${error.type}`);
+      } else {
+        log.error(`Problem running command ${params._[0]}`);
+      }
 
- const msg = error.message || error.toString();
- log.error(msg);
+      const msg = error.message || error.toString();
+      log.error(msg);
 
- if (process.env.AUTH0_DEBUG === 'true') {
- log.debug(error.stack);
- }
+      if (process.env.AUTH0_DEBUG === 'true') {
+        log.debug(error.stack);
+      }
 
- if (typeof msg === 'string' && msg.includes('Payload validation error')) {
- log.info('Please see https://github.com/auth0/auth0-deploy-cli#troubleshooting for common issues');
- }
- process.exit(1);
- });
+      if (typeof msg === 'string' && msg.includes('Payload validation error')) {
+        log.info('Please see https://github.com/auth0/auth0-deploy-cli#troubleshooting for common issues');
+      }
+      process.exit(1);
+    });
 }
 
 
 // Export commands to be used programmatically
 module.exports = {
- deploy: commands.import,
- dump: commands.export,
- import: commands.import,
- export: commands.export
+  deploy: commands.import,
+  dump: commands.export,
+  import: commands.import,
+  export: commands.export
 };


### PR DESCRIPTION

## ✏️ Changes

In some scenarios, logic which extracts parameters from the command line will execute even when
the package is being used as a library (as opposed to being run from the command line). This minor refactor shifts the parameter extraction logic in to the statement block which checks how the package is being used, first. 

## 🔗 References

> https://github.com/auth0/auth0-deploy-cli/issues/176

## 🎯 Testing

Tested by running package using the command line commands to ensure commands still function as intended. 
Tested by including the package as a library, to ensure using as a library still functions as intended.
Test with standard `npm test` suite

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
