### PR TITLE
[DXEX-629] pages: fix error when dumping error_page without html property

### DIFF
--- a/src/context/directory/handlers/pages.js
+++ b/src/context/directory/handlers/pages.js
@@ -50,15 +50,20 @@ async function dump(context) {
   fs.ensureDirSync(pagesFolder);
 
   pages.forEach((page) => {
-    // Dump template html to file
-    const htmlFile = path.join(pagesFolder, `${page.name}.html`);
-    log.info(`Writing ${htmlFile}`);
-    fs.writeFileSync(htmlFile, page.html);
+    var metadata = { ...page };
+
+    if (page.name !== 'error_page' || page.html !== undefined) {
+      // Dump template html to file
+      const htmlFile = path.join(pagesFolder, `${page.name}.html`);
+      log.info(`Writing ${htmlFile}`);
+      fs.writeFileSync(htmlFile, page.html);
+      metadata.html = `./${page.name}.html`;
+    }
 
     // Dump page metadata
     const pageFile = path.join(pagesFolder, `${page.name}.json`);
     log.info(`Writing ${pageFile}`);
-    fs.writeFileSync(pageFile, JSON.stringify({ ...page, html: `./${page.name}.html` }, null, 2));
+    fs.writeFileSync(pageFile, JSON.stringify(metadata), null, 2);
   });
 }
 

--- a/src/context/yaml/handlers/pages.js
+++ b/src/context/yaml/handlers/pages.js
@@ -28,6 +28,10 @@ async function dump(context) {
     fs.ensureDirSync(pagesFolder);
 
     pages = pages.map((page) => {
+      if (page.name === 'error_page' && page.html === undefined) {
+        return page;
+      }
+
       // Dump html to file
       const htmlFile = path.join(pagesFolder, `${page.name}.html`);
       log.info(`Writing ${htmlFile}`);

--- a/test/context/directory/pages.test.js
+++ b/test/context/directory/pages.test.js
@@ -16,12 +16,17 @@ const pages = {
   'guardian_multifactor.html': '<html>this is a page env ##env##</html>',
   'password_reset.json': '{ "name": "password_reset", "enabled": true }',
   'password_reset.html': '<html>this is a page env ##env##</html>',
-  'error_page.json': '{ "name": "error_page", "enabled": false }',
+  'error_page.json': '{ "name": "error_page", "url": "https://example.com/error", "show_log_link": false }',
   'error_page.html': '<html>this is a page env ##env##</html>'
 };
 
 const pagesTarget = [
-  { enabled: false, html: '<html>this is a page env test</html>', name: 'error_page' },
+  {
+    html: '<html>this is a page env test</html>',
+    name: 'error_page',
+    url: 'https://example.com/error',
+    show_log_link: false
+  },
   { enabled: true, html: '<html>this is a page env test</html>', name: 'guardian_multifactor' },
   { enabled: true, html: '<html>this is a page env test</html>', name: 'login' },
   { enabled: true, html: '<html>this is a page env test</html>', name: 'password_reset' }
@@ -71,6 +76,7 @@ describe('#directory context pages', () => {
     const dir = path.join(testDataDir, 'directory', 'pagesDump');
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    const errorPageUrl = 'https://example.com/error';
 
     const htmlValidation = '<html>this is a env1 "env2"</html>';
 
@@ -78,7 +84,12 @@ describe('#directory context pages', () => {
       { html: htmlValidation, name: 'login' },
       { html: htmlValidation, name: 'password_reset' },
       { enabled: false, html: htmlValidation, name: 'guardian_multifactor' },
-      { html: htmlValidation, name: 'error_page' }
+      {
+        html: htmlValidation,
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
+      }
     ];
 
     await handler.dump(context);
@@ -94,7 +105,37 @@ describe('#directory context pages', () => {
     expect(loadJSON(path.join(pagesFolder, 'guardian_multifactor.json'))).to.deep.equal({ html: './guardian_multifactor.html', name: 'guardian_multifactor', enabled: false });
     expect(fs.readFileSync(path.join(pagesFolder, 'guardian_multifactor.html'), 'utf8')).to.deep.equal(htmlValidation);
 
-    expect(loadJSON(path.join(pagesFolder, 'error_page.json'))).to.deep.equal({ html: './error_page.html', name: 'error_page' });
+    expect(loadJSON(path.join(pagesFolder, 'error_page.json'))).to.deep.equal({
+      html: './error_page.html',
+      name: 'error_page',
+      url: errorPageUrl,
+      show_log_link: false
+    });
     expect(fs.readFileSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.deep.equal(htmlValidation);
+  });
+
+  it('should dump error page without html', async () => {
+    const dir = path.join(testDataDir, 'directory', 'pagesDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    const errorPageUrl = 'https://example.com/error';
+
+    context.assets.pages = [
+      {
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
+      }
+    ];
+
+    await handler.dump(context);
+
+    const pagesFolder = path.join(dir, constants.PAGES_DIRECTORY);
+    expect(loadJSON(path.join(pagesFolder, 'error_page.json'))).to.deep.equal({
+      name: 'error_page',
+      url: errorPageUrl,
+      show_log_link: false
+    });
+    expect(fs.existsSync(path.join(pagesFolder, 'error_page.html'))).to.equal(false);
   });
 });

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -32,6 +32,7 @@ describe('#YAML context pages', () => {
     const htmlFile = path.join(testDataDir, 'page.html');
     fs.writeFileSync(htmlFile, htmlContext);
 
+    const errorPageUrl = 'https://example.com';
     const yaml = `
     pages:
       - name: "login"
@@ -46,6 +47,8 @@ describe('#YAML context pages', () => {
 
       - name: "error_page"
         html: "${htmlFile}"
+        url: "${errorPageUrl}"
+        show_log_link: false
     `;
 
     const htmlValidation = '<html>this is a env1 "env2"</html>';
@@ -65,7 +68,9 @@ describe('#YAML context pages', () => {
       },
       {
         html: htmlValidation,
-        name: 'error_page'
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
       }
     ];
     createPagesDir(dir, target);
@@ -84,12 +89,18 @@ describe('#YAML context pages', () => {
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: path.join(dir, 'tennat.yaml') }, mockMgmtClient());
     const htmlValidation = '<html>this is a env1 "env2"</html>';
+    const errorPageUrl = 'https://example.com';
 
     context.assets.pages = [
       { html: htmlValidation, name: 'login' },
       { html: htmlValidation, name: 'password_reset' },
       { enabled: false, html: htmlValidation, name: 'guardian_multifactor' },
-      { html: htmlValidation, name: 'error_page' }
+      {
+        html: htmlValidation,
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
+      }
     ];
 
     const dumped = await handler.dump(context);
@@ -98,7 +109,12 @@ describe('#YAML context pages', () => {
         { html: './pages/login.html', name: 'login' },
         { html: './pages/password_reset.html', name: 'password_reset' },
         { enabled: false, html: './pages/guardian_multifactor.html', name: 'guardian_multifactor' },
-        { html: './pages/error_page.html', name: 'error_page' }
+        {
+          html: './pages/error_page.html',
+          name: 'error_page',
+          url: errorPageUrl,
+          show_log_link: false
+        }
       ]
     });
 
@@ -106,6 +122,67 @@ describe('#YAML context pages', () => {
     expect(fs.readFileSync(path.join(pagesFolder, 'login.html'), 'utf8')).to.deep.equal(htmlValidation);
     expect(fs.readFileSync(path.join(pagesFolder, 'password_reset.html'), 'utf8')).to.deep.equal(htmlValidation);
     expect(fs.readFileSync(path.join(pagesFolder, 'guardian_multifactor.html'), 'utf8')).to.deep.equal(htmlValidation);
+    expect(fs.readFileSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.deep.equal(htmlValidation);
+  });
+
+  it('should dump error_page with html undefined', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'pagesDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: path.join(dir, 'tennat.yaml') }, mockMgmtClient());
+    const errorPageUrl = 'https://example.com';
+
+    context.assets.pages = [
+      {
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
+      }
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      pages: [
+        {
+          name: 'error_page',
+          url: errorPageUrl,
+          show_log_link: false
+        }
+      ]
+    });
+
+    const pagesFolder = path.join(dir, 'pages');
+    expect(fs.existsSync(path.join(pagesFolder, 'error_page.html'))).to.equal(false);
+  });
+
+  it('should dump error_page with empty html', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'pagesDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: path.join(dir, 'tennat.yaml') }, mockMgmtClient());
+    const htmlValidation = '';
+    const errorPageUrl = 'https://example.com';
+
+    context.assets.pages = [
+      {
+        html: htmlValidation,
+        name: 'error_page',
+        url: errorPageUrl,
+        show_log_link: false
+      }
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      pages: [
+        {
+          html: './pages/error_page.html',
+          name: 'error_page',
+          url: errorPageUrl,
+          show_log_link: false
+        }
+      ]
+    });
+
+    const pagesFolder = path.join(dir, 'pages');
     expect(fs.readFileSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.deep.equal(htmlValidation);
   });
 });


### PR DESCRIPTION
## ✏️ Changes

The `error_page` object in tenant setting may contain only a `url` property for redirection and without a `html` property for templating. Previously we assume `html` is always present and thus will attempt to pass `undefined` as the `data` argument to `fs.writeFileSync()`, which now [throws error on Node.js 14](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).

This PR fixes this by skipping writing the template file when `error_page` does not have the property `html`. Tests for `url` and `show_log_link` in `error_page` were also added.

## 🔗 References

- https://auth0team.atlassian.net/browse/DXEX-629
- Documentation on universal login error page: https://auth0.com/docs/universal-login/error-pages
- Management APIv2 explorer for tenant settings of error_page: https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings

## 🎯 Testing

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
