### PR TITLE
fix: remove roles permissions limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.4] - 2021-03-12
+### Fixed
+- Remove limit on permissions in roles
+
 ## [5.5.3] - 2021-03-10
 ### Added
 - Add webauthn platform as a supported factor
@@ -300,7 +304,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#291]: https://github.com/auth0/auth0-deploy-cli/issues/291
 [#309]: https://github.com/auth0/auth0-deploy-cli/issues/309
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.3...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.4...HEAD
+[5.5.4]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.3...v5.5.4
 [5.5.3]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.2...v5.5.3
 [5.5.2]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.1...v5.5.2
 [5.5.1]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.0...v5.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.4.2.tgz",
-      "integrity": "sha512-kJpOvWYfjhlsoo0dRH+afJPUIych6lwNmg3lzj/0JLpGh+r+21098HWQxo6Sqi+ZWPyH48LIvoGVNGfBPsno4g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-4.4.3.tgz",
+      "integrity": "sha512-MU27DXhH6W460RDeqEj48qda9D418BtcBslBs9lDTuGMJF6QhaSJ7HqewXjvf9SwAlvyRbXw6cUw/vvCUZizaw==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.4.2",
+    "auth0-source-control-extension-tools": "^4.4.3",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -74,11 +74,17 @@ export function mockMgmtClient() {
         }
       ),
       permissions: {
-        get: () => [
+        getAll: () => (
           {
-            permission_name: 'create:data', resource_server_identifier: 'urn:ref'
+            permissions: [
+              {
+                permission_name: 'create:data', resource_server_identifier: 'urn:ref'
+              }
+            ],
+            total: 1,
+            limit: 50
           }
-        ]
+        )
       }
     },
     tenant: {


### PR DESCRIPTION
## ✏️ Changes

roles.permissions.getAll now supports pagination and thus removes the default limit of 50 when exporting roles.permissions.

## 🎯 Testing

export a tenant with a role with more than 50 permissions.

✅ This change has unit test coverage

✅ This change has integration test coverage

✅ This change has been tested for performance
