### PR TITLE
Alphabetically sort database customScripts by name

### DIFF
--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -88,7 +88,9 @@ async function dump(context) {
         ...database.options,
         // customScripts option only written if there are scripts
         ...(database.options.customScripts && {
-          customScripts: Object.entries(database.options.customScripts).reduce((scripts, [ name, script ]) => {
+          customScripts: Object.entries(database.options.customScripts).sort(
+            (entry1, entry2) => entry1[0] === entry2[0] ? 0 : (entry1 > entry2 ? 1 : -1)
+          ).reduce((scripts, [ name, script ]) => {
             // Dump custom script to file
             const scriptName = sanitize(`${name}.js`);
             const scriptFile = path.join(dbFolder, scriptName);

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -75,6 +75,11 @@ async function dump(context) {
     const dbFolder = path.join(databasesFolder, sanitize(database.name));
     fs.ensureDirSync(dbFolder);
 
+    const sortCustomScripts = ([ name1 ], [ name2 ]) => {
+      if (name1 === name2) return 0;
+      return name1 > name2 ? 1 : -1;
+    };
+
     const formatted = {
       ...database,
       enabled_clients: [
@@ -88,9 +93,7 @@ async function dump(context) {
         ...database.options,
         // customScripts option only written if there are scripts
         ...(database.options.customScripts && {
-          customScripts: Object.entries(database.options.customScripts).sort(
-            (entry1, entry2) => entry1[0] === entry2[0] ? 0 : (entry1 > entry2 ? 1 : -1)
-          ).reduce((scripts, [ name, script ]) => {
+          customScripts: Object.entries(database.options.customScripts).sort(sortCustomScripts).reduce((scripts, [ name, script ]) => {
             // Dump custom script to file
             const scriptName = sanitize(`${name}.js`);
             const scriptFile = path.join(dbFolder, scriptName);


### PR DESCRIPTION
## ✏️ Changes

Alphabetically sort database customScripts when exporting to .json file.

## 🔗 References

Every time I export it's in like a different order / gives me spurious diffs.

## 🎯 Testing

Fairly sure your tests already cover this they're just resilient to map key ordering differences when running `expect()`

✅ This change has unit test coverage

❓ This change has integration test coverage

🚫 This change has been tested for performance
