### PR TITLE
[ESD-11133] fix: retries not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issue with ManagementClient retries not enabled as intended 
 
 ## [5.3.2] - 2020-12-17
 ### Fixed

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -51,7 +51,7 @@ export default async function(config) {
   const mgmtClient = new ManagementClient({
     domain: config.AUTH0_DOMAIN,
     token: accessToken,
-    retry: { maxRetries: config.AUTH0_API_MAX_RETRIES || 10 },
+    retry: { maxRetries: config.AUTH0_API_MAX_RETRIES || 10, enabled: true },
     headers: {
       'User-agent': `deploy-cli/${packageVersion} (node.js/${process.version.replace('v', '')})`
     }


### PR DESCRIPTION
## ✏️ Changes

Retries are intended to be enabled on the ManagementClient instance but the override of the option `retry` causes `retry.enabled` to be unset. 

I have validated that the retry object is not merged with the defaults in the constructor of the ManagementClient. It is defined as is. [See line](https://github.com/auth0/node-auth0/blob/master/src/management/index.js#L153) 

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-11133

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
