### PR TITLE
Don't default to empty resource collections if directory doesn't exist

### DIFF
--- a/src/context/directory/handlers/clientGrants.js
+++ b/src/context/directory/handlers/clientGrants.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
-  if (!existsMustBeDir(grantsFolder)) return { clientGrants: [] }; // Skip
+  if (!existsMustBeDir(grantsFolder)) return { clientGrants: undefined }; // Skip
 
   const foundFiles = getFiles(grantsFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -7,7 +7,7 @@ import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, clearClientArray
 
 function parse(context) {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
-  if (!existsMustBeDir(clientsFolder)) return { clients: [] }; // Skip
+  if (!existsMustBeDir(clientsFolder)) return { clients: undefined }; // Skip
 
   const foundFiles = getFiles(clientsFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -8,7 +8,7 @@ import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, ensureProp } fro
 function parse(context) {
   const connectionDirectory = context.config.AUTH0_CONNECTIONS_DIRECTORY || constants.CONNECTIONS_DIRECTORY;
   const connectionsFolder = path.join(context.filePath, connectionDirectory);
-  if (!existsMustBeDir(connectionsFolder)) return { connections: [] }; // Skip
+  if (!existsMustBeDir(connectionsFolder)) return { connections: undefined }; // Skip
 
   const foundFiles = getFiles(connectionsFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -48,7 +48,7 @@ function getDatabase(folder, mappings) {
 
 function parse(context) {
   const databaseFolder = path.join(context.filePath, constants.DATABASE_CONNECTIONS_DIRECTORY);
-  if (!existsMustBeDir(databaseFolder)) return { databases: [] }; // Skip
+  if (!existsMustBeDir(databaseFolder)) return { databases: undefined }; // Skip
 
   const folders = fs.readdirSync(databaseFolder)
     .map(f => path.join(databaseFolder, f))

--- a/src/context/directory/handlers/emailTemplates.js
+++ b/src/context/directory/handlers/emailTemplates.js
@@ -8,7 +8,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);
-  if (!existsMustBeDir(emailsFolder)) return { emailTemplates: [] }; // Skip
+  if (!existsMustBeDir(emailsFolder)) return { emailTemplates: undefined }; // Skip
 
   const files = getFiles(emailsFolder, [ '.json', '.html' ]).filter(f => path.basename(f) !== 'provider.json');
 

--- a/src/context/directory/handlers/guardianFactorProviders.js
+++ b/src/context/directory/handlers/guardianFactorProviders.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorProvidersFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_PROVIDERS_DIRECTORY);
-  if (!existsMustBeDir(factorProvidersFolder)) return { guardianFactorProviders: [] }; // Skip
+  if (!existsMustBeDir(factorProvidersFolder)) return { guardianFactorProviders: undefined }; // Skip
 
   const foundFiles = getFiles(factorProvidersFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/guardianFactorTemplates.js
+++ b/src/context/directory/handlers/guardianFactorTemplates.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorTemplatesFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_TEMPLATES_DIRECTORY);
-  if (!existsMustBeDir(factorTemplatesFolder)) return { guardianFactorTemplates: [] }; // Skip
+  if (!existsMustBeDir(factorTemplatesFolder)) return { guardianFactorTemplates: undefined }; // Skip
 
   const foundFiles = getFiles(factorTemplatesFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/guardianFactors.js
+++ b/src/context/directory/handlers/guardianFactors.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorsFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_FACTORS_DIRECTORY);
-  if (!existsMustBeDir(factorsFolder)) return { guardianFactors: [] }; // Skip
+  if (!existsMustBeDir(factorsFolder)) return { guardianFactors: undefined }; // Skip
 
   const foundFiles = getFiles(factorsFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/hooks.js
+++ b/src/context/directory/handlers/hooks.js
@@ -8,7 +8,7 @@ import log from '../../../logger';
 
 function parse(context) {
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);
-  if (!existsMustBeDir(hooksFolder)) return { hooks: [] }; // Skip
+  if (!existsMustBeDir(hooksFolder)) return { hooks: undefined }; // Skip
 
   const files = getFiles(hooksFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/pages.js
+++ b/src/context/directory/handlers/pages.js
@@ -8,7 +8,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const pagesFolder = path.join(context.filePath, constants.PAGES_DIRECTORY);
-  if (!existsMustBeDir(pagesFolder)) return { pages: [] }; // Skip
+  if (!existsMustBeDir(pagesFolder)) return { pages: undefined }; // Skip
 
   const files = getFiles(pagesFolder, [ '.json', '.html' ]);
 

--- a/src/context/directory/handlers/resourceServers.js
+++ b/src/context/directory/handlers/resourceServers.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);
-  if (!existsMustBeDir(resourceServersFolder)) return { resourceServers: [] }; // Skip
+  if (!existsMustBeDir(resourceServersFolder)) return { resourceServers: undefined }; // Skip
 
   const foundFiles = getFiles(resourceServersFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/roles.js
+++ b/src/context/directory/handlers/roles.js
@@ -7,7 +7,7 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);
-  if (!existsMustBeDir(rolesFolder)) return { roles: [] }; // Skip
+  if (!existsMustBeDir(rolesFolder)) return { roles: undefined }; // Skip
 
   const files = getFiles(rolesFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/rules.js
+++ b/src/context/directory/handlers/rules.js
@@ -8,7 +8,7 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const rulesFolder = path.join(context.filePath, constants.RULES_DIRECTORY);
-  if (!existsMustBeDir(rulesFolder)) return { rules: [] }; // Skip
+  if (!existsMustBeDir(rulesFolder)) return { rules: undefined }; // Skip
 
   const files = getFiles(rulesFolder, [ '.json' ]);
 

--- a/src/context/directory/handlers/rulesConfigs.js
+++ b/src/context/directory/handlers/rulesConfigs.js
@@ -5,7 +5,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 
 function parse(context) {
   const rulesConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);
-  if (!existsMustBeDir(rulesConfigsFolder)) return { rulesConfigs: [] }; // Skip
+  if (!existsMustBeDir(rulesConfigsFolder)) return { rulesConfigs: undefined }; // Skip
 
   const foundFiles = getFiles(rulesConfigsFolder, [ '.json' ]);
 

--- a/test/context/directory/context.test.js
+++ b/test/context/directory/context.test.js
@@ -15,11 +15,11 @@ describe('#directory context validation', () => {
     const context = new Context({ AUTH0_INPUT_FILE: dir });
     await context.load();
 
-    expect(context.assets.rules).to.deep.equal([]);
-    expect(context.assets.databases).to.deep.equal([]);
-    expect(context.assets.pages).to.deep.equal([]);
-    expect(context.assets.clients).to.deep.equal([]);
-    expect(context.assets.resourceServers).to.deep.equal([]);
+    Object.entries(context.assets).forEach(([ k, v ]) => {
+      if (typeof v === 'undefined') delete context.assets[k];
+    });
+
+    expect(context.assets).to.have.all.keys('exclude');
   });
 
   it('should load excludes', async () => {


### PR DESCRIPTION
## ✏️ Changes

The PR changes the defaults in the asset collection for a directory import.   It now matches the asset collection for yaml imported so that both formats are imported with consistent behavior.

Previously when importing a directory where a resource directory didn't exist, a0deploy would delete (or warn) any resources of that type that exist in the tenant.   This behavior is different from the yaml import where a0deploy will skip any resource types not defined in the yaml rather than deleting them.

## 🔗 References

Refer to https://github.com/auth0/auth0-deploy-cli/issues/231 for a longer description of the issue this PR fixes.

## 🎯 Testing

There are instructions to reproduce in the above referenced issue.

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
