### PR TITLE
Fix deploy error_pages without html field

### DIFF
--- a/src/context/yaml/handlers/pages.js
+++ b/src/context/yaml/handlers/pages.js
@@ -12,7 +12,7 @@ async function parse(context) {
     pages: [
       ...context.assets.pages.map(page => ({
         ...page,
-        html: context.loadFile(page.html)
+        html: page.html ? context.loadFile(page.html) : undefined
       }))
     ]
   };

--- a/src/context/yaml/handlers/pages.js
+++ b/src/context/yaml/handlers/pages.js
@@ -12,7 +12,7 @@ async function parse(context) {
     pages: [
       ...context.assets.pages.map(page => ({
         ...page,
-        html: page.html ? context.loadFile(page.html) : undefined
+        html: page.html ? context.loadFile(page.html) : ''
       }))
     ]
   };

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -185,4 +185,32 @@ describe('#YAML context pages', () => {
     const pagesFolder = path.join(dir, 'pages');
     expect(fs.readFileSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.deep.equal(htmlValidation);
   });
+
+  it('should process error_pages without html field', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'pages1');
+    cleanThenMkdir(dir);
+
+    const errorPageUrl = 'https://example.com';
+    const yaml = `
+    pages:
+      - name: "error_page"
+        url: "${errorPageUrl}"
+    `;
+    const target = [
+      {
+        name: 'error_page',
+        url: errorPageUrl,
+        html: undefined
+      }
+    ];
+    createPagesDir(dir, target);
+    const yamlFile = path.join(dir, 'rule1.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    expect(context.assets.pages).to.deep.equal(target);
+  });
 });

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -200,7 +200,7 @@ describe('#YAML context pages', () => {
       {
         name: 'error_page',
         url: errorPageUrl,
-        html: undefined
+        html: ''
       }
     ];
     createPagesDir(dir, target);


### PR DESCRIPTION
## ✏️ Changes

Error pages haven't an HTML code file, but when assets are being created to process changes, loadFile(page.html) function is called, this generates an error.

This PRefixes that issue

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-7637

## 🎯 Testing

✅ This change has unit test coverage
