### PR TITLE
Support PERSIST_MAPPINGS to not replace the configs with defined variable substitutions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+PERSIST_MAPPINGS: New Config option. This option will persist your mapping when you try sync your local repo with tenant config. Option is only supported for format directory. User will have to add the properties defined in mapping to `EXCLUDED_PROPS` else it will be overriden.
+
+eg:
+If I have configuration with mappings `@@APP_CALLBACKS@@` below should be recommended config:
+
+```json
+"PERSIST_MAPPINGS": true
+"EXCLUDED_PROPS": {
+  "clients": ["callbacks", "...other_props"]
+}
+```
 
 ## [5.3.1] - 2020-11-16
 ### Fixed
@@ -75,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.3.0] - 2020-05-18
 ### Removed
 - Removed several unused dependencies:
-  
+
   - ajv
   - e6-template-strings
   - node-storage

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The tool can be called programmatically. Please see below for an example.
 import { deploy, dump } from 'auth0-deploy-cli';
 
 const config = {
+  PERSIST_MAPPINGS: true,
   AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
   AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
   AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,

--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -54,7 +54,7 @@ async function dump(context) {
 
       client.custom_login_page = `./${clientName}_custom_login_page.html`;
     }
-    dumpJSON(clientFile, clearClientArrays(client));
+    dumpJSON(clientFile, clearClientArrays(client), context.config.PERSIST_MAPPINGS);
   });
 }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -229,7 +229,7 @@ describe('#utils', function() {
 
     const testFileContents = fs.readFileSync(file, { encoding: 'utf8' });
 
-    it('should dump JSON with the contents of passed object', () => {``
+    it('should dump JSON with the contents of passed object', () => {
       expect(JSON.parse(testFileContents)).deep.equal(testObject);
     });
     it('should dump json with trailing newline', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -208,7 +208,6 @@ describe('#utils', function() {
   });
 
   describe('dumpJSON', () => {
-    console.log('----------- should not come here')
     const dir = path.join(testDataDir, 'utils', 'json');
     cleanThenMkdir(dir);
     const file = path.join(dir, 'test1.json');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -208,18 +208,29 @@ describe('#utils', function() {
   });
 
   describe('dumpJSON', () => {
+    console.log('----------- should not come here')
     const dir = path.join(testDataDir, 'utils', 'json');
     cleanThenMkdir(dir);
     const file = path.join(dir, 'test1.json');
+    const mapfile = path.join(dir, 'testmapping1.json');
     const testObject = {
       env1: 'test1',
       env2: 'test2',
       test: '123'
     };
+
+    const testObject2 = {
+      env1: 'mapping1',
+      env2: 'mapping2',
+      test: '123',
+      callbacks: '@@APP_CALLBACKS@@'
+    };
+
     dumpJSON(file, testObject);
+
     const testFileContents = fs.readFileSync(file, { encoding: 'utf8' });
 
-    it('should dump JSON with the contents of passed object', () => {
+    it('should dump JSON with the contents of passed object', () => {``
       expect(JSON.parse(testFileContents)).deep.equal(testObject);
     });
     it('should dump json with trailing newline', () => {
@@ -229,6 +240,18 @@ describe('#utils', function() {
       expect(() => {
         dumpJSON('http://notavalidfilepath', testObject);
       }).throws(/Error writing JSON.*/);
+    });
+
+    it('should persist mappings when reexported config', () => {
+      fs.writeJSONSync(mapfile, testObject2);
+      dumpJSON(mapfile, { env1: 'updatedenv1' }, true);
+      const updatedContents = fs.readJSONSync(mapfile);
+      expect(updatedContents).deep.equals({
+        env1: 'updatedenv1',
+        env2: 'mapping2',
+        test: '123',
+        callbacks: '@@APP_CALLBACKS@@'
+      });
     });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

When automating using auth0 cli we want to sync the changes to made to auth0 dashboard to local repo.If we have already defined the mappings in our client config or any resource it will be replaced when we export the tenant configs.

## Testing
`npm test`

## Code Changes
Allow to specify PERSIST_MAPPINGS: bool in env specific config file passed to a0deploy. 


## 🎯 Testing

✅ This change has unit test coverage

✅ This change has integration test coverage

✅ This change has been tested for performance
