### PR TITLE
fix: add webauthn-platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add webauthn platform as a supported factor
 
 ## [5.5.2] - 2021-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.5.3] - 2021-03-10
 ### Added
 - Add webauthn platform as a supported factor
 
@@ -298,7 +300,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#291]: https://github.com/auth0/auth0-deploy-cli/issues/291
 [#309]: https://github.com/auth0/auth0-deploy-cli/issues/309
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.2...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.3...HEAD
+[5.5.3]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.2...v5.5.3
 [5.5.2]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.1...v5.5.2
 [5.5.1]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.0...v5.5.1
 [5.5.0]: https://github.com/auth0/auth0-deploy-cli/compare/v5.3.2...v5.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.4.1.tgz",
-      "integrity": "sha512-AkqNCe91LI6T9jT2QqdhFPaUQjjYgkhssPmcpUVAkJYFa7RJSYF73IFN8XkaH3gq3kPiRrrEkBgvESVbCP/Abw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.4.2.tgz",
+      "integrity": "sha512-kJpOvWYfjhlsoo0dRH+afJPUIych6lwNmg3lzj/0JLpGh+r+21098HWQxo6Sqi+ZWPyH48LIvoGVNGfBPsno4g==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.4.1",
+    "auth0-source-control-extension-tools": "^4.4.2",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",


### PR DESCRIPTION
## ✏️ Changes

- Add support for webauthn-platform as guardian factors

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-12259

## 🎯 Testing

Enable webauthn on your tenant, export your tenant and reimport it.

✅ This change has unit test coverage

✅ This change has integration test coverage

✅ This change has been tested for performance
