### PR TITLE
enable configuration of log levels with environment variable

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -6,7 +6,7 @@ const log = new winston.Logger({
   transports: [
     new winston.transports.Console({
       timestamp: true,
-      level: 'info',
+      level: process.env.AUTH0_LOG || 'info',
       handleExceptions: true,
       json: false,
       colorize: true


### PR DESCRIPTION
## ✏️ Changes

Modified `log/logger.js` to permit configuration of the log level via an `AUTH0_LOG` environment variable and to use the current default value of 'info' if no environment variable is detected.

## 🔗 References

References #227 for additional context

## 🎯 Testing

Current test plan was manual since there was no automated coverage of the file currently. After building locally, I required from the local path and ran the deploy command, e.g.,

```javascript
// auth0-deploy.js

const { deploy } = require('../path/to/local/build/lib');

deploy({
  input_file: 'tenant.yaml',
  config_file: 'config.json',
}).then(() => {
  console.log('Deploy completed successfully');
}).catch((err) => {
  console.error(err);
  process.exitCode = 1;
});
```

```bash 
$ export AUTH0_LOG=debug
$ node auth0-deploy.js
2020-04-23T03:58:06.578Z - debug: Loading YAML from \path\to\tenant.yaml
2020-04-23T03:58:06.957Z - info: Getting access token for TOKEN_VALUE/Auth0-domain
2020-04-23T03:58:07.651Z - info: Updated [rules]: {"name":"Rule name","order":1}
2020-04-23T03:58:07.655Z - info: Import Successful
Deploy completed successfull
```

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
