### PR TITLE
Issue 277 - update example and tests for guardian/policies.json

### DIFF
--- a/examples/directory/guardian/policies.json
+++ b/examples/directory/guardian/policies.json
@@ -1,3 +1,5 @@
-[
-  "all-applications"
-]
+{
+  "policies": [
+    "all-applications"
+  ]
+}

--- a/test/context/directory/guardianPolicies.test.js
+++ b/test/context/directory/guardianPolicies.test.js
@@ -13,7 +13,7 @@ describe('#directory context guardian policies provider', () => {
     const guardianPoliciesTest = {
       'policies.json': `{
         "policies": [
-          "all-application"
+          "all-applications"
         ]
       }`
     };
@@ -25,7 +25,7 @@ describe('#directory context guardian policies provider', () => {
     await context.load();
 
     expect(context.assets.guardianPolicies).to.deep.equal({
-      policies: [ 'all-application' ]
+      policies: [ 'all-applications' ]
     });
   });
 
@@ -35,13 +35,13 @@ describe('#directory context guardian policies provider', () => {
     const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
 
     context.assets.guardianPolicies = {
-      policies: [ 'all-application' ]
+      policies: [ 'all-applications' ]
     };
 
     await handler.dump(context);
     const guardianFolder = path.join(dir, constants.GUARDIAN_DIRECTORY);
     expect(loadJSON(path.join(guardianFolder, 'policies.json'))).to.deep.equal({
-      policies: [ 'all-application' ]
+      policies: [ 'all-applications' ]
     });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

As described in the linked issue, a couple of files had some slightly incorrect values:

* `/examples/directory/guardian/policies.json` was incorrectly structured, so if you tried to use it you would get an error when running `a0deploy`
* `/examples/context/directory/guardianPolicies.test.js` incorrectly referred to the policy "all-application" instead of the correct "all-applications"

I changed both of these files and no others.

## 🔗 References

This fixes issue #277 

## 🎯 Testing

This doesn't change how the `a0deploy` tool itself works. It is a good idea to run the tests before and after this change to confirm nothing has changed.

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
