### PR TITLE
[DXEX-1074] bump auth0-source-control-extension-tools version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.1] - 2020-11-16
+### Fixed
+- Fix report error exporting hooks by bumping auth0-source-control-extension-tools@4.1.12 [#289]
+- Add MFA factor webauthn-roaming support by bumping auth0-source-control-extension-tools@4.1.12 [#289]
+
 ## [5.3.0] - 2020-11-05
 ### Fixed
 - Fix the structure of the example policies.json, and correct the guardianPolicies test to use `all-applications` instead of `all-application` [#278]
 - Fix pagination for specific API calls by bumping auth0-source-control-extension-tools@4.1.9 [#287]
-- Fix report error exporting hooks by bumping auth0-source-control-extension-tools@4.1.12 [#289]
-- Add MFA factor webauthn-roaming support by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 
 ### Changed
 - Return database `enabled_clients` in deterministic order [#281]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix the structure of the example policies.json, and correct the guardianPolicies test to use `all-applications` instead of `all-application` [#278]
 - Fix pagination for specific API calls by bumping auth0-source-control-extension-tools@4.1.9 [#287]
+- Fix report error exporting hooks by bumping auth0-source-control-extension-tools@4.1.12 [#289]
+- Add MFA factor webauthn-roaming support by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 
 ### Changed
 - Return database `enabled_clients` in deterministic order [#281]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.9.tgz",
-      "integrity": "sha512-izRXKUYSw6qBRhT9C98J2NogBvfWXr/5FQQo39toMqRsbt1YI2SlE7JMXG7DC9C6z+WXdnb7jOzua9Mz6NQF9w==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.12.tgz",
+      "integrity": "sha512-mJOX6u1GV2ecTCIjgHtUBzLbpPZYLdYdRvY5N3TYMP+acs/6s4mLUvcfH9hcFbvgBkf1I5XUDgvB985i3Cf+8g==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.9.tgz",
-      "integrity": "sha512-izRXKUYSw6qBRhT9C98J2NogBvfWXr/5FQQo39toMqRsbt1YI2SlE7JMXG7DC9C6z+WXdnb7jOzua9Mz6NQF9w==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.12.tgz",
+      "integrity": "sha512-mJOX6u1GV2ecTCIjgHtUBzLbpPZYLdYdRvY5N3TYMP+acs/6s4mLUvcfH9hcFbvgBkf1I5XUDgvB985i3Cf+8g==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.1",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.12.tgz",
-      "integrity": "sha512-mJOX6u1GV2ecTCIjgHtUBzLbpPZYLdYdRvY5N3TYMP+acs/6s4mLUvcfH9hcFbvgBkf1I5XUDgvB985i3Cf+8g==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.9.tgz",
+      "integrity": "sha512-izRXKUYSw6qBRhT9C98J2NogBvfWXr/5FQQo39toMqRsbt1YI2SlE7JMXG7DC9C6z+WXdnb7jOzua9Mz6NQF9w==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.1",
+  "version": "5.3.0",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.12",
+    "auth0-source-control-extension-tools": "^4.1.9",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.9",
+    "auth0-source-control-extension-tools": "^4.1.12",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.9",
+    "auth0-source-control-extension-tools": "^4.1.12",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",


### PR DESCRIPTION
## ✏️ Changes

bump auth0-source-control-extension-tools version

Fixes:

- a0deploy hooks export failed but no error reported
- add webauth-roaming as valid MFA factor name

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-9513
https://auth0team.atlassian.net/browse/ESD-10050

## 🎯 Testing

✅ This change has been tested locally
