### PR TITLE
ESD-4561 Client name in connection options.idpinitiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2020-03-28
+- When importing SAML database connections, support client name in the `options.idpinitiated.client_id` property.
+- When exporting SAML database connections, convert client ID to client name.
+
 ## [4.1.0] - 2020-03-28
 - When exporting a mailgun email provider, a placholder api key will be included in the export..
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3050,9 +3050,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -721,12 +721,12 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.0.2.tgz",
-      "integrity": "sha512-YxpZtwo5f33bKvuPtkzn4IgRUFsKcimffyZA4WQNqX2fAhIn+dfp2Tbf3IkIYlNDTP92B8071DKfrhMaFHIjqw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.0.4.tgz",
+      "integrity": "sha512-k27PuMyzDthQeXIX+uEvNXpIU+1DnPjga08yGj4cyhEXmFyA1x6wcAdK2YeO5jBwzSverTM90vU/zQZNDT5lDQ==",
       "requires": {
         "ajv": "^6.5.2",
-        "auth0-extension-tools": "^1.3.1",
+        "auth0-extension-tools": "^1.4.4",
         "babel-preset-env": "^1.7.0",
         "dot-prop": "^4.2.0",
         "promise-pool-executor": "^1.1.1",
@@ -7206,7 +7206,7 @@
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-limit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {
@@ -29,7 +29,7 @@
     "ajv": "^6.5.2",
     "auth0": "^2.23.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.0.2",
+    "auth0-source-control-extension-tools": "^4.0.4",
     "dot-prop": "^4.2.0",
     "es6-template-strings": "^2.0.1",
     "fs-extra": "^7.0.0",

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -31,6 +31,16 @@ describe('#YAML context connections', () => {
         options:
           email:
             body: "./email.html"
+      - name: "someSamlConnection"
+        strategy: "samlp"
+        enabled_clients:
+          - "client1"
+        options:
+          passwordPolicy: "testPolicy"
+          idpinitiated:
+            client_id: "idp-one"
+            client_protocol: samlp
+            client_authorizequery: ""
     `;
 
     const target = [
@@ -57,6 +67,19 @@ describe('#YAML context connections', () => {
           }
         },
         strategy: 'email'
+      },
+      {
+        name: 'someSamlConnection',
+        strategy: 'samlp',
+        enabled_clients: [ 'client1' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'idp-one',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
       }
     ];
 
@@ -85,6 +108,32 @@ describe('#YAML context connections', () => {
         strategy: 'email',
         enabled_clients: [],
         options: { email: { body: 'html code' } }
+      },
+      {
+        name: 'someSamlConnection',
+        strategy: 'samlp',
+        enabled_clients: [ 'client1-id' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-one-id',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
+      },
+      {
+        name: 'someSamlConnectionNoClientFound',
+        strategy: 'samlp',
+        enabled_clients: [ 'client2-id' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-two-id',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
       }
     ];
 
@@ -95,9 +144,41 @@ describe('#YAML context connections', () => {
         strategy: 'email',
         enabled_clients: [],
         options: { email: { body: './email.html' } }
+      },
+      {
+        name: 'someSamlConnection',
+        strategy: 'samlp',
+        enabled_clients: [ 'client1' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-one-name',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
+      },
+      {
+        name: 'someSamlConnectionNoClientFound',
+        strategy: 'samlp',
+        enabled_clients: [ 'client2-id' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-two-id',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
       }
     ];
 
+    const clients = [
+      { name: 'client-idp-one-name', app_type: 'spa', client_id: 'client-idp-one-id' },
+      { name: 'client1', app_type: 'spa', client_id: 'client1-id' }
+    ];
+
+    context.assets.clients = clients;
     context.assets.connections = connections;
 
     const dumped = await handler.dump(context);


### PR DESCRIPTION
## ✏️ Changes

- Bumping `auth0-source-control-extension-tools` v4.0.4 to support importing SAML database connection with client name in the `options.idpinitiated.client_id` property
- Support exporting SAML database connection with client name in the `options.idpinitiated.client_id` property

## 🔗 References

[ESD-4561](https://auth0team.atlassian.net/browse/ESD-4561)

## 🎯 Testing

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance