### PR TITLE
FEAT: Configurable connections directory

### DIFF
--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -6,7 +6,8 @@ import log from '../../../logger';
 import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, ensureProp } from '../../../utils';
 
 function parse(context) {
-  const connectionsFolder = path.join(context.filePath, constants.CONNECTIONS_DIRECTORY);
+  const connectionDirectory = context.config.AUTH0_CONNECTIONS_DIRECTORY || constants.CONNECTIONS_DIRECTORY;
+  const connectionsFolder = path.join(context.filePath, connectionDirectory);
   if (!existsMustBeDir(connectionsFolder)) return { connections: [] }; // Skip
 
   const foundFiles = getFiles(connectionsFolder, [ '.json' ]);

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -42,6 +42,31 @@ describe('#directory context connections', () => {
     expect(context.assets.connections).to.deep.equal(target);
   });
 
+
+  it('should process a custom connections directory', async () => {
+    const customConnectionDirectory = 'connections-custom';
+
+    const files = {
+      [customConnectionDirectory]: {
+        'a-connection.json': '{ "name": "A Connection" }'
+      }
+    };
+
+    const repoDir = path.join(testDataDir, 'directory', 'connections1');
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_CONNECTIONS_DIRECTORY: customConnectionDirectory };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    const target = [
+      { name: 'A Connection' }
+    ];
+
+    expect(context.assets.connections).to.deep.equal(target);
+  });
+
+
   it('should ignore unknown file', async () => {
     const files = {
       [constants.CONNECTIONS_DIRECTORY]: {


### PR DESCRIPTION
## ✏️ Changes

Adds a new configuration variable `AUTH0_CONNECTIONS_DIRECTORY` that allows one to override the default directory (`/connections`) in which to source tenant connection configurations.

This allows you to have separate connection directories for each tenant which greatly improves the ability to be explicit on the tenant targets for each connection.   As it stands now, in order to target a single tenant for a connection, one must add the connection name to `AUTH0_EXCLUDED_CONNECTIONS` on every other tenant which is cumbersome and hard to maintain.  

Further we have found that connection configurations are very environment specific (keys, endpoints, etc) which leads to excessive bloat in tenant configuration definition files.   With this change, the connection files themselves can be bound to a specific environments.

## 🎯 Testing

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
