### PR TITLE
bump auth0-source-control-extension-tools fix exporting roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.3.tgz",
-      "integrity": "sha512-dUtN0kj2glvkCI/Zk694hX+Qj3Bt6oki2zXxLA0Rj1AHHqIz6u9H9h8Dhqttnyfoac5MINDX6NyGEuhX6TVdOA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.4.tgz",
+      "integrity": "sha512-/PcSxb8hooxzeUMC/FKiyNuvKw4Z5b8xX4tfwKiaX2l6qaNhsuwI6KE/ZXHjG7oYXQxLx9bwkhneWdE8Gag0uA==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.3",
+    "auth0-source-control-extension-tools": "^4.1.4",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "http-proxy-agent": "^2.0.0",

--- a/test/utils.js
+++ b/test/utils.js
@@ -52,17 +52,19 @@ export function mockMgmtClient() {
       ]
     },
     roles: {
-      getAll: () => [
+      getAll: () => (
         {
-          name: 'App Admin',
-          description: 'Admin of app',
-          permissions: [
+          roles: [
             {
-              permission_name: 'create:data', resource_server_identifier: 'urn:ref'
+              name: 'App Admin',
+              id: 'myRoleId',
+              description: 'Admin of app'
             }
-          ]
+          ],
+          total: 1,
+          limit: 50
         }
-      ],
+      ),
       permissions: {
         get: () => [
           {


### PR DESCRIPTION
## ✏️ Changes

bump auth0-source-control-extension-tools to include the fix that retrieves paginated roles and loops over all the pages to return all roles.

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-7536

