### PR TITLE
ESD 4561 import client name connections idpinitiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2020-03-28
+- When importing SAML database connection, support client name in the `options.idpinitiated.client_id` property.
+
 ## [4.1.0] - 2020-03-28
 - When exporting a mailgun email provider, a placholder api key will be included in the export..
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {
@@ -29,7 +29,7 @@
     "ajv": "^6.5.2",
     "auth0": "^2.23.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.0.2",
+    "auth0-source-control-extension-tools": "^4.0.4",
     "dot-prop": "^4.2.0",
     "es6-template-strings": "^2.0.1",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
## ✏️ Changes

Bumping `auth0-source-control-extension-tools` v4.0.4 to support importing SAML database connection with client name in the `options.idpinitiated.client_id` property

## 🔗 References

[ESD-4561](https://auth0team.atlassian.net/browse/ESD-4561)

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance