### PR TITLE
Validate AUTH0_DOMAIN in config

### DIFF
--- a/src/context/index.js
+++ b/src/context/index.js
@@ -33,6 +33,10 @@ export default async function(config) {
     throw new Error(`The following parameters were missing. Please add them to your config.json or as an environment variable. ${JSON.stringify(errors)}`);
   }
 
+  if (config.AUTH0_DOMAIN.startsWith('http') || !config.AUTH0_DOMAIN.endsWith('auth0.com')) {
+    throw new Error("The AUTH0_DOMAIN in config.json needs to match your tenant's domain. This should be in the format '{TENANT NAME}.[us?|eu|au].auth0.com' and can be found in the Domain setting of the Application created for the deploy-cli.");
+  }
+
   let accessToken = config.AUTH0_ACCESS_TOKEN;
 
   if (!accessToken) {

--- a/test/context/context.test.js
+++ b/test/context/context.test.js
@@ -15,7 +15,7 @@ const config = {
 
 describe('#context loader validation', async () => {
   it('should error on bad file', async () => {
-    expect(async () => context(config).to.throw(Error));
+    await expect(context(config)).to.be.eventually.rejectedWith(Error);
   });
 
   it('should error on misconfigured AUTH0_DOMAIN in config file', async () => {

--- a/test/context/context.test.js
+++ b/test/context/context.test.js
@@ -18,6 +18,14 @@ describe('#context loader validation', async () => {
     expect(async () => context(config).to.throw(Error));
   });
 
+  it('should error on misconfigured AUTH0_DOMAIN in config file', async () => {
+    const dir = path.resolve(testDataDir, 'context');
+    cleanThenMkdir(dir);
+
+    await expect(context({ ...config, AUTH0_INPUT_FILE: dir, AUTH0_DOMAIN: 'https://tenant.auth0.com' })).to.be.eventually.rejectedWith(Error);
+    await expect(context({ ...config, AUTH0_INPUT_FILE: dir, AUTH0_DOMAIN: 'tenant.auth0.com/api/v2' })).to.be.eventually.rejectedWith(Error);
+  });
+
   it('should load directory context', async () => {
     /* Create empty directory */
     const dir = path.resolve(testDataDir, 'context');


### PR DESCRIPTION
## ✏️ Changes

 Lack of domain validation can result in less than helpful error messages that bubble up from node-auth0
 - Added a check for properly formed `AUTH0_DOMAIN` in `config.json`
 - Added test

## 🔗 References

n/a

## 🎯 Testing

Test added. Manually, test using an invalid `AUTH_DOMAIN` in `config.js`

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
