### PR TITLE
Fix: Add <EOF> new line support to directory JSON dumps

### DIFF
--- a/src/context/directory/handlers/clientGrants.js
+++ b/src/context/directory/handlers/clientGrants.js
@@ -2,8 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
@@ -37,8 +36,7 @@ async function dump(context) {
 
     const name = sanitize(`${dumpGrant.client_id} (${dumpGrant.audience})`);
     const grantFile = path.join(grantsFolder, `${name}.json`);
-    log.info(`Writing ${grantFile}`);
-    fs.writeFileSync(grantFile, JSON.stringify(dumpGrant, null, 2));
+    dumpJSON(grantFile, dumpGrant);
   });
 }
 

--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants, loadFile } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, clearClientArrays } from '../../../utils';
+import { isFile, getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize, clearClientArrays } from '../../../utils';
 
 function parse(context) {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
@@ -54,9 +54,7 @@ async function dump(context) {
 
       client.custom_login_page = `./${clientName}_custom_login_page.html`;
     }
-
-    log.info(`Writing ${clientFile}`);
-    fs.writeFileSync(clientFile, JSON.stringify(clearClientArrays(client), null, 2));
+    dumpJSON(clientFile, clearClientArrays(client));
   });
 }
 

--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants, loadFile } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, ensureProp } from '../../../utils';
+import { isFile, getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize, ensureProp } from '../../../utils';
 
 function parse(context) {
   const connectionDirectory = context.config.AUTH0_CONNECTIONS_DIRECTORY || constants.CONNECTIONS_DIRECTORY;
@@ -70,8 +70,7 @@ async function dump(context) {
     }
 
     const connectionFile = path.join(connectionsFolder, `${connectionName}.json`);
-    log.info(`Writing ${connectionFile}`);
-    fs.writeFileSync(connectionFile, JSON.stringify(dumpedConnection, null, 2));
+    dumpJSON(connectionFile, dumpedConnection);
   });
 }
 

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import { constants, loadFile } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { isDirectory, existsMustBeDir, loadJSON, getFiles, sanitize } from '../../../utils';
+import { isDirectory, existsMustBeDir, dumpJSON, loadJSON, getFiles, sanitize } from '../../../utils';
 
 
 function getDatabase(folder, mappings) {
@@ -102,8 +102,7 @@ async function dump(context) {
     };
 
     const databaseFile = path.join(dbFolder, 'database.json');
-    log.info(`Writing ${databaseFile}`);
-    fs.writeFileSync(databaseFile, JSON.stringify(formatted, null, 2));
+    dumpJSON(databaseFile, formatted);
   });
 }
 

--- a/src/context/directory/handlers/emailProvider.js
+++ b/src/context/directory/handlers/emailProvider.js
@@ -2,8 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import log from '../../../logger';
-import { existsMustBeDir, isFile, loadJSON } from '../../../utils';
+import { existsMustBeDir, isFile, dumpJSON, loadJSON } from '../../../utils';
 import { emailProviderDefaults } from '../../defaults';
 
 function parse(context) {
@@ -37,8 +36,7 @@ async function dump(context) {
   fs.ensureDirSync(emailsFolder);
 
   const emailProviderFile = path.join(emailsFolder, 'provider.json');
-  log.info(`Writing ${emailProviderFile}`);
-  fs.writeFileSync(emailProviderFile, JSON.stringify(emailProvider, null, 2));
+  dumpJSON(emailProviderFile, emailProvider);
 }
 
 

--- a/src/context/directory/handlers/emailTemplates.js
+++ b/src/context/directory/handlers/emailTemplates.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants, loadFile } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 
 
 function parse(context) {
@@ -57,8 +57,7 @@ async function dump(context) {
 
     // Dump template metadata
     const templateFile = path.join(templatesFolder, `${template.template}.json`);
-    log.info(`Writing ${templateFile}`);
-    fs.writeFileSync(templateFile, JSON.stringify({ ...template, body: `./${template.template}.html` }, null, 2));
+    dumpJSON(templateFile, { ...template, body: `./${template.template}.html` });
   });
 }
 

--- a/src/context/directory/handlers/guardianFactorProviders.js
+++ b/src/context/directory/handlers/guardianFactorProviders.js
@@ -2,8 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorProvidersFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_PROVIDERS_DIRECTORY);
@@ -30,8 +29,7 @@ async function dump(context) {
 
   guardianFactorProviders.forEach((factorProvider) => {
     const factorProviderFile = path.join(factorProvidersFolder, `${factorProvider.name}-${factorProvider.provider}.json`);
-    log.info(`Writing ${factorProviderFile}`);
-    fs.writeFileSync(factorProviderFile, JSON.stringify(factorProvider, null, 2));
+    dumpJSON(factorProviderFile, factorProvider);
   });
 }
 

--- a/src/context/directory/handlers/guardianFactorTemplates.js
+++ b/src/context/directory/handlers/guardianFactorTemplates.js
@@ -2,8 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorTemplatesFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_TEMPLATES_DIRECTORY);
@@ -30,8 +29,7 @@ async function dump(context) {
 
   guardianFactorTemplates.forEach((factorTemplates) => {
     const factorTemplatesFile = path.join(factorTemplatesFolder, `${factorTemplates.name}.json`);
-    log.info(`Writing ${factorTemplatesFile}`);
-    fs.writeFileSync(factorTemplatesFile, JSON.stringify(factorTemplates, null, 2));
+    dumpJSON(factorTemplatesFile, factorTemplates);
   });
 }
 

--- a/src/context/directory/handlers/guardianFactors.js
+++ b/src/context/directory/handlers/guardianFactors.js
@@ -2,8 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 
 function parse(context) {
   const factorsFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_FACTORS_DIRECTORY);
@@ -30,8 +29,7 @@ async function dump(context) {
 
   guardianFactors.forEach((factor) => {
     const factorFile = path.join(factorsFolder, `${factor.name}.json`);
-    log.info(`Writing ${factorFile}`);
-    fs.writeFileSync(factorFile, JSON.stringify(factor, null, 2));
+    dumpJSON(factorFile, factor);
   });
 }
 

--- a/src/context/directory/handlers/guardianPhoneFactorMessageTypes.js
+++ b/src/context/directory/handlers/guardianPhoneFactorMessageTypes.js
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
-
-import log from '../../../logger';
-import { existsMustBeDir, loadJSON, isFile } from '../../../utils';
+import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 
 function parse(context) {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
@@ -30,8 +28,7 @@ async function dump(context) {
   fs.ensureDirSync(guardianFolder);
 
   const file = path.join(guardianFolder, 'phoneFactorMessageTypes.json');
-  log.info(`Writing ${file}`);
-  fs.writeFileSync(file, JSON.stringify(guardianPhoneFactorMessageTypes, null, 2));
+  dumpJSON(file, guardianPhoneFactorMessageTypes);
 }
 
 

--- a/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.js
+++ b/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.js
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
-
-import log from '../../../logger';
-import { existsMustBeDir, loadJSON, isFile } from '../../../utils';
+import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 
 function parse(context) {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
@@ -30,8 +28,7 @@ async function dump(context) {
   fs.ensureDirSync(guardianFolder);
 
   const file = path.join(guardianFolder, 'phoneFactorSelectedProvider.json');
-  log.info(`Writing ${file}`);
-  fs.writeFileSync(file, JSON.stringify(guardianPhoneFactorSelectedProvider, null, 2));
+  dumpJSON(file, guardianPhoneFactorSelectedProvider);
 }
 
 

--- a/src/context/directory/handlers/guardianPolicies.js
+++ b/src/context/directory/handlers/guardianPolicies.js
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
-
-import log from '../../../logger';
-import { existsMustBeDir, loadJSON, isFile } from '../../../utils';
+import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 
 function parse(context) {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
@@ -30,8 +28,7 @@ async function dump(context) {
   fs.ensureDirSync(guardianFolder);
 
   const file = path.join(guardianFolder, 'policies.json');
-  log.info(`Writing ${file}`);
-  fs.writeFileSync(file, JSON.stringify(guardianPolicies, null, 2));
+  dumpJSON(file, guardianPolicies);
 }
 
 

--- a/src/context/directory/handlers/hooks.js
+++ b/src/context/directory/handlers/hooks.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import log from '../../../logger';
 
 
@@ -47,8 +47,7 @@ async function dump(context) {
 
     // Dump template metadata
     const hookFile = path.join(hooksFolder, `${name}.json`);
-    log.info(`Writing ${hookFile}`);
-    fs.writeFileSync(hookFile, JSON.stringify({ ...hook, script: `./${name}.js` }, null, 2));
+    dumpJSON(hookFile, { ...hook, script: `./${name}.js` });
   });
 }
 

--- a/src/context/directory/handlers/migrations.js
+++ b/src/context/directory/handlers/migrations.js
@@ -1,8 +1,5 @@
-import fs from 'fs-extra';
 import path from 'path';
-
-import log from '../../../logger';
-import { existsMustBeDir, isFile, loadJSON } from '../../../utils';
+import { existsMustBeDir, isFile, dumpJSON, loadJSON } from '../../../utils';
 
 
 function parse(context) {
@@ -28,8 +25,7 @@ async function dump(context) {
   if (!migrations || Object.keys(migrations).length === 0) return; // Skip, nothing to dump
 
   const migrationsFile = path.join(context.filePath, 'migrations.json');
-  log.info(`Writing ${migrationsFile}`);
-  fs.writeFileSync(migrationsFile, JSON.stringify(migrations, null, 2));
+  dumpJSON(migrationsFile, migrations);
 }
 
 

--- a/src/context/directory/handlers/pages.js
+++ b/src/context/directory/handlers/pages.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants, loadFile } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 
 
 function parse(context) {
@@ -62,8 +62,7 @@ async function dump(context) {
 
     // Dump page metadata
     const pageFile = path.join(pagesFolder, `${page.name}.json`);
-    log.info(`Writing ${pageFile}`);
-    fs.writeFileSync(pageFile, JSON.stringify(metadata), null, 2);
+    dumpJSON(pageFile, metadata);
   });
 }
 

--- a/src/context/directory/handlers/resourceServers.js
+++ b/src/context/directory/handlers/resourceServers.js
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
-
-import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);
@@ -30,8 +28,7 @@ async function dump(context) {
 
   resourceServers.forEach((resourceServer) => {
     const resourceServerFile = path.join(resourceServersFolder, sanitize(`${resourceServer.name}.json`));
-    log.info(`Writing ${resourceServerFile}`);
-    fs.writeFileSync(resourceServerFile, JSON.stringify(resourceServer, null, 2));
+    dumpJSON(resourceServerFile, resourceServer);
   });
 }
 

--- a/src/context/directory/handlers/roles.js
+++ b/src/context/directory/handlers/roles.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 
 function parse(context) {
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);
@@ -39,7 +39,7 @@ async function dump(context) {
       delete role.description;
     }
 
-    fs.writeFileSync(roleFile, JSON.stringify(role, null, 2));
+    dumpJSON(roleFile, role);
   });
 }
 

--- a/src/context/directory/handlers/rules.js
+++ b/src/context/directory/handlers/rules.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { constants } from 'auth0-source-control-extension-tools';
 
 import log from '../../../logger';
-import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
+import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 
 
 function parse(context) {
@@ -43,8 +43,7 @@ async function dump(context) {
 
     // Dump template metadata
     const ruleFile = path.join(rulesFolder, `${name}.json`);
-    log.info(`Writing ${ruleFile}`);
-    fs.writeFileSync(ruleFile, JSON.stringify({ ...rule, script: `./${name}.js` }, null, 2));
+    dumpJSON(ruleFile, { ...rule, script: `./${name}.js` });
   });
 }
 

--- a/src/context/directory/handlers/tenant.js
+++ b/src/context/directory/handlers/tenant.js
@@ -1,8 +1,5 @@
-import fs from 'fs-extra';
 import path from 'path';
-
-import log from '../../../logger';
-import { existsMustBeDir, isFile, loadJSON, hoursAsInteger, clearTenantFlags } from '../../../utils';
+import { existsMustBeDir, isFile, dumpJSON, loadJSON, hoursAsInteger, clearTenantFlags } from '../../../utils';
 
 function parse(context) {
   const baseFolder = path.join(context.filePath);
@@ -42,8 +39,7 @@ async function dump(context) {
   clearTenantFlags(tenant);
 
   const tenantFile = path.join(context.filePath, 'tenant.json');
-  log.info(`Writing ${tenantFile}`);
-  fs.writeFileSync(tenantFile, JSON.stringify(tenant, null, 2));
+  dumpJSON(tenantFile, tenant);
 }
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ import path from 'path';
 import sanitizeName from 'sanitize-filename';
 import { loadFile } from 'auth0-source-control-extension-tools';
 import dotProp from 'dot-prop';
+import log from './logger';
 
 export function isDirectory(f) {
   try {
@@ -40,6 +41,18 @@ export function loadJSON(file, mappings) {
   }
 }
 
+export function dumpJSON(file, mappings) {
+  try {
+    log.info(`Writing ${file}`);
+    const jsonBody = JSON.stringify(mappings, null, 2);
+    fs.writeFileSync(
+      file,
+      jsonBody.endsWith('\n') ? jsonBody : `${jsonBody}\n`
+    );
+  } catch (e) {
+    throw new Error(`Error writing JSON to metadata file: ${file}, because: ${e.message}`);
+  }
+}
 
 export function existsMustBeDir(folder) {
   if (fs.existsSync(folder)) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,18 +5,19 @@ import { Auth0 } from 'auth0-source-control-extension-tools';
 
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from './utils';
 import {
-  isFile,
-  isDirectory,
-  getFiles,
-  loadJSON,
+  clearClientArrays,
+  dumpJSON,
   existsMustBeDir,
-  toConfigFn,
-  stripIdentifiers,
-  sanitize,
-  hoursAsInteger,
   formatResults,
+  getFiles,
+  hoursAsInteger,
+  isDirectory,
+  isFile,
+  loadJSON,
   recordsSorter,
-  clearClientArrays
+  sanitize,
+  stripIdentifiers,
+  toConfigFn
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -39,7 +40,6 @@ describe('#utils', function() {
     expect(isFile(fileExist)).is.equal(true);
     expect(isFile(fileNotExist)).is.equal(false);
   });
-
 
   it('should get files', () => {
     const dir = path.join(testDataDir, 'utils', 'getfiles');
@@ -69,7 +69,6 @@ describe('#utils', function() {
       test: '123'
     });
   });
-
 
   it('exist must be dir', () => {
     const dirExist = path.join(testDataDir, 'utils', 'existmustbedir');
@@ -206,5 +205,30 @@ describe('#utils', function() {
     };
 
     expect(clearClientArrays(client)).to.deep.equal(client);
+  });
+
+  describe('dumpJSON', () => {
+    const dir = path.join(testDataDir, 'utils', 'json');
+    cleanThenMkdir(dir);
+    const file = path.join(dir, 'test1.json');
+    const testObject = {
+      env1: 'test1',
+      env2: 'test2',
+      test: '123'
+    };
+    dumpJSON(file, testObject);
+    const testFileContents = fs.readFileSync(file, { encoding: 'utf8' });
+
+    it('should dump JSON with the contents of passed object', () => {
+      expect(JSON.parse(testFileContents)).deep.equal(testObject);
+    });
+    it('should dump json with trailing newline', () => {
+      expect(testFileContents).match(/\n$/g);
+    });
+    it('should throw an error if a path is not writable', () => {
+      expect(() => {
+        dumpJSON('http://notavalidfilepath', testObject);
+      }).throws(/Error writing JSON.*/);
+    });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

- Add new line support to JSON files generated in directory dumps
- Move write file method to common util 

## 🔗 References

https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file
Issue: https://github.com/auth0/auth0-deploy-cli/issues/128
Ticket: https://support.auth0.com/tickets/00464642

## 🎯 Testing

Have tested this locally dumping appliance config for Auth0 customer.

✅ This change has unit test coverage
🚫  This change has integration test coverage - (no framework for integration test in this repo)
✅This change has been tested for performance
