### PR TITLE
[CAUTH-837] add `verify_email_by_code` email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for `verify_email_by_code` email template [#309]
 
 ## [5.3.2] - 2020-12-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.4.0] - 2021-01-28
 ### Added
 - Add support for `verify_email_by_code` email template [#309]
 
@@ -284,8 +286,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#287]: https://github.com/auth0/auth0-deploy-cli/issues/287
 [#289]: https://github.com/auth0/auth0-deploy-cli/issues/289
 [#291]: https://github.com/auth0/auth0-deploy-cli/issues/291
+[#309]: https://github.com/auth0/auth0-deploy-cli/issues/309
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.3.2...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.4.0...HEAD
+[5.4.0]: https://github.com/auth0/auth0-deploy-cli/compare/v5.3.2...v5.4.0
 [5.3.2]: https://github.com/auth0/auth0-deploy-cli/compare/v5.3.1...v5.3.2
 [5.3.1]: https://github.com/auth0/auth0-deploy-cli/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/auth0/auth0-deploy-cli/compare/v5.2.1...v5.3.0

--- a/examples/directory/emails/verify_email_by_code.html
+++ b/examples/directory/emails/verify_email_by_code.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Example Email
+</body>
+</html>

--- a/examples/directory/emails/verify_email_by_code.json
+++ b/examples/directory/emails/verify_email_by_code.json
@@ -1,0 +1,8 @@
+{
+  "template": "verify_email_by_code",
+  "from": "",
+  "subject": "",
+  "syntax": "liquid",
+  "body": "./verify_email_by_code.html",
+  "enabled": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.1.12.tgz",
-      "integrity": "sha512-mJOX6u1GV2ecTCIjgHtUBzLbpPZYLdYdRvY5N3TYMP+acs/6s4mLUvcfH9hcFbvgBkf1I5XUDgvB985i3Cf+8g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.3.0.tgz",
+      "integrity": "sha512-lNPnQFm6N6MzTMjSDivhikVAoyKQKdg/J/DTrqYEvbsq6XvpA6GbzCEZ99cgEmGTqhAFlIJThoo4f6URA1gMBw==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",
@@ -6833,9 +6833,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.1.12",
+    "auth0-source-control-extension-tools": "~4.3.0",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -135,6 +135,7 @@ describe('#YAML context validation', () => {
         { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
         { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
         { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/verify_email_by_code.html', enabled: true, template: 'verify_email_by_code' },
         { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' }
       ],
       pages: [
@@ -203,6 +204,7 @@ describe('#YAML context validation', () => {
         { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
         { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
         { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/verify_email_by_code.html', enabled: true, template: 'verify_email_by_code' },
         { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' }
       ],
       pages: [
@@ -275,6 +277,7 @@ describe('#YAML context validation', () => {
         { body: './emailTemplates/reset_email.html', enabled: true, template: 'reset_email' },
         { body: './emailTemplates/stolen_credentials.html', enabled: true, template: 'stolen_credentials' },
         { body: './emailTemplates/verify_email.html', enabled: true, template: 'verify_email' },
+        { body: './emailTemplates/verify_email_by_code.html', enabled: true, template: 'verify_email_by_code' },
         { body: './emailTemplates/welcome_email.html', enabled: true, template: 'welcome_email' }
       ],
       pages: [


### PR DESCRIPTION
## ✏️ Changes

⚠️ Depends on: https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/123

⚠️ I'd like this change to be merged to `master`, I don't need this on the `beta` branch. Let me know if there's something to adjust here.

Add a new email template key `verify_email_by_code`, to support the "Verification Email (using Code)" template that was introduced in the past few months in the dashboard:
![image](https://user-images.githubusercontent.com/1411117/105085136-576ead80-5a65-11eb-8a11-6a227d3d4abb.png)

Fixes https://github.com/auth0/auth0-deploy-cli/issues/303

## 🔗 References

https://auth0team.atlassian.net/browse/CAUTH-837

## 🎯 Testing

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
