### PR TITLE
[ESD-4992] Export placeholder api key for mailgun.

### DIFF
--- a/src/context/defaults.js
+++ b/src/context/defaults.js
@@ -2,7 +2,7 @@
 export function emailProviderDefaults(emailProvider) {  // eslint-disable-line
   const updated = { ...emailProvider };
 
-  const apiKeyProviders = [ 'mandrill', 'sendgrid', 'sparkpost' ];
+  const apiKeyProviders = [ 'mailgun', 'mandrill', 'sendgrid', 'sparkpost' ];
 
   // Add placeholder for credentials as they cannot be exported
   const { name } = updated;

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -29,6 +29,15 @@ describe('#context defaults', () => {
     });
   });
 
+  it('should set emailProvider defaults for mailgun', async () => {
+    expect(emailProviderDefaults({ name: 'mailgun' })).to.deep.equal({
+      credentials: {
+        api_key: 'YOUR_MAILGUN_API_KEY'
+      },
+      name: 'mailgun'
+    });
+  });
+
   it('should set emailProvider defaults for mandrill', async () => {
     expect(emailProviderDefaults({ name: 'mandrill' })).to.deep.equal({
       credentials: {


### PR DESCRIPTION
## ✏️ Changes

Unlike other email providers (sendgrid, etc.), mailgun was not adding a placeholder API key to the
export. This means that if a user tried to import the file again, they would get an error that the
schema was invalid.

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-4993

## 🎯 Testing

I exported a tenant with a mailgun email provider and verified that `api_key: YOUR_MAILGUN_API_KEY` appeared in the export.

✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
