### PR TITLE
feat: terraform export/mirgration support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,4 +8,8 @@ RUN apt-get update \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 RUN echo "source /etc/profile.d/bash_completion.sh" >> ~/.bashrc
+RUN curl -fsL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform_0.12.29_linux_amd64.zip \
+  && unzip terraform_0.12.29_linux_amd64.zip \
+  && mv terraform /usr/local/bin \
+  && chmod +x /usr/local/bin/terraform
 ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-buster
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL [ "/bin/bash", "-c" ]
+RUN apt-get update \
+  && apt-get install -y bash-completion \
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
+RUN echo "source /etc/profile.d/bash_completion.sh" >> ~/.bashrc
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Node.js 12",
+  "dockerFile": "Dockerfile",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "eamodio.gitlens",
+    "hbenl.vscode-test-explorer"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "eamodio.gitlens",
-    "hbenl.vscode-test-explorer"
+    "hbenl.vscode-test-explorer",
+    "hbenl.vscode-mocha-test-adapter"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
         "-f",
         "yaml",
         "-o",
-        "export/bittrd-test"
+        "local/bittrd-test"
       ],
       "sourceMaps": true,
       "outFiles": [
@@ -57,7 +57,7 @@
         "-f",
         "tf",
         "-o",
-        "export/bittrd-test"
+        "local/bittrd-test"
       ],
       "sourceMaps": true,
       "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,68 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Export YAML",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "preLaunchTask": "build",
+      "runtimeExecutable": null,
+      "program": "${workspaceFolder}/lib/index.js",
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "args": [
+        "export",
+        "-c",
+        "config.json",
+        "-f",
+        "yaml",
+        "-o",
+        "export/bittrd-test"
+      ],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/lib/**/*.js"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Export TF",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "preLaunchTask": "build",
+      "runtimeExecutable": null,
+      "program": "${workspaceFolder}/lib/index.js",
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "args": [
+        "export",
+        "-c",
+        "config.json",
+        "-f",
+        "tf",
+        "-o",
+        "export/bittrd-test"
+      ],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/lib/**/*.js"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   },
   "editor.codeActionsOnSave": {
     "source.fixAll": true
-  }
+  },
+  "mochaExplorer.require": "@babel/register"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[javascript]": {
+    "editor.formatOnSave": true,
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "command": "npm",
+  "shell": true,
+  "reveal": "always",
+  "tasks": [
+    {
+      "label": "build",
+      "args": [
+        "run",
+        "build",
+        "--",
+        "--source-maps"
+      ],
+      "group": "build",
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "a0deploy": "lib/index.js"
   },
   "scripts": {
-    "lint": "eslint --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
+    "lint": "eslint --fix --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "pretest": "rimraf ./.nyc_output",
     "test": "cross-env NODE_ENV=test nyc mocha --recursive --require @babel/register test",
     "build": "rimraf ./lib && babel src -d lib",

--- a/src/args.js
+++ b/src/args.js
@@ -51,7 +51,7 @@ export default yargs
       alias: 'f',
       describe: 'The output format.',
       type: 'string',
-      choices: [ 'yaml', 'directory' ],
+      choices: [ 'yaml', 'directory', 'tf' ],
       demandOption: true
     },
     config_file: {

--- a/src/args.js
+++ b/src/args.js
@@ -1,5 +1,61 @@
 import yargs from 'yargs';
 
+const commonArgs = {
+  config_file: {
+    alias: 'c',
+    describe: 'The JSON configuration file.',
+    type: 'string'
+  },
+  secret: {
+    alias: 'x',
+    describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+    type: 'string'
+  }
+};
+
+const importArgs = {
+  input_file: {
+    alias: 'i',
+    describe: 'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
+    type: 'string',
+    demandOption: true
+  },
+  env: {
+    alias: 'e',
+    describe: 'Override the mappings in config with process.env environment variables.',
+    type: 'string',
+    boolean: true,
+    default: true
+  },
+  secret: {
+    alias: 'x',
+    describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
+    type: 'string'
+  }
+};
+
+const exportArgs = {
+  output_folder: {
+    alias: 'o',
+    describe: 'The output directory.',
+    type: 'string',
+    demandOption: true
+  },
+  format: {
+    alias: 'f',
+    describe: 'The output format.',
+    type: 'string',
+    choices: [ 'yaml', 'directory', 'tf' ],
+    demandOption: true
+  },
+  export_ids: {
+    alias: 'e',
+    describe: 'Export identifier field for each object type.',
+    type: 'boolean',
+    default: false
+  }
+};
+
 export default yargs
   .demandCommand(1, 'A command is required')
   .usage('Auth0 Deploy CLI')
@@ -15,62 +71,9 @@ export default yargs
     describe: 'A url for proxying requests, only set this if you are behind a proxy.',
     type: 'string'
   })
-  .command([ 'import', 'deploy' ], 'Deploy Configuration', {
-    input_file: {
-      alias: 'i',
-      describe: 'The updates to deploy. Either a JSON file, or directory that contains the correct file layout. See README and online for more info.',
-      type: 'string',
-      demandOption: true
-    },
-    config_file: {
-      alias: 'c',
-      describe: 'The JSON configuration file.',
-      type: 'string'
-    },
-    env: {
-      alias: 'e',
-      describe: 'Override the mappings in config with process.env environment variables.',
-      type: 'string',
-      boolean: true,
-      default: true
-    },
-    secret: {
-      alias: 'x',
-      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
-      type: 'string'
-    }
-  })
-  .command([ 'export', 'dump' ], 'Export Auth0 Tenant Configuration', {
-    output_folder: {
-      alias: 'o',
-      describe: 'The output directory.',
-      type: 'string',
-      demandOption: true
-    },
-    format: {
-      alias: 'f',
-      describe: 'The output format.',
-      type: 'string',
-      choices: [ 'yaml', 'directory', 'tf' ],
-      demandOption: true
-    },
-    config_file: {
-      alias: 'c',
-      describe: 'The JSON configuration file.',
-      type: 'string'
-    },
-    secret: {
-      alias: 'x',
-      describe: 'The client secret, this allows you to encrypt the secret in your build configuration instead of storing it in a config file',
-      type: 'string'
-    },
-    export_ids: {
-      alias: 'e',
-      describe: 'Export identifier field for each object type.',
-      type: 'boolean',
-      default: false
-    }
-  })
+  .command([ 'import', 'deploy' ], 'Deploy Configuration', { ...commonArgs, ...importArgs })
+  .command([ 'export', 'dump' ], 'Export Auth0 Tenant Configuration', { ...commonArgs, ...exportArgs })
+  .command([ 'convert' ], 'Convert Auth0 Tenant Configuration between two formats', { ...commonArgs, ...importArgs, ...exportArgs })
   .example('$0 export -c config.json -f yaml -o path/to/export', 'Dump Auth0 config to folder in YAML format')
   .example('$0 export -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
   .example('$0 import -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
@@ -79,5 +82,6 @@ export default yargs
   .example('$0 dump -c config.json -f directory -o path/to/export', 'Dump Auth0 config to folder in directory format')
   .example('$0 deploy -c config.json -i tenant.yaml', 'Deploy Auth0 via YAML')
   .example('$0 deploy -c config.json -i path/to/files', 'Deploy Auth0 via Path')
+  .example('$0 convert -c config.json -i path/to/files -f yaml -o path/to/export', 'Convert Auth0 from directory to yaml')
   .epilogue('See README (https://github.com/auth0/auth0-deploy-cli) for more in-depth information on configuration and setup.')
   .wrap(null);

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,10 +1,6 @@
-import nconf from 'nconf';
-
 import log from '../logger';
-import getImportContext from './import';
-import getExportContext from './export';
-import { isDirectory } from '../utils';
-import setupContext from '../context';
+import { getImportContext } from './import';
+import { getExportContext } from './export';
 
 export default async function convert(params) {
   const importContext = await getImportContext(params);

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,0 +1,15 @@
+import nconf from 'nconf';
+
+import log from '../logger';
+import getImportContext from './import';
+import getExportContext from './export';
+import { isDirectory } from '../utils';
+import setupContext from '../context';
+
+export default async function convert(params) {
+  const importContext = await getImportContext(params);
+  log.info('Import Successful');
+  const exportContext = await getExportContext(params);
+  log.info(exportContext);
+  await exportContext.dump(importContext.assets);
+}

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -50,7 +50,7 @@ export default async function deploy(params) {
     overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.yaml');
   }
   if (params.format === 'tf') {
-    overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.yaml');
+    overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.tf');
   }
 
   nconf.overrides(overrides);

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -26,6 +26,7 @@ export default async function deploy(params) {
     AUTH0_INPUT_FILE: outputFolder,
     AUTH0_BASE_PATH: basePath,
     AUTH0_CONFIG_FILE: configFile,
+    AUTH0_CONTEXT_TYPE: params.format,
     ...configObj || {}
   };
 
@@ -41,16 +42,13 @@ export default async function deploy(params) {
   }
 
   // Check output folder
-  if (!isDirectory(outputFolder)) {
+  if (!isDirectory(outputFolder) || params.format === 'tf') {
     log.info(`Creating ${outputFolder}`);
     mkdirp.sync(outputFolder);
   }
 
   if (params.format === 'yaml') {
     overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.yaml');
-  }
-  if (params.format === 'tf') {
-    overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.tf');
   }
 
   nconf.overrides(overrides);

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -6,7 +6,7 @@ import log from '../logger';
 import { isDirectory } from '../utils';
 import setupContext from '../context';
 
-export default async function deploy(params) {
+export async function getExportContext(params) {
   const {
     output_folder: outputFolder,
     base_path: basePath,
@@ -55,6 +55,11 @@ export default async function deploy(params) {
 
   // Setup context and load
   const context = await setupContext(nconf.get());
+  return context;
+}
+
+export default async function dump(params) {
+  const context = await getExportContext(params);
   await context.dump();
   log.info('Export Successful');
 }

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -49,6 +49,9 @@ export default async function deploy(params) {
   if (params.format === 'yaml') {
     overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.yaml');
   }
+  if (params.format === 'tf') {
+    overrides.AUTH0_INPUT_FILE = path.join(outputFolder, 'tenant.yaml');
+  }
 
   nconf.overrides(overrides);
 

--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -4,7 +4,7 @@ import tools from 'auth0-source-control-extension-tools';
 import log from '../logger';
 import setupContext from '../context';
 
-export default async function deploy(params) {
+export async function getImportContext(params) {
   const {
     input_file: inputFile,
     base_path: basePath,
@@ -25,7 +25,7 @@ export default async function deploy(params) {
     AUTH0_BASE_PATH: basePath,
     AUTH0_CONFIG_FILE: configFile,
     AUTH0_KEYWORD_REPLACE_MAPPINGS: {},
-    ...configObj || {}
+    ...(configObj || {})
   };
 
   // Prepare configuration by initializing nconf, then passing that as the provider to the config object
@@ -36,7 +36,10 @@ export default async function deploy(params) {
 
   if (env) {
     const mappings = nconf.get('AUTH0_KEYWORD_REPLACE_MAPPINGS') || {};
-    nconf.set('AUTH0_KEYWORD_REPLACE_MAPPINGS', Object.assign(mappings, process.env));
+    nconf.set(
+      'AUTH0_KEYWORD_REPLACE_MAPPINGS',
+      Object.assign(mappings, process.env)
+    );
   }
 
   nconf.overrides(overrides);
@@ -44,7 +47,11 @@ export default async function deploy(params) {
   // Setup context and load
   const context = await setupContext(nconf.get());
   await context.load();
+  return context;
+}
 
+export default async function deploy(params) {
+  const context = await getImportContext(params);
   const config = extTools.config();
   config.setProvider(key => nconf.get(key));
 

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,9 +1,11 @@
 import importCMD from './import';
 import exportCMD from './export';
+import convertCMD from './convert';
 
 export default {
   import: importCMD,
   export: exportCMD,
   deploy: importCMD,
-  dump: exportCMD
+  dump: exportCMD,
+  convert: convertCMD
 };

--- a/src/context/directory/index.js
+++ b/src/context/directory/index.js
@@ -54,11 +54,15 @@ export default class {
     throw new Error(`Not sure what to do with, ${this.filePath} as it is not a directory...`);
   }
 
-  async dump() {
+  async dump(assets) {
     const auth0 = new Auth0(this.mgmtClient, this.assets, toConfigFn(this.config));
-    log.info('Loading Auth0 Tenant Data');
-    await auth0.loadAll();
-    this.assets = auth0.assets;
+    if (!assets) {
+      log.info('Loading Auth0 Tenant Data');
+      await auth0.loadAll();
+      this.assets = auth0.assets;
+    } else {
+      this.assets = { ...assets, ...this.assets };
+    }
 
     // Clean known read only fields
     this.assets = cleanAssets(this.assets, this.config);

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -90,6 +90,9 @@ export default async function(config) {
   if (ext === '.yaml' || ext === '.yml') {
     return new YAMLContext(config, mgmtClient);
   }
+  if (ext === '.tf') {
+    return new TFContext(config, mgmtClient);
+  }
 
   throw new Error(`Unable to determine context processor to load for file ${inputFile}, does it exist? `);
 }

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import { AuthenticationClient, ManagementClient } from 'auth0';
 import YAMLContext from './yaml';
+import TFContext from './terraform';
 import DirectoryContext from './directory';
 
 import { isDirectory } from '../utils';

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -83,7 +83,7 @@ export default async function(config) {
     return new YAMLContext(config, mgmtClient);
   }
 
-  if (isDirectory(inputFile)) {
+  if (isDirectory(inputFile) && config.AUTH0_CONTEXT_TYPE === 'directory') {
     return new DirectoryContext(config, mgmtClient);
   }
 
@@ -91,7 +91,7 @@ export default async function(config) {
   if (ext === '.yaml' || ext === '.yml') {
     return new YAMLContext(config, mgmtClient);
   }
-  if (ext === '.tf') {
+  if (config.AUTH0_CONTEXT_TYPE === 'tf') {
     return new TFContext(config, mgmtClient);
   }
 

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -83,16 +83,16 @@ export default async function(config) {
     return new YAMLContext(config, mgmtClient);
   }
 
-  if (isDirectory(inputFile) && config.AUTH0_CONTEXT_TYPE === 'directory') {
+  if (isDirectory(inputFile)) {
+    if (config.AUTH0_CONTEXT_TYPE === 'tf') {
+      return new TFContext(config, mgmtClient);
+    }
     return new DirectoryContext(config, mgmtClient);
   }
 
   const ext = path.extname(inputFile);
   if (ext === '.yaml' || ext === '.yml') {
     return new YAMLContext(config, mgmtClient);
-  }
-  if (config.AUTH0_CONTEXT_TYPE === 'tf') {
-    return new TFContext(config, mgmtClient);
   }
 
   throw new Error(`Unable to determine context processor to load for file ${inputFile}, does it exist? `);

--- a/src/context/terraform/formatter.js
+++ b/src/context/terraform/formatter.js
@@ -1,5 +1,10 @@
-function wrapIfNeeded(value) {
+function handleRawValue(value) {
   if (typeof value === 'string') {
+    if (value.indexOf('\n') !== -1) {
+      return `<<EOT
+${value}
+EOT`;
+    }
     return `"${value}"`;
   }
   return value;
@@ -13,7 +18,7 @@ function formatHCLContent(content, tabs) {
     if (Array.isArray(value)) {
       if (value.length > 0 && typeof value[0] !== 'object') {
         return `${indent(tabs)}${key} = [
-${indent(tabs + 1)}${value.map(arrVal => wrapIfNeeded(arrVal)).join(`${indent(tabs + 1)}\n`)}
+${indent(tabs + 1)}${value.map(arrVal => handleRawValue(arrVal)).join(`${indent(tabs + 1)}\n`)}
 ${indent(tabs)}]`;
       }
       return value.map(subContent => `${indent(tabs)}${key} {
@@ -24,7 +29,7 @@ ${indent(tabs)}}`).join('\n');
 ${formatHCLContent(value, tabs + 1)}
 ${indent(tabs)}}`;
     }
-    return `${indent(tabs)}${key} = ${wrapIfNeeded(value)}`;
+    return `${indent(tabs)}${key} = ${handleRawValue(value)}`;
   }).join('\n');
 }
 

--- a/src/context/terraform/formatter.js
+++ b/src/context/terraform/formatter.js
@@ -1,0 +1,35 @@
+function wrapIfNeeded(value) {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  return value;
+}
+function indent(tabs) {
+  return '  '.repeat(tabs);
+}
+function formatHCLContent(content, tabs) {
+  return Object.keys(content).map((key) => {
+    const value = content[key];
+    if (Array.isArray(value)) {
+      if (value.length > 0 && typeof value[0] !== 'object') {
+        return `${indent(tabs)}${key} = [
+${indent(tabs + 1)}${value.map(arrVal => wrapIfNeeded(arrVal)).join(`${indent(tabs + 1)}\n`)}
+${indent(tabs)}]`;
+      }
+      return value.map(subContent => `${indent(tabs)}${key} {
+${formatHCLContent(subContent, tabs + 1)}
+${indent(tabs)}}`).join('\n');
+    } else if (typeof value === 'object') {
+      return `${indent(tabs)}${key} {
+${formatHCLContent(value, tabs + 1)}
+${indent(tabs)}}`;
+    }
+    return `${indent(tabs)}${key} = ${wrapIfNeeded(value)}`;
+  }).join('\n');
+}
+
+export default function(jsonObject) {
+  return `resource ${jsonObject.type} "${jsonObject.name.replace(/[^A-Z,^a-z,^0-9,^_,^-]/g, '_')}" {
+${formatHCLContent(jsonObject.content, 1)}
+}`;
+}

--- a/src/context/terraform/formatter.js
+++ b/src/context/terraform/formatter.js
@@ -82,7 +82,7 @@ function formatHCLContent(content, tabs) {
   }).filter(x => x !== null && x !== undefined).join('\n');
 }
 
-export default function (jsonObject) {
+export default function(jsonObject) {
   const resourceName = tfNameSantizer(jsonObject.name);
   return `resource ${jsonObject.type} "${resourceName}" {
 ${formatHCLContent(jsonObject.content, 1)}

--- a/src/context/terraform/formatter.js
+++ b/src/context/terraform/formatter.js
@@ -63,7 +63,7 @@ function formatHCLContent(content, tabs) {
     const value = content[key];
 
     // undefined
-    if (value === undefined) {
+    if (!value) {
       return null;
     }
 
@@ -82,7 +82,7 @@ function formatHCLContent(content, tabs) {
   }).filter(x => x !== null && x !== undefined).join('\n');
 }
 
-export default function(jsonObject) {
+export default function (jsonObject) {
   const resourceName = tfNameSantizer(jsonObject.name);
   return `resource ${jsonObject.type} "${resourceName}" {
 ${formatHCLContent(jsonObject.content, 1)}

--- a/src/context/terraform/formatter.js
+++ b/src/context/terraform/formatter.js
@@ -1,5 +1,7 @@
-import { tfNameSantizer } from '../../utils';
 /* eslint-disable no-use-before-define */
+
+import { tfNameSantizer } from '../../utils';
+
 function handleRawValue(value) {
   if (typeof value !== 'string') {
     return value;
@@ -19,6 +21,8 @@ EOT`;
 function indent(tabs) {
   return '  '.repeat(tabs);
 }
+
+const isNil = value => value === null || value === undefined;
 
 function formatObject(key, value, tabs) {
   const ind = indent(tabs);
@@ -63,9 +67,7 @@ function formatHCLContent(content, tabs) {
     const value = content[key];
 
     // undefined
-    if (!value) {
-      return null;
-    }
+    if (isNil(value)) return value;
 
     // Array
     if (Array.isArray(value)) {
@@ -79,7 +81,7 @@ function formatHCLContent(content, tabs) {
 
     // Other - String, Number, Boolean
     return formatOther(key, value, tabs);
-  }).filter(x => x !== null && x !== undefined).join('\n');
+  }).filter(x => !isNil(x)).join('\n');
 }
 
 export default function(jsonObject) {

--- a/src/context/terraform/handlers/client.js
+++ b/src/context/terraform/handlers/client.js
@@ -1,0 +1,45 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  return (context.assets.clients || []).map(client => ({
+    type: 'auth0_client',
+    name: client.name,
+    content: {
+      name: client.name,
+      description: client.description,
+      app_type: client.app_type,
+      logo_uri: client.logo_uri,
+      is_first_party: client.is_first_party,
+      is_token_endpoint_ip_header_trusted: client.is_token_endpoint_ip_header_trusted,
+      oidc_conformant: client.oidc_conformant,
+      callbacks: client.callbacks,
+      allowed_logout_urls: client.allowed_logout_urls,
+      grant_types: client.grant_types,
+      allowed_origins: client.allowed_origins,
+      web_origins: client.web_origins,
+      jwt_configuration: client.jwt_configuration,
+      encryption_key: client.encryption_key,
+      sso: client.sso,
+      sso_disabled: client.sso_disabled,
+      cross_origin_auth: client.cross_origin_auth,
+      cross_origin_loc: client.cross_origin_loc,
+      custom_login_page_on: client.custom_login_page_on,
+      custom_login_page: client.custom_login_page,
+      custom_login_page_preview: client.custom_login_page_preview,
+      form_template: client.form_template,
+      addons: client.addons,
+      token_endpoint_auth_method: client.token_endpoint_auth_method,
+      client_metadata: client.client_metadata,
+      mobile: client.mobile,
+      initiate_login_uri: client.initiate_login_uri
+    }
+  }));
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/client.js
+++ b/src/context/terraform/handlers/client.js
@@ -1,7 +1,3 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   return (context.assets.clients || []).map(client => ({
     type: 'auth0_client',
@@ -40,6 +36,5 @@ async function dump(context) {
 
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/clientGrants.js
+++ b/src/context/terraform/handlers/clientGrants.js
@@ -1,3 +1,5 @@
+import { tfNameSantizer } from '../../../utils';
+
 async function parse(context) {
   throw new Error('Not Implemented ' + context);
 }
@@ -9,7 +11,7 @@ async function dump(context) {
   return (context.assets.clientGrants || []).map((grant) => {
     const dumpGrant = { ...grant };
     const found = clients.find(c => c.client_id === dumpGrant.client_id);
-    if (found) dumpGrant.client_id = found.name;
+    if (found) dumpGrant.client_id = `\${auth0_client.${tfNameSantizer(found.name)}.client_id}`;
 
     return {
       type: 'auth0_client_grant',

--- a/src/context/terraform/handlers/clientGrants.js
+++ b/src/context/terraform/handlers/clientGrants.js
@@ -1,9 +1,5 @@
 import { tfNameSantizer } from '../../../utils';
 
-async function parse(context) {
-  throw new Error('Not Implemented ' + context);
-}
-
 
 async function dump(context) {
   const clients = context.assets.clientsOrig || [];
@@ -23,6 +19,5 @@ async function dump(context) {
 
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/clientGrants.js
+++ b/src/context/terraform/handlers/clientGrants.js
@@ -1,0 +1,26 @@
+async function parse(context) {
+  throw new Error('Not Implemented ' + context);
+}
+
+
+async function dump(context) {
+  const clients = context.assets.clientsOrig || [];
+
+  return (context.assets.clientGrants || []).map((grant) => {
+    const dumpGrant = { ...grant };
+    const found = clients.find(c => c.client_id === dumpGrant.client_id);
+    if (found) dumpGrant.client_id = found.name;
+
+    return {
+      type: 'auth0_client_grant',
+      name: `${dumpGrant.client_id}_grant`,
+      content: dumpGrant
+    };
+  });
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/connection.js
+++ b/src/context/terraform/handlers/connection.js
@@ -1,0 +1,88 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  return (context.assets.connections || []).map(connection => ({
+    type: 'auth0_connection',
+    name: connection.name,
+    content: {
+      name: connection.name,
+      display_name: connection.display_name,
+      is_domain_connection: connection.is_domain_connection,
+      strategy: connection.strategy,
+      options: connection.options ? {
+        validation: connection.options.validation,
+        password_policy: connection.options.password_policy,
+        password_history: connection.options.password_history,
+        password_no_personal_info: connection.options.password_no_personal_info,
+        password_dictionary: connection.options.password_dictionary,
+        password_complexity_options: connection.options.password_complexity_options,
+        enabled_database_customization: connection.options.enabled_database_customization,
+        brute_force_protection: connection.options.brute_force_protection,
+        import_mode: connection.options.import_mode,
+        disable_signup: connection.options.disable_signup,
+        requires_username: connection.options.requires_username,
+        custom_scripts: connection.options.custom_scripts,
+        configuration: connection.options.configuration,
+        client_id: connection.options.client_id,
+        allowed_audiences: connection.options.allowed_audiences,
+        api_enable_users: connection.options.api_enable_users,
+        app_id: connection.options.app_id,
+        app_domain: connection.options.app_domain,
+        domain: connection.options.domain,
+        domain_aliases: connection.options.domain_aliases,
+        max_groups_to_retrieve: connection.options.max_groups_to_retrieve,
+        tenant_domain: connection.options.tenant_domain,
+        use_wsfed: connection.options.use_wsfed,
+        waad_protocol: connection.options.waad_protocol,
+        waad_common_endpoint: connection.options.waad_common_endpoint,
+        icon_url: connection.options.icon_url,
+        identity_api: connection.options.identity_api,
+        ips: connection.options.ips,
+        use_cert_auth: connection.options.use_cert_auth,
+        use_kerberos: connection.options.use_kerberos,
+        disable_cache: connection.options.disable_cache,
+        name: connection.options.name,
+        twilio_sid: connection.options.twilio_sid,
+        from: connection.options.from,
+        syntax: connection.options.syntax,
+        subject: connection.options.subject,
+        template: connection.options.template,
+        totp: connection.options.totp,
+        messaging_service_sid: connection.options.messaging_service_sid,
+        team_id: connection.options.team_id,
+        key_id: connection.options.key_id,
+        adfs_server: connection.options.adfs_server,
+        community_base_url: connection.options.community_base_url,
+        strategy_version: connection.options.strategy_version,
+        scopes: connection.options.scope,
+        type: connection.options.type,
+        issuer: connection.options.issuer,
+        jwks_uri: connection.options.jwks_uri,
+        discovery_url: connection.options.discovery_url,
+        token_endpoint: connection.options.token_endpoint,
+        userinfo_endpoint: connection.options.userinfo_endpoint,
+        authorization_endpoint: connection.options.authorization_endpoint,
+        debug: connection.options.debug,
+        signing_cert: connection.options.signing_cert,
+        protocol_binding: connection.options.protocol_binding,
+        idp_initiated: connection.options.idp_initiated,
+        sign_in_endpoint: connection.options.sign_in_endpoint,
+        sign_out_endpoint: connection.options.sign_out_endpoint,
+        fields_map: connection.options.fields_map,
+        sign_saml_request: connection.options.sign_saml_request,
+        signature_algorithm: connection.options.signature_algorithm,
+        digest_algorithm: connection.options.digest_algorithm
+      } : undefined,
+      enabled_clients: connection.enabled_clients,
+      realms: connection.realms
+    }
+  }));
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/connection.js
+++ b/src/context/terraform/handlers/connection.js
@@ -1,7 +1,3 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   return (context.assets.connections || []).map(connection => ({
     type: 'auth0_connection',
@@ -83,6 +79,5 @@ async function dump(context) {
 
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/email.js
+++ b/src/context/terraform/handlers/email.js
@@ -7,18 +7,18 @@ function parse(context) {
 async function dump(context) {
   let { emailProvider } = context.assets;
 
-  if (!emailProvider) return; // Skip, nothing to dump
+  if (!emailProvider) return null; // Skip, nothing to dump
 
   const excludedDefaults = context.assets.exclude.defaults || [];
   if (!excludedDefaults.includes('emailProvider')) {
     // Add placeholder for credentials as they cannot be exported
     emailProvider = emailProviderDefaults(emailProvider);
   }
-  return ({
+  return {
     type: 'auth0_email',
     name: emailProvider.name,
     content: emailProvider
-  });
+  };
 }
 
 

--- a/src/context/terraform/handlers/email.js
+++ b/src/context/terraform/handlers/email.js
@@ -7,7 +7,7 @@ function parse(context) {
 async function dump(context) {
   let { emailProvider } = context.assets;
 
-  if (!emailProvider) return null; // Skip, nothing to dump
+  if (!emailProvider || !emailProvider.name) return null; // Skip, nothing to dump
 
   const excludedDefaults = context.assets.exclude.defaults || [];
   if (!excludedDefaults.includes('emailProvider')) {

--- a/src/context/terraform/handlers/email.js
+++ b/src/context/terraform/handlers/email.js
@@ -1,8 +1,5 @@
 import { emailProviderDefaults } from '../../defaults';
 
-function parse(context) {
-  throw new Error('Not Implemented ' + context);
-}
 
 async function dump(context) {
   let { emailProvider } = context.assets;
@@ -23,6 +20,5 @@ async function dump(context) {
 
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/email.js
+++ b/src/context/terraform/handlers/email.js
@@ -1,0 +1,28 @@
+import { emailProviderDefaults } from '../../defaults';
+
+function parse(context) {
+  throw new Error('Not Implemented ' + context);
+}
+
+async function dump(context) {
+  let { emailProvider } = context.assets;
+
+  if (!emailProvider) return; // Skip, nothing to dump
+
+  const excludedDefaults = context.assets.exclude.defaults || [];
+  if (!excludedDefaults.includes('emailProvider')) {
+    // Add placeholder for credentials as they cannot be exported
+    emailProvider = emailProviderDefaults(emailProvider);
+  }
+  return ({
+    type: 'auth0_email',
+    name: emailProvider.name,
+    content: emailProvider
+  });
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/emailTemplates.js
+++ b/src/context/terraform/handlers/emailTemplates.js
@@ -1,0 +1,17 @@
+
+function parse(context) {
+  throw new Error('Not Implemented ' + context);
+}
+
+async function dump(context) {
+  return (context.assets.emailTemplates || []).map((emailTemplate, i) => ({
+    type: 'auth0_email_template',
+    name: `email_template_${i}`,
+    content: emailTemplate
+  }));
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/emailTemplates.js
+++ b/src/context/terraform/handlers/emailTemplates.js
@@ -1,8 +1,3 @@
-
-function parse(context) {
-  throw new Error('Not Implemented ' + context);
-}
-
 async function dump(context) {
   return (context.assets.emailTemplates || []).map((emailTemplate, i) => ({
     type: 'auth0_email_template',
@@ -12,6 +7,5 @@ async function dump(context) {
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/hooks.js
+++ b/src/context/terraform/handlers/hooks.js
@@ -1,7 +1,3 @@
-function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   return (context.assets.hooks || []).map(hook => ({
     type: 'auth0_hook',
@@ -18,6 +14,5 @@ async function dump(context) {
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/hooks.js
+++ b/src/context/terraform/handlers/hooks.js
@@ -1,0 +1,23 @@
+function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  return (context.assets.hooks || []).map(hook => ({
+    type: 'auth0_hook',
+    name: hook.name,
+    content: {
+      name: hook.name,
+      script: hook.script,
+      trigger_id: hook.triggerId,
+      enabled: hook.enabled
+      // dependencies: hook.dependencies,
+      // secrets: hook.secrets
+    }
+  }));
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -4,6 +4,7 @@ import rulesConfigs from './rulesConfigs';
 import roles from './roles';
 import resourceServers from './resourceServers';
 import hooks from './hooks';
+import email from './email';
 
 export default {
   tenant,
@@ -11,5 +12,6 @@ export default {
   rules,
   rulesConfigs,
   resourceServers,
-  hooks
+  hooks,
+  email
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -1,19 +1,21 @@
-import tenant from './tenant';
-import rules from './rules';
-import rulesConfigs from './rulesConfigs';
-import roles from './roles';
-import resourceServers from './resourceServers';
-import hooks from './hooks';
+import clientGrants from './clientGrants';
 import email from './email';
 import emailTemplates from './emailTemplates';
+import hooks from './hooks';
+import resourceServers from './resourceServers';
+import roles from './roles';
+import rules from './rules';
+import rulesConfigs from './rulesConfigs';
+import tenant from './tenant';
 
 export default {
-  tenant,
+  clientGrants,
+  email,
+  emailTemplates,
+  hooks,
+  resourceServers,
   roles,
   rules,
   rulesConfigs,
-  resourceServers,
-  hooks,
-  email,
-  emailTemplates
+  tenant
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -2,10 +2,12 @@ import tenant from './tenant';
 import rules from './rules';
 import rulesConfigs from './rulesConfigs';
 import roles from './roles';
+import resourceServers from './resourceServers';
 
 export default {
   tenant,
   roles,
   rules,
-  rulesConfigs
+  rulesConfigs,
+  resourceServers
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -1,4 +1,6 @@
+import client from './client';
 import clientGrants from './clientGrants';
+import connection from './connection';
 import email from './email';
 import emailTemplates from './emailTemplates';
 import hooks from './hooks';
@@ -7,12 +9,11 @@ import roles from './roles';
 import rules from './rules';
 import rulesConfigs from './rulesConfigs';
 import tenant from './tenant';
-import client from './client';
-import connection from './connection';
 
 export default {
   client,
   clientGrants,
+  connection,
   email,
   emailTemplates,
   hooks,
@@ -20,6 +21,5 @@ export default {
   roles,
   rules,
   rulesConfigs,
-  tenant,
-  connection
+  tenant
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -1,0 +1,5 @@
+import tenant from './tenant';
+
+export default {
+  tenant
+};

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -1,5 +1,7 @@
 import tenant from './tenant';
+import roles from './roles';
 
 export default {
-  tenant
+  tenant,
+  roles
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -8,6 +8,7 @@ import rules from './rules';
 import rulesConfigs from './rulesConfigs';
 import tenant from './tenant';
 import client from './client';
+import connection from './connection';
 
 export default {
   client,
@@ -19,5 +20,6 @@ export default {
   roles,
   rules,
   rulesConfigs,
-  tenant
+  tenant,
+  connection
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -3,11 +3,13 @@ import rules from './rules';
 import rulesConfigs from './rulesConfigs';
 import roles from './roles';
 import resourceServers from './resourceServers';
+import hooks from './hooks';
 
 export default {
   tenant,
   roles,
   rules,
   rulesConfigs,
-  resourceServers
+  resourceServers,
+  hooks
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -5,6 +5,7 @@ import roles from './roles';
 import resourceServers from './resourceServers';
 import hooks from './hooks';
 import email from './email';
+import emailTemplates from './emailTemplates';
 
 export default {
   tenant,
@@ -13,5 +14,6 @@ export default {
   rulesConfigs,
   resourceServers,
   hooks,
-  email
+  email,
+  emailTemplates
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -1,7 +1,11 @@
 import tenant from './tenant';
+import rules from './rules';
+import rulesConfigs from './rulesConfigs';
 import roles from './roles';
 
 export default {
   tenant,
-  roles
+  roles,
+  rules,
+  rulesConfigs
 };

--- a/src/context/terraform/handlers/index.js
+++ b/src/context/terraform/handlers/index.js
@@ -7,8 +7,10 @@ import roles from './roles';
 import rules from './rules';
 import rulesConfigs from './rulesConfigs';
 import tenant from './tenant';
+import client from './client';
 
 export default {
+  client,
   clientGrants,
   email,
   emailTemplates,

--- a/src/context/terraform/handlers/resourceServers.js
+++ b/src/context/terraform/handlers/resourceServers.js
@@ -1,0 +1,17 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  // nothing to do, set default if empty
+  return (context.assets.resourceServers || []).map(resourceServer => ({
+    type: 'auth0_resource_server',
+    name: resourceServer.name,
+    content: resourceServer
+  }));
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/resourceServers.js
+++ b/src/context/terraform/handlers/resourceServers.js
@@ -1,7 +1,3 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   // nothing to do, set default if empty
   return (context.assets.resourceServers || []).map(resourceServer => ({
@@ -12,6 +8,5 @@ async function dump(context) {
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/roles.js
+++ b/src/context/terraform/handlers/roles.js
@@ -1,7 +1,3 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   return (context.assets.roles || []).map(role => ({
     type: 'auth0_role',
@@ -19,6 +15,5 @@ async function dump(context) {
 
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/roles.js
+++ b/src/context/terraform/handlers/roles.js
@@ -1,0 +1,24 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  return (context.assets.roles || []).map(role => ({
+    type: 'auth0_role',
+    name: role.name,
+    content: {
+      name: role.name,
+      description: role.description,
+      permissions: (role.permissions || []).map(permission => ({
+        resource_server_identifier: permission.resource_server_identifier,
+        name: permission.name
+      }))
+    }
+  }));
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/roles.js
+++ b/src/context/terraform/handlers/roles.js
@@ -11,7 +11,7 @@ async function dump(context) {
       description: role.description,
       permissions: (role.permissions || []).map(permission => ({
         resource_server_identifier: permission.resource_server_identifier,
-        name: permission.name
+        name: permission.permission_name
       }))
     }
   }));

--- a/src/context/terraform/handlers/rules.js
+++ b/src/context/terraform/handlers/rules.js
@@ -1,0 +1,21 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  return (context.assets.rules || []).map(rule => ({
+    type: 'auth0_rule',
+    name: rule.name,
+    content: {
+      name: rule.name,
+      script: rule.script,
+      order: rule.order,
+      enabled: rule.enabled
+    }
+  }));
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/rules.js
+++ b/src/context/terraform/handlers/rules.js
@@ -1,7 +1,3 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump(context) {
   return (context.assets.rules || []).map(rule => ({
     type: 'auth0_rule',
@@ -16,6 +12,5 @@ async function dump(context) {
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/rulesConfigs.js
+++ b/src/context/terraform/handlers/rulesConfigs.js
@@ -1,13 +1,8 @@
-async function parse(context) {
-  throw new Error('Not Implemented' + context);
-}
-
 async function dump() {
   // do not export rulesConfigs as its values cannot be extracted
   return null;
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/rulesConfigs.js
+++ b/src/context/terraform/handlers/rulesConfigs.js
@@ -1,0 +1,15 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump() {
+  // do not export rulesConfigs as its values cannot be extracted
+  return {
+    rulesConfigs: []
+  };
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/handlers/rulesConfigs.js
+++ b/src/context/terraform/handlers/rulesConfigs.js
@@ -4,9 +4,7 @@ async function parse(context) {
 
 async function dump() {
   // do not export rulesConfigs as its values cannot be extracted
-  return {
-    rulesConfigs: []
-  };
+  return null;
 }
 
 export default {

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -12,11 +12,11 @@ async function dump(context) {
   return {
     type: 'auth0-tenant',
     name: 'tenant',
-    content: tenant,
+    content: tenant
   };
 }
 
 export default {
   parse,
-  dump,
+  dump
 };

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -1,8 +1,5 @@
 import { clearTenantFlags } from '../../../utils';
 
-async function parse(context) {
-  throw new Error('Not Implemented ' + context);
-}
 
 async function dump(context) {
   const tenant = { ...(context.assets.tenant || {}) };
@@ -17,6 +14,5 @@ async function dump(context) {
 }
 
 export default {
-  parse,
   dump
 };

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -1,15 +1,42 @@
+import fs from 'fs-extra';
+
+import log from '../../../logger';
 import { clearTenantFlags } from '../../../utils';
 
+function getPages(context) {
+  const { pages } = context.assets;
+  if (!pages) return undefined;
+
+  return pages.reduce((r, p) => {
+    const { name, ...page } = p;
+
+    if (name !== 'error_page' || page.html !== undefined) {
+      // Dump template html to file
+      const htmlFile = `./${name}.html`;
+      log.info(`Writing ${htmlFile}`);
+      fs.writeFileSync(htmlFile, page.html);
+      page.html = `\${file("./${name}.html")}`;
+    }
+
+    r[name] = page;
+    return r;
+  }, {});
+}
 
 async function dump(context) {
   const tenant = { ...(context.assets.tenant || {}) };
 
   clearTenantFlags(tenant);
 
+  const pages = getPages(context);
+
   return {
     type: 'auth0_tenant',
     name: 'tenant',
-    content: tenant
+    content: {
+      ...tenant,
+      ...pages
+    },
   };
 }
 

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -1,13 +1,22 @@
+import { clearTenantFlags } from '../../../utils';
+
 async function parse(context) {
   throw new Error('Not Implemented' + context);
 }
 
 async function dump(context) {
-  throw new Error('Not Implemented' + context);
-}
+  const tenant = { ...(context.assets.tenant || {}) };
 
+  clearTenantFlags(tenant);
+
+  return {
+    type: 'auth0-tenant',
+    name: 'tenant',
+    content: tenant,
+  };
+}
 
 export default {
   parse,
-  dump
+  dump,
 };

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -10,7 +10,7 @@ async function dump(context) {
   clearTenantFlags(tenant);
 
   return {
-    type: 'auth0-tenant',
+    type: 'auth0_tenant',
     name: 'tenant',
     content: tenant
   };

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -1,7 +1,7 @@
 import { clearTenantFlags } from '../../../utils';
 
 async function parse(context) {
-  throw new Error('Not Implemented' + context);
+  throw new Error('Not Implemented ' + context);
 }
 
 async function dump(context) {

--- a/src/context/terraform/handlers/tenant.js
+++ b/src/context/terraform/handlers/tenant.js
@@ -1,0 +1,13 @@
+async function parse(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+async function dump(context) {
+  throw new Error('Not Implemented' + context);
+}
+
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -51,15 +51,19 @@ export default class {
     throw new Error(`Not sure what to do with, ${this.filePath} as it is not a directory...`);
   }
 
-  async dump() {
+  async dump(assets) {
     const auth0 = new Auth0(
       this.mgmtClient,
       this.assets,
       toConfigFn(this.config)
     );
-    log.info('Loading Auth0 Tenant Data');
-    await auth0.loadAll();
-    this.assets = auth0.assets;
+    if (!assets) {
+      log.info('Loading Auth0 Tenant Data');
+      await auth0.loadAll();
+      this.assets = auth0.assets;
+    } else {
+      this.assets = { ...assets, ...this.assets };
+    }
 
     // Clean known read only fields
     this.assets = cleanAssets(this.assets, this.config);

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -79,9 +79,9 @@ export default class {
     await Promise.all(Object.entries(handlers).map(async ([ name, handler ]) => {
       try {
         const data = await handler.dump(this);
-        writeFileSync(path.join(this.filePath, `${name}.tf`), formatTF(data));
         if (data) {
           log.info(`Exporting ${name}`);
+          writeFileSync(path.join(this.filePath, `${name}.tf`), formatTF(data));
         }
       } catch (err) {
         log.debug(err.stack);

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -1,0 +1,121 @@
+import fs from 'fs-extra';
+import yaml from 'js-yaml';
+import path from 'path';
+import { loadFile, keywordReplace, Auth0 } from 'auth0-source-control-extension-tools';
+
+import log from '../../logger';
+import { isFile, toConfigFn, stripIdentifiers, formatResults, recordsSorter } from '../../utils';
+import handlers from './handlers';
+import cleanAssets from '../../readonly';
+
+export default class {
+  constructor(config, mgmtClient) {
+    this.configFile = config.AUTH0_INPUT_FILE;
+    this.config = config;
+    this.mappings = config.AUTH0_KEYWORD_REPLACE_MAPPINGS;
+    this.mgmtClient = mgmtClient;
+
+    // Get excluded rules
+    this.assets = {
+      exclude: {
+        rules: config.AUTH0_EXCLUDED_RULES || [],
+        clients: config.AUTH0_EXCLUDED_CLIENTS || [],
+        databases: config.AUTH0_EXCLUDED_DATABASES || [],
+        connections: config.AUTH0_EXCLUDED_CONNECTIONS || [],
+        resourceServers: config.AUTH0_EXCLUDED_RESOURCE_SERVERS || [],
+        defaults: config.AUTH0_EXCLUDED_DEFAULTS || []
+      }
+    };
+
+    this.basePath = config.AUTH0_BASE_PATH;
+    if (!this.basePath) {
+      this.basePath = (typeof configFile === 'object') ? process.cwd() : path.dirname(this.configFile);
+    }
+  }
+
+  loadFile(f) {
+    let toLoad = path.join(this.basePath, f);
+    if (!isFile(toLoad)) {
+      // try load not relative to yaml file
+      toLoad = f;
+    }
+    return loadFile(path.resolve(toLoad), this.mappings);
+  }
+
+  async load() {
+    // Allow to send object/json directly
+    if (typeof this.configFile === 'object') {
+      this.assets = this.configFile;
+    } else {
+      try {
+        const fPath = path.resolve(this.configFile);
+        log.debug(`Loading YAML from ${fPath}`);
+        Object.assign(this.assets, yaml.safeLoad(keywordReplace(fs.readFileSync(fPath, 'utf8'), this.mappings)) || {});
+      } catch (err) {
+        log.debug(err.stack);
+        throw new Error(`Problem loading ${this.configFile}\n${err}`);
+      }
+    }
+
+    // Run initial schema check to ensure valid YAML
+    const auth0 = new Auth0(this.mgmtClient, this.assets, toConfigFn(this.config));
+    await auth0.validate('validate');
+
+    // Allow handlers to process the assets such as loading files etc
+    await Promise.all(Object.entries(handlers).map(async ([ name, handler ]) => {
+      try {
+        const parsed = await handler.parse(this);
+        Object.entries(parsed)
+          .forEach(([ k, v ]) => {
+            this.assets[k] = v;
+          });
+      } catch (err) {
+        log.debug(err.stack);
+        throw new Error(`Problem deploying ${name}`);
+      }
+    }));
+  }
+
+  async dump() {
+    const auth0 = new Auth0(this.mgmtClient, this.assets, toConfigFn(this.config));
+    log.info('Loading Auth0 Tenant Data');
+    try {
+      await auth0.loadAll();
+      this.assets = auth0.assets;
+    } catch (err) {
+      throw new Error(`Problem loading tenant data from Auth0 ${err}`);
+    }
+
+    await Promise.all(Object.entries(handlers).map(async ([ name, handler ]) => {
+      try {
+        const data = await handler.dump(this);
+        if (data) {
+          log.info(`Exporting ${name}`);
+          Object.entries(data)
+            .forEach(([ k, v ]) => {
+              this.assets[k] = Array.isArray(v) ? v.map(formatResults).sort(recordsSorter) : formatResults(v);
+            });
+        }
+      } catch (err) {
+        log.debug(err.stack);
+        throw new Error(`Problem exporting ${name}`);
+      }
+    }));
+
+    // Clean known read only fields
+    let cleaned = cleanAssets(this.assets, this.config);
+
+    // Delete exclude as it's not part of the auth0 tenant config
+    delete cleaned.exclude;
+
+    // Optionally Strip identifiers
+    if (!this.config.AUTH0_EXPORT_IDENTIFIERS) {
+      cleaned = stripIdentifiers(auth0, cleaned);
+    }
+
+    // Write YAML File
+    const raw = yaml.dump(cleaned);
+    log.info(`Writing ${this.configFile}`);
+    fs.writeFileSync(this.configFile, raw);
+  }
+}

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -6,17 +6,14 @@ import log from '../../logger';
 import {
   toConfigFn,
   stripIdentifiers,
-  isDirectory,
-  convertToHCL
+  isDirectory
 } from '../../utils';
 import handlers from './handlers';
 import cleanAssets from '../../readonly';
+import fromJSON from './formatter';
 
 function formatTF(data) {
-  return `resource "${data.type}" "${data.name}" {
-  ${convertToHCL(data.content)}
-}
-`;
+  return (Array.isArray(data) ? data : [ data ]).map(item => fromJSON(item)).join('\n');
 }
 export default class {
   constructor(config, mgmtClient) {

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -72,7 +72,10 @@ export default class {
     if (!this.config.AUTH0_EXPORT_IDENTIFIERS) {
       this.assets = stripIdentifiers(auth0, this.assets);
     }
-
+    writeFileSync(path.join(this.filePath, 'provider.tf'), `provider "auth0" {
+  version = "> 0.8"
+  domain  = "${this.config.AUTH0_DOMAIN}"
+}`);
     await Promise.all(Object.entries(handlers).map(async ([ name, handler ]) => {
       try {
         const data = await handler.dump(this);

--- a/src/context/terraform/index.js
+++ b/src/context/terraform/index.js
@@ -5,8 +5,7 @@ import { writeFileSync } from 'fs-extra';
 import log from '../../logger';
 import {
   toConfigFn,
-  stripIdentifiers,
-  isDirectory
+  stripIdentifiers
 } from '../../utils';
 import handlers from './handlers';
 import cleanAssets from '../../readonly';
@@ -36,19 +35,8 @@ export default class {
   }
 
   async load() {
-    if (isDirectory(this.filePath)) {
-      /* If this is a directory, look for each file in the directory */
-      log.info(`Processing terraform directory ${this.filePath}`);
-
-      Object.values(handlers).forEach((handler) => {
-        const parsed = handler.parse(this);
-        Object.entries(parsed).forEach(([ k, v ]) => {
-          this.assets[k] = v;
-        });
-      });
-      return;
-    }
-    throw new Error(`Not sure what to do with, ${this.filePath} as it is not a directory...`);
+    log.info(`Processing terraform directory ${this.filePath}`);
+    throw new Error('Import is not supported for the Terraform format. Please use terraform-provider-auth0.');
   }
 
   async dump(assets) {

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -76,14 +76,18 @@ export default class {
     }));
   }
 
-  async dump() {
+  async dump(assets) {
     const auth0 = new Auth0(this.mgmtClient, this.assets, toConfigFn(this.config));
-    log.info('Loading Auth0 Tenant Data');
-    try {
-      await auth0.loadAll();
-      this.assets = auth0.assets;
-    } catch (err) {
-      throw new Error(`Problem loading tenant data from Auth0 ${err}`);
+    if (!assets) {
+      log.info('Loading Auth0 Tenant Data');
+      try {
+        await auth0.loadAll();
+        this.assets = auth0.assets;
+      } catch (err) {
+        throw new Error(`Problem loading tenant data from Auth0 ${err}`);
+      }
+    } else {
+      this.assets = { ...assets, ...this.assets };
     }
 
     await Promise.all(Object.entries(handlers).map(async ([ name, handler ]) => {

--- a/src/index.js
+++ b/src/index.js
@@ -66,11 +66,11 @@ if (require.main === module) {
     });
 }
 
-
 // Export commands to be used programmatically
 module.exports = {
   deploy: commands.import,
   dump: commands.export,
   import: commands.import,
-  export: commands.export
+  export: commands.export,
+  convert: commands.convert
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,8 +6,7 @@ import dotProp from 'dot-prop';
 
 export function isDirectory(f) {
   try {
-    return fs.statSync(path.resolve(f))
-      .isDirectory();
+    return fs.statSync(path.resolve(f)).isDirectory();
   } catch (err) {
     return false;
   }
@@ -15,8 +14,7 @@ export function isDirectory(f) {
 
 export function isFile(f) {
   try {
-    return fs.statSync(path.resolve(f))
-      .isFile();
+    return fs.statSync(path.resolve(f)).isFile();
   } catch (err) {
     return false;
   }
@@ -24,7 +22,8 @@ export function isFile(f) {
 
 export function getFiles(folder, exts) {
   if (isDirectory(folder)) {
-    return fs.readdirSync(folder)
+    return fs
+      .readdirSync(folder)
       .map(f => path.join(folder, f))
       .filter(f => isFile(f) && exts.includes(path.extname(f)));
   }
@@ -40,7 +39,6 @@ export function loadJSON(file, mappings) {
   }
 }
 
-
 export function existsMustBeDir(folder) {
   if (fs.existsSync(folder)) {
     if (!isDirectory(folder)) {
@@ -54,7 +52,6 @@ export function existsMustBeDir(folder) {
 export function toConfigFn(data) {
   return key => data[key];
 }
-
 
 export function stripIdentifiers(auth0, assets) {
   const updated = { ...assets };
@@ -86,17 +83,14 @@ export function stripIdentifiers(auth0, assets) {
   return updated;
 }
 
-
 export function sanitize(str) {
   return sanitizeName(str, { replacement: '-' });
 }
-
 
 export function hoursAsInteger(property, hours) {
   if (Number.isInteger(hours)) return { [property]: hours };
   return { [`${property}_in_minutes`]: Math.round(hours * 60) };
 }
-
 
 export function formatResults(item) {
   if (typeof item !== 'object') {
@@ -115,9 +109,11 @@ export function formatResults(item) {
   };
   const result = { ...importantFields };
 
-  Object.entries(item).sort().forEach(([ key, value ]) => {
-    result[key] = value;
-  });
+  Object.entries(item)
+    .sort()
+    .forEach(([ key, value ]) => {
+      result[key] = value;
+    });
 
   Object.keys(importantFields).forEach((key) => {
     if (result[key] === null) delete result[key];
@@ -126,14 +122,8 @@ export function formatResults(item) {
   return result;
 }
 
-
 export function recordsSorter(a, b) {
-  const importantFields = [
-    'name',
-    'key',
-    'client_id',
-    'template'
-  ];
+  const importantFields = [ 'name', 'key', 'client_id', 'template' ];
 
   for (let i = 0; i < importantFields.length; i += 1) {
     const key = importantFields[i];
@@ -146,13 +136,11 @@ export function recordsSorter(a, b) {
   return 0;
 }
 
-
 export function clearTenantFlags(tenant) {
   if (tenant.flags && !Object.keys(tenant.flags).length) {
     delete tenant.flags;
   }
 }
-
 
 export function ensureProp(obj, props, value = '') {
   if (!dotProp.has(obj, props)) {
@@ -160,9 +148,13 @@ export function ensureProp(obj, props, value = '') {
   }
 }
 
-
 export function clearClientArrays(client) {
-  const propsToClear = [ 'allowed_clients', 'allowed_logout_urls', 'allowed_origins', 'callbacks' ];
+  const propsToClear = [
+    'allowed_clients',
+    'allowed_logout_urls',
+    'allowed_origins',
+    'callbacks'
+  ];
   Object.keys(client).forEach((prop) => {
     if (propsToClear.indexOf(prop) >= 0 && !client[prop]) {
       client[prop] = [];
@@ -170,4 +162,24 @@ export function clearClientArrays(client) {
   });
 
   return client;
+}
+
+export function convertToHCL(obj) {
+  let hclString = '';
+  Object.keys(obj).forEach((key) => {
+    if (Array.isArray(obj[key])) {
+      hclString += `  ${key} [\n  ${obj[key]
+        .map(o => `  "${o}"`)
+        .join(',\n  ')}\n  ]\n`;
+    } else if (typeof obj[key] === 'object') {
+      hclString += `  ${key} {\n  ${convertToHCL(obj[key])}  }\n`;
+    } else if (typeof obj[key] === 'string') {
+      hclString += `  ${key} = "${obj[key]}"\n`;
+    } else if (!Number.isNaN(obj[key])) {
+      hclString += `  ${key} = ${obj[key]}\n`;
+    } else {
+      hclString += `  ${key} = "${obj[key]}"\n`;
+    }
+  });
+  return hclString;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,23 +163,3 @@ export function clearClientArrays(client) {
 
   return client;
 }
-
-export function convertToHCL(obj) {
-  let hclString = '';
-  Object.keys(obj).forEach((key) => {
-    if (Array.isArray(obj[key])) {
-      hclString += `  ${key} [\n  ${obj[key]
-        .map(o => `  "${o}"`)
-        .join(',\n  ')}\n  ]\n`;
-    } else if (typeof obj[key] === 'object') {
-      hclString += `  ${key} {\n  ${convertToHCL(obj[key])}  }\n`;
-    } else if (typeof obj[key] === 'string') {
-      hclString += `  ${key} = "${obj[key]}"\n`;
-    } else if (!Number.isNaN(obj[key])) {
-      hclString += `  ${key} = ${obj[key]}\n`;
-    } else {
-      hclString += `  ${key} = "${obj[key]}"\n`;
-    }
-  });
-  return hclString;
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -164,11 +164,11 @@ export function clearClientArrays(client) {
   return client;
 }
 
-export function tfNameSantizer(name) {
-  return trim(name.replace(/[^A-Z,^a-z,^0-9,^_,^-]/g, '_').replace(/__/g, '_'), '_');
-}
 function trim(s, c) {
   if (c === ']') c = '\\]';
   if (c === '\\') c = '\\\\';
   return s.replace(new RegExp('^[' + c + ']+|[' + c + ']+$', 'g'), '');
+}
+export function tfNameSantizer(name) {
+  return trim(name.replace(/[^A-Z,^a-z,^0-9,^_,^-]/g, '_').replace(/__/g, '_'), '_');
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,3 +163,12 @@ export function clearClientArrays(client) {
 
   return client;
 }
+
+export function tfNameSantizer(name) {
+  return trim(name.replace(/[^A-Z,^a-z,^0-9,^_,^-]/g, '_').replace(/__/g, '_'), '_');
+}
+function trim(s, c) {
+  if (c === ']') c = '\\]';
+  if (c === '\\') c = '\\\\';
+  return s.replace(new RegExp('^[' + c + ']+|[' + c + ']+$', 'g'), '');
+}

--- a/test/context/terraform/formatter.test.js
+++ b/test/context/terraform/formatter.test.js
@@ -39,6 +39,9 @@ describe('HCL formatter tests', () => {
       type: 'auth0_tenant',
       name: 'test-tenant',
       content: {
+        undefined_field: undefined,
+        // eslint-disable-next-line no-template-curly-in-string
+        terraform_var: '${auth0_role.fake_role.id}',
         enabled_locales: [ 'en' ],
         idle_session_lifetime: 123.4,
         flags: { disable_clickjack_protection_headers: false },
@@ -50,6 +53,7 @@ describe('HCL formatter tests', () => {
       }
     });
     assert.equal(result, `resource auth0_tenant "test-tenant" {
+  terraform_var = auth0_role.fake_role.id
   enabled_locales = [
     "en"
   ]

--- a/test/context/terraform/formatter.test.js
+++ b/test/context/terraform/formatter.test.js
@@ -51,4 +51,30 @@ describe('HCL formatter tests', () => {
   }
 }`);
   });
+  it('rule HCL', () => {
+    var result = fromJSON({
+      type: 'auth0_rule',
+      name: 'Empty rule',
+      content: {
+        name: 'Empty rule',
+        script: `function (user, context, callback) {
+  // TODO: implement your rule
+  return callback(null, user, context);
+}`,
+        order: 1,
+        enabled: true
+      }
+    });
+    assert.equal(result, `resource auth0_rule "Empty_rule" {
+  name = "Empty rule"
+  script = <<EOT
+function (user, context, callback) {
+  // TODO: implement your rule
+  return callback(null, user, context);
+}
+EOT
+  order = 1
+  enabled = true
+}`);
+  });
 });

--- a/test/context/terraform/formatter.test.js
+++ b/test/context/terraform/formatter.test.js
@@ -33,24 +33,38 @@ describe('HCL formatter tests', () => {
   }
 }`);
   });
+
   it('tenant HCL', () => {
     var result = fromJSON({
       type: 'auth0_tenant',
       name: 'test-tenant',
       content: {
         enabled_locales: [ 'en' ],
-        flags: { disable_clickjack_protection_headers: false }
+        idle_session_lifetime: 123.4,
+        flags: { disable_clickjack_protection_headers: false },
+        empty: {},
+        allowed_logout_urls: [
+          'http://mysite/logout',
+          'http://myothersite/logout'
+        ]
       }
     });
     assert.equal(result, `resource auth0_tenant "test-tenant" {
   enabled_locales = [
     "en"
   ]
+  idle_session_lifetime = 123.4
   flags {
     disable_clickjack_protection_headers = false
   }
+  empty {}
+  allowed_logout_urls = [
+    "http://mysite/logout",
+    "http://myothersite/logout"
+  ]
 }`);
   });
+
   it('rule HCL', () => {
     var result = fromJSON({
       type: 'auth0_rule',

--- a/test/context/terraform/formatter.test.js
+++ b/test/context/terraform/formatter.test.js
@@ -1,0 +1,54 @@
+const fromJSON = require('../../../src/context/terraform/formatter').default;
+const { assert } = require('chai');
+
+describe('HCL formatter tests', () => {
+  it('role HCL', () => {
+    var result = fromJSON({
+      type: 'auth0_role',
+      name: 'My Test Role',
+      content: {
+        name: 'My Test Role',
+        description: 'A test role',
+        permissions: [
+          {
+            resource_server_identifier: 'https://test-api',
+            name: 'read:stuff'
+          }, {
+            resource_server_identifier: 'https://test-api',
+            name: 'write:stuff'
+          }
+        ]
+      }
+    });
+    assert.equal(result, `resource auth0_role "My_Test_Role" {
+  name = "My Test Role"
+  description = "A test role"
+  permissions {
+    resource_server_identifier = "https://test-api"
+    name = "read:stuff"
+  }
+  permissions {
+    resource_server_identifier = "https://test-api"
+    name = "write:stuff"
+  }
+}`);
+  });
+  it('tenant HCL', () => {
+    var result = fromJSON({
+      type: 'auth0_tenant',
+      name: 'test-tenant',
+      content: {
+        enabled_locales: [ 'en' ],
+        flags: { disable_clickjack_protection_headers: false }
+      }
+    });
+    assert.equal(result, `resource auth0_tenant "test-tenant" {
+  enabled_locales = [
+    "en"
+  ]
+  flags {
+    disable_clickjack_protection_headers = false
+  }
+}`);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,13 @@ import { expect } from 'chai';
 const a0deploy = require('../src');
 
 describe('#index exports', () => {
-  it('should expose functions for deploy, dump, import, and export', () => {
-    expect(Object.keys(a0deploy)).to.have.all.members([ 'deploy', 'dump', 'import', 'export' ]);
+  it('should expose functions for deploy, dump, import, export, and convert', () => {
+    expect(Object.keys(a0deploy)).to.have.all.members([
+      'deploy',
+      'dump',
+      'import',
+      'export',
+      'convert'
+    ]);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -16,7 +16,8 @@ import {
   hoursAsInteger,
   formatResults,
   recordsSorter,
-  clearClientArrays
+  clearClientArrays,
+  convertToHCL
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -206,5 +207,34 @@ describe('#utils', function() {
     };
 
     expect(clearClientArrays(client)).to.deep.equal(client);
+  });
+
+  it('should convert to hcl', () => {
+    const tenant = {
+      friendly_name: 'Auth0 Test',
+      default_directory: 'users',
+      session_lifetime: 1.48394893,
+      idle_session_lifetime: 123.4,
+      flags: { universal_login: true },
+      allowed_logout_urls: [
+        'http://mysite/logout',
+        'http://myothersite/logout'
+      ]
+    };
+
+    const hclString = `  friendly_name = "Auth0 Test"
+  default_directory = "users"
+  session_lifetime = 1.48394893
+  idle_session_lifetime = 123.4
+  flags {
+    universal_login = true
+  }
+  allowed_logout_urls [
+    "http://mysite/logout",
+    "http://myothersite/logout"
+  ]
+`;
+
+    expect(convertToHCL(tenant)).to.deep.equal(hclString);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -40,7 +40,6 @@ describe('#utils', function() {
     expect(isFile(fileNotExist)).is.equal(false);
   });
 
-
   it('should get files', () => {
     const dir = path.join(testDataDir, 'utils', 'getfiles');
     cleanThenMkdir(dir);
@@ -62,14 +61,16 @@ describe('#utils', function() {
     const dir = path.join(testDataDir, 'utils', 'json');
     cleanThenMkdir(dir);
     const file = path.join(dir, 'test1.json');
-    fs.writeFileSync(file, '{"test": "123", "env1": @@env1@@, "env2": "##env2##"}');
+    fs.writeFileSync(
+      file,
+      '{"test": "123", "env1": @@env1@@, "env2": "##env2##"}'
+    );
     expect(loadJSON(file, { env1: 'test1', env2: 'test2' })).to.deep.equal({
       env1: 'test1',
       env2: 'test2',
       test: '123'
     });
   });
-
 
   it('exist must be dir', () => {
     const dirExist = path.join(testDataDir, 'utils', 'existmustbedir');
@@ -131,7 +132,15 @@ describe('#utils', function() {
       name: 'Name',
       a: 'Alpha'
     });
-    expect(Object.keys(result)).to.deep.equal([ 'name', 'identifier', 'id', 'a', 'b', 'c', 'd' ]);
+    expect(Object.keys(result)).to.deep.equal([
+      'name',
+      'identifier',
+      'id',
+      'a',
+      'b',
+      'c',
+      'd'
+    ]);
     expect(result).to.deep.equal({
       name: 'Name',
       identifier: 'Identifier',

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -16,8 +16,7 @@ import {
   hoursAsInteger,
   formatResults,
   recordsSorter,
-  clearClientArrays,
-  convertToHCL
+  clearClientArrays
 } from '../src/utils';
 
 describe('#utils', function() {
@@ -207,34 +206,5 @@ describe('#utils', function() {
     };
 
     expect(clearClientArrays(client)).to.deep.equal(client);
-  });
-
-  it('should convert to hcl', () => {
-    const tenant = {
-      friendly_name: 'Auth0 Test',
-      default_directory: 'users',
-      session_lifetime: 1.48394893,
-      idle_session_lifetime: 123.4,
-      flags: { universal_login: true },
-      allowed_logout_urls: [
-        'http://mysite/logout',
-        'http://myothersite/logout'
-      ]
-    };
-
-    const hclString = `  friendly_name = "Auth0 Test"
-  default_directory = "users"
-  session_lifetime = 1.48394893
-  idle_session_lifetime = 123.4
-  flags {
-    universal_login = true
-  }
-  allowed_logout_urls [
-    "http://mysite/logout",
-    "http://myothersite/logout"
-  ]
-`;
-
-    expect(convertToHCL(tenant)).to.deep.equal(hclString);
   });
 });


### PR DESCRIPTION
## ✏️ Changes

This PR adds export and migration support for terraform.

As an Auth0 Customer, I should be able to:

✅ Export my Auth0 configurations from cloud to `terraform-provider-auth0`-compatible configurations, with at least equivalent support as auth0-deploy-cli exporting. 

✅ Convert my existing auth0-deploy-cli configuration files (`directory` or `yaml`) into  `terraform-provider-auth0`-compatible configurations

## 🔗 References

https://auth0.com/blog/use-terraform-to-manage-your-auth0-configuration/


## 🎯 Testing

- [ ] This change has unit test coverage

- [ ] This change has integration test coverage

- [ ] This change has been tested for performance
