### PR TITLE
[ESD-7795] bump auth0-source-control-extension-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,9 +1771,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.5.tgz",
-      "integrity": "sha512-B7onbGlKD36RWYAeB97VhTh/yEOSVjZFgLB480ZitMj0Bkw3EvkDKyrU82YATOhmJWYofUzWIK9GotoYXmV2vw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.6.tgz",
+      "integrity": "sha512-ngqGrjYyNZz9oXfsLo1X0ylJpNgxs2kzdR6363CIrk6O6A491AMShUYc2qB8RxdyBNsoS5GyHy84XnudjJx4YQ==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.5",
+    "auth0-source-control-extension-tools": "^4.1.6",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "http-proxy-agent": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
## ✏️ Changes

bump auth0-source-control-extension-tools with a fix for connections disabled when the client is added AUTH0_EXCLUDED_CLIENTS list.

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-7795
