### PR TITLE
Fix: Load argument object during cli run

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -1,82 +1,112 @@
 import yargs from 'yargs';
 
-export default yargs
-  .demandCommand(1, 'A command is required')
-  .usage('Auth0 Deploy CLI')
-  .option('debug', {
-    alias: 'd',
-    describe: 'Dump extra debug information.',
-    type: 'boolean',
-    default: false
-  })
-  .option('proxy_url', {
-    alias: 'p',
-    describe: 'A url for proxying requests, only set this if you are behind a proxy.',
-    type: 'string'
-  })
-  .command([ 'import', 'deploy' ], 'Deploy Configuration', {
-    input_file: {
-      alias: 'i',
-      describe: 'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
-      type: 'string',
-      demandOption: true
-    },
-    config_file: {
-      alias: 'c',
-      describe: 'The JSON configuration file.',
-      type: 'string'
-    },
-    env: {
-      alias: 'e',
-      describe: 'Override the mappings in config with process.env environment variables.',
+export function constructArgs() {
+  return yargs
+    .demandCommand(1, 'A command is required')
+    .usage('Auth0 Deploy CLI')
+    .option('debug', {
+      alias: 'd',
+      describe: 'Dump extra debug information.',
       type: 'string',
       boolean: true,
-      default: true
-    },
-    secret: {
-      alias: 'x',
-      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
-      type: 'string'
-    }
-  })
-  .command([ 'export', 'dump' ], 'Export Auth0 Tenant Configuration', {
-    output_folder: {
-      alias: 'o',
-      describe: 'The output directory.',
-      type: 'string',
-      demandOption: true
-    },
-    format: {
-      alias: 'f',
-      describe: 'The output format.',
-      type: 'string',
-      choices: [ 'yaml', 'directory' ],
-      demandOption: true
-    },
-    config_file: {
-      alias: 'c',
-      describe: 'The JSON configuration file.',
-      type: 'string'
-    },
-    secret: {
-      alias: 'x',
-      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
-      type: 'string'
-    },
-    export_ids: {
-      alias: 'e',
-      describe: 'Export identifier field for each object type.',
-      type: 'boolean',
       default: false
-    }
-  })
-  .example('$0 export -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
-  .example('$0 export -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
-  .example('$0 import -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
-  .example('$0 import -c config.json -i path/to/files', 'Deploy Auth0 via Path')
-  .example('$0 dump -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
-  .example('$0 dump -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
-  .example('$0 deploy -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
-  .example('$0 deploy -c config.json -i path/to/files', 'Deploy Auth0 via Path')
-  .epilogue('See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.')
-  .wrap(null);
+    })
+    .option('proxy_url', {
+      alias: 'p',
+      describe:
+        'A url for proxying requests, only set this if you are behind a proxy.',
+      type: 'string'
+    })
+    .command([ 'import', 'deploy' ], 'Deploy Configuration', {
+      input_file: {
+        alias: 'i',
+        describe:
+          'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
+        type: 'string',
+        demandOption: true
+      },
+      config_file: {
+        alias: 'c',
+        describe: 'The JSON configuration file.',
+        type: 'string'
+      },
+      env: {
+        alias: 'e',
+        describe:
+          'Override the mappings in config with process.env environment variables.',
+        type: 'string',
+        boolean: true,
+        default: true
+      },
+      secret: {
+        alias: 'x',
+        describe:
+          'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+        type: 'string'
+      }
+    })
+    .command([ 'export', 'dump' ], 'Export Auth0 Tenant Configuration', {
+      output_folder: {
+        alias: 'o',
+        describe: 'The output directory.',
+        type: 'string',
+        demandOption: true
+      },
+      format: {
+        alias: 'f',
+        describe: 'The output format.',
+        type: 'string',
+        choices: [ 'yaml', 'directory' ],
+        demandOption: true
+      },
+      config_file: {
+        alias: 'c',
+        describe: 'The JSON configuration file.',
+        type: 'string'
+      },
+      secret: {
+        alias: 'x',
+        describe:
+          'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+        type: 'string'
+      },
+      export_ids: {
+        alias: 'e',
+        describe: 'Export identifier field for each object type.',
+        type: 'boolean',
+        default: false
+      }
+    })
+    .example(
+      '$0 export -c config.json -f yaml -o path/to/export',
+      'Dump Auth0 config to folder in YAML format'
+    )
+    .example(
+      '$0 export -c config.json -f directory -o path/to/export',
+      'Dump Auth0 config to folder in directory format'
+    )
+    .example('$0 import -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
+    .example(
+      '$0 import -c config.json -i path/to/files',
+      'Deploy Auth0 via Path'
+    )
+    .example(
+      '$0 dump -c config.json -f yaml -o path/to/export',
+      'Dump Auth0 config to folder in YAML format'
+    )
+    .example(
+      '$0 dump -c config.json -f directory -o path/to/export',
+      'Dump Auth0 config to folder in directory format'
+    )
+    .example('$0 deploy -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
+    .example(
+      '$0 deploy -c config.json -i path/to/files',
+      'Deploy Auth0 via Path'
+    )
+    .epilogue('See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.')
+    .wrap(null);
+}
+
+export function loadArguments() {
+  return constructArgs().argv;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { bootstrap } from 'global-agent';
 
-import args from './args';
+import { loadArguments } from './args';
 import commands from './commands';
 import log from './logger';
 
@@ -30,7 +30,7 @@ async function run(params) {
 // Only run if from command line
 if (require.main === module) {
   // Load cli params
-  const params = args.argv;
+  const params = loadArguments();
 
   log.debug('Starting Auth0 Deploy CLI Tool');
 

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { constructArgs } from '../src/args';
+
+
+describe('#args', () => {
+  it('should throw if no command is specified', () => {
+    const constructedArgs = constructArgs().exitProcess(false);
+
+    expect(() => constructedArgs.parse('')).to.throw('A command is required');
+  });
+
+  it('should not attempt to resolve args', () => {
+    expect(() => constructArgs()).to.not.throw();
+  });
+});


### PR DESCRIPTION
## ✏️ Changes

Only load arguments when running the tool from the command line. This is to avoid involuntarily loading the the library programmatically i.e.

```javascript
var auth0 = require('auth0-deploy-cli');
```

## 🔗 References

Issue raised here: https://github.com/auth0/auth0-deploy-cli/issues/264

```javascript
var auth0 = require('auth0-deploy-cli');

var argv = require('yargs')
    .boolean('bark')
    .alias('b', 'bark')
    .argv;

if (argv.bark) console.log("Woof!");
else console.log("Meow!");
```

Results in 

```console
> node index.js --bark true

Auth0 Deploy CLI

Commands:
  index.js import  Deploy Configuration  [aliases: deploy]
  index.js export  Export Auth0 Tenant Configuration  [aliases: dump]

Options:
  --help           Show help  [boolean]
  --version        Show version number  [boolean]
  --debug, -d      Dump extra debug information.  [string] [default: false]
  --proxy_url, -p  A url for proxying requests, only set this if you are behind a proxy.  [string]

Examples:
  index.js export -c config.json -f yaml -o path/to/export       Dump Auth0 config to folder in YAML format
  index.js export -c config.json -f directory -o path/to/export  Dump Auth0 config to folder in directory format
  index.js import -c config.json -i tenant.yaml                  Deploy Auth0 via YAML
  index.js import -c config.json -i path/to/files                Deploy Auth0 via Path
  index.js dump -c config.json -f yaml -o path/to/export         Dump Auth0 config to folder in YAML format
  index.js dump -c config.json -f directory -o path/to/export    Dump Auth0 config to folder in directory format
  index.js deploy -c config.json -i tenant.yaml                  Deploy Auth0 via YAML
  index.js deploy -c config.json -i path/to/files                Deploy Auth0 via Path

See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.

A command is required
```

## 🎯 Testing

2 paths can be validated to ensure there is no regression

1) Validating that the CLI arguments options are still loaded as intended
2) Validating that the CLI arguments are not loaded importing (`require('auth0-deploy-cli');`)

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
