### PR TITLE
[ESD-12571] 5.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.5] - 2021-03-26
+### Fixed
+- Broken dependencies on 4.5.x range of source-countrol-extension-tools because of organizations.
+
 ## [5.5.4] - 2021-03-12
 ### Fixed
 - Remove limit on permissions in roles
@@ -304,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#291]: https://github.com/auth0/auth0-deploy-cli/issues/291
 [#309]: https://github.com/auth0/auth0-deploy-cli/issues/309
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.4...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.5...HEAD
+[5.5.5]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.4...v5.5.5
 [5.5.4]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.3...v5.5.4
 [5.5.3]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.2...v5.5.3
 [5.5.2]: https://github.com/auth0/auth0-deploy-cli/compare/v5.5.1...v5.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "auth0": "^2.27.0",
     "auth0-extension-tools": "^1.4.4",
-    "auth0-source-control-extension-tools": "^4.4.3",
+    "auth0-source-control-extension-tools": "~4.4.3",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
## ✏️ Changes

4.5.x of auth0-source-control extension tools is not releasable yet because organizations is not available to customers. We'll revert this from auth0-source-control-extension-tools, but for now, get a fix out for deploy cli.

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-12571

