### PR TITLE
fix: remove roles permissions limit (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1-beta.3] - 2021-03-12
+### Fixed
+- Remove limit on permissions in roles
+
 ## [6.0.1-beta.2] - 2021-03-10
 ### Added
 - Support for webauthn-platform guardian factor
@@ -302,7 +306,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#289]: https://github.com/auth0/auth0-deploy-cli/issues/289
 [#291]: https://github.com/auth0/auth0-deploy-cli/issues/291
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.1-beta.2...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.1-beta.3...HEAD
+[6.0.1-beta.3]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.1-beta.2...v6.0.1-beta.3
 [6.0.1-beta.2]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.1-beta.1...v6.0.1-beta.2
 [6.0.1-beta.1]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.1-beta.0...v6.0.1-beta.1
 [6.0.1-beta.0]: https://github.com/auth0/auth0-deploy-cli/compare/v6.0.0...v6.0.1-beta.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1994,9 +1994,9 @@
       }
     },
     "auth0-source-control-extension-tools": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-5.1.2.tgz",
-      "integrity": "sha512-aj6/8CfUEzmqgf3H8UPUdvmg4uBGOZVY1NyUI13JxMGoQmVUfG4Rj1Q7d4L7/9sxjjCbNvczVVoukdreF92gsg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/auth0-source-control-extension-tools/-/auth0-source-control-extension-tools-5.1.3.tgz",
+      "integrity": "sha512-ZHV8wvtpW3y9SCGfJqqlskUteINVRTyqXCFC5Msbl7u/2aD6wmsa8qZq8NnotnSFAPGxwtCz2U8mCp+wDxFqbg==",
       "requires": {
         "ajv": "^6.5.2",
         "auth0-extension-tools": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "6.0.1-beta.2",
+  "version": "6.0.1-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "6.0.1-beta.2",
+  "version": "6.0.1-beta.3",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "git://github.com/auth0/node-auth0.git#actionsManager",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^5.1.2",
+    "auth0-source-control-extension-tools": "^5.1.3",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/test/utils.js
+++ b/test/utils.js
@@ -77,11 +77,17 @@ export function mockMgmtClient() {
         }
       ),
       permissions: {
-        get: () => [
+        getAll: () => (
           {
-            permission_name: 'create:data', resource_server_identifier: 'urn:ref'
+            permissions: [
+              {
+                permission_name: 'create:data', resource_server_identifier: 'urn:ref'
+              }
+            ],
+            total: 1,
+            limit: 50
           }
-        ]
+        )
       }
     },
     tenant: {


### PR DESCRIPTION
## ✏️ Changes

roles.permissions.getAll now supports pagination and thus removes the default limit of 50 when exporting roles.permissions.

## 🎯 Testing

export a tenant with a role with more than 50 permissions.

✅ This change has unit test coverage

✅ This change has integration test coverage

✅ This change has been tested for performance
