### PR TITLE
Removes demo URL from verify_email.json example

### DIFF
--- a/examples/directory/emails/verify_email.json
+++ b/examples/directory/emails/verify_email.json
@@ -2,7 +2,7 @@
   "template": "verify_email",
   "from": "",
   "subject": "",
-  "resultUrl": "http://steve.a0demo.s3-website-ap-southeast-2.amazonaws.com/verified.html",
+  "resultUrl": "",
   "body": "./verify_email.html",
   "urlLifetimeInSeconds": 432000,
   "syntax": "liquid",


### PR DESCRIPTION
## ✏️ Changes

This removes a demo URL from the `verify_email.json` directory-structure example. Files in the examples directory often serve as template files for any Auth0 tenants that wish to customize their configuration via the Auth0 deployment tools. It is very easy for an app to miss that this one particular `resultUrl` setting was set to an actual. And then before you know it, you have production users being redirected to a page hosted by "Steve".

I think it's best to leave this field blank. It's safer to rely on Auth0 defaults unless an Auth0 tenant explicitly decides to customize the value. It's also consistent with how almost all other Auth0 configuration acts in this project.

I hope this helps. Thanks.