### PR TITLE
Issue 275 Return database enabled_clients in deterministic order

### DIFF
--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -53,7 +53,7 @@ async function dump(context) {
           if (found) return found.name;
           return clientId;
         })
-      ]
+      ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
     };
 
     const connectionName = sanitize(dumpedConnection.name);

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -88,7 +88,7 @@ async function dump(context) {
           if (found) return found.name;
           return clientId;
         })
-      ],
+      ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())),
       options: {
         ...database.options,
         // customScripts option only written if there are scripts

--- a/src/context/yaml/handlers/connections.js
+++ b/src/context/yaml/handlers/connections.js
@@ -74,7 +74,7 @@ async function dump(context) {
         ...getFormattedOptions(connection, clients),
         enabled_clients: [
           ...(connection.enabled_clients || []).map(clientNameOrId => convertClientIdToName(clientNameOrId, clients))
-        ]
+        ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
       };
 
       if (dumpedConnection.strategy === 'email') {

--- a/src/context/yaml/handlers/databases.js
+++ b/src/context/yaml/handlers/databases.js
@@ -52,7 +52,7 @@ async function dump(context) {
             if (found) return found.name;
             return clientId;
           })
-        ],
+        ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())),
         options: {
           ...database.options,
           // customScripts option only written if there are scripts

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -155,4 +155,20 @@ describe('#directory context connections', () => {
     const clientFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
     expect(loadJSON(path.join(clientFolder, 'my-ad-waad.json'))).to.deep.equal(context.assets.connections[0]);
   });
+
+  it('should dum connections with enabled_clients sorted', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.connections = [
+      {
+        name: 'my/ad-waad', strategy: 'waad', var: 'something', enabled_clients: [ 'client2', 'client3', 'client1' ]
+      }
+    ];
+
+    await handler.dump(context);
+    const clientFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    expect(loadJSON(path.join(clientFolder, 'my-ad-waad.json')).enabled_clients).to.deep.equal(['client1', 'client2', 'client3']);
+  });
 });

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -156,7 +156,7 @@ describe('#directory context connections', () => {
     expect(loadJSON(path.join(clientFolder, 'my-ad-waad.json'))).to.deep.equal(context.assets.connections[0]);
   });
 
-  it('should dum connections with enabled_clients sorted', async () => {
+  it('should dump connections with enabled_clients sorted', async () => {
     const dir = path.join(testDataDir, 'directory', 'connectionsDump');
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -169,6 +169,6 @@ describe('#directory context connections', () => {
 
     await handler.dump(context);
     const clientFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
-    expect(loadJSON(path.join(clientFolder, 'my-ad-waad.json')).enabled_clients).to.deep.equal(['client1', 'client2', 'client3']);
+    expect(loadJSON(path.join(clientFolder, 'my-ad-waad.json')).enabled_clients).to.deep.equal([ 'client1', 'client2', 'client3' ]);
   });
 });

--- a/test/context/directory/databases.test.js
+++ b/test/context/directory/databases.test.js
@@ -197,6 +197,26 @@ describe('#directory context databases', () => {
     });
   });
 
+  it('should dump normal databases with enabled_clients sorted', async () => {
+    cleanThenMkdir(dbDumpDir);
+    const context = new Context({ AUTH0_INPUT_FILE: dbDumpDir }, mockMgmtClient());
+
+    context.assets.databases = [
+      {
+        name: 'users',
+        enabled_clients: ['client2', 'client1', 'client3'],
+        options: {
+          requires_username: true
+        },
+        strategy: 'auth0'
+      }
+    ];
+
+    await handler.dump(context);
+    const scripsFolder = path.join(dbDumpDir, constants.DATABASE_CONNECTIONS_DIRECTORY, 'users');
+    expect(loadJSON(path.join(scripsFolder, 'database.json')).enabled_clients).to.deep.equal(['client1','client2','client3']);
+  });
+
   it('should dump custom databases', async () => {
     cleanThenMkdir(dbDumpDir);
     const context = new Context({ AUTH0_INPUT_FILE: dbDumpDir }, mockMgmtClient());

--- a/test/context/directory/databases.test.js
+++ b/test/context/directory/databases.test.js
@@ -204,7 +204,7 @@ describe('#directory context databases', () => {
     context.assets.databases = [
       {
         name: 'users',
-        enabled_clients: ['client2', 'client1', 'client3'],
+        enabled_clients: [ 'client2', 'client1', 'client3' ],
         options: {
           requires_username: true
         },
@@ -214,7 +214,7 @@ describe('#directory context databases', () => {
 
     await handler.dump(context);
     const scripsFolder = path.join(dbDumpDir, constants.DATABASE_CONNECTIONS_DIRECTORY, 'users');
-    expect(loadJSON(path.join(scripsFolder, 'database.json')).enabled_clients).to.deep.equal(['client1','client2','client3']);
+    expect(loadJSON(path.join(scripsFolder, 'database.json')).enabled_clients).to.deep.equal([ 'client1', 'client2', 'client3' ]);
   });
 
   it('should dump custom databases', async () => {

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -134,6 +134,19 @@ describe('#YAML context connections', () => {
             client_authorizequery: ''
           }
         }
+      },
+      {
+        name: 'someSamlConnectionWithMultipleEnabledClients',
+        strategy: 'samlp',
+        enabled_clients: [ 'client3', 'client2', 'client1' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-three-id',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
       }
     ];
 
@@ -166,6 +179,19 @@ describe('#YAML context connections', () => {
           passwordPolicy: 'testPolicy',
           idpinitiated: {
             client_id: 'client-idp-two-id',
+            client_protocol: 'samlp',
+            client_authorizequery: ''
+          }
+        }
+      },
+      {
+        name: 'someSamlConnectionWithMultipleEnabledClients',
+        strategy: 'samlp',
+        enabled_clients: [ 'client1', 'client2', 'client3' ],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            client_id: 'client-idp-three-id',
             client_protocol: 'samlp',
             client_authorizequery: ''
           }

--- a/test/context/yaml/databases.test.js
+++ b/test/context/yaml/databases.test.js
@@ -195,7 +195,7 @@ describe('#YAML context databases', () => {
     context.assets.databases = [
       {
         name: 'users/test',
-        enabled_clients: [],
+        enabled_clients: ['client3', 'client2', 'client1'],
         options: {
           import_mode: true,
           customScripts: {
@@ -212,7 +212,7 @@ describe('#YAML context databases', () => {
       databases: [
         {
           name: 'users/test',
-          enabled_clients: [],
+          enabled_clients: ['client1', 'client2', 'client3'],
           options: {
             import_mode: true,
             customScripts: {

--- a/test/context/yaml/databases.test.js
+++ b/test/context/yaml/databases.test.js
@@ -195,7 +195,7 @@ describe('#YAML context databases', () => {
     context.assets.databases = [
       {
         name: 'users/test',
-        enabled_clients: ['client3', 'client2', 'client1'],
+        enabled_clients: [ 'client3', 'client2', 'client1' ],
         options: {
           import_mode: true,
           customScripts: {
@@ -212,7 +212,7 @@ describe('#YAML context databases', () => {
       databases: [
         {
           name: 'users/test',
-          enabled_clients: ['client1', 'client2', 'client3'],
+          enabled_clients: [ 'client1', 'client2', 'client3' ],
           options: {
             import_mode: true,
             customScripts: {


### PR DESCRIPTION
## ✏️ Changes

> Dump enabled_clients in a deterministic order  to aid in merging dumped configuration files
> - All connections and database resources now dump the enabled_clients array in sorted order.
> - The default locale of the JavaScript runtime is used for the sort

## 🔗 References

> https://github.com/auth0/auth0-deploy-cli/issues/275

## 🎯 Testing

> - Unit Tests added.

✅ This change has unit test coverage

🚫 This change has integration test coverage  

🚫 This change has been tested for performance
