### PR TITLE
Implement prompts API support for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported Auth0 Management API resources
 - [ ] [Log Streams](https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams)
 - [ ] [Logs](https://auth0.com/docs/api/management/v2#!/Logs/get_logs)
 - [x] [Organizations](https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations)
-- [ ] [Prompts](https://auth0.com/docs/api/management/v2#!/Prompts/get_prompts)
+- [x] [Prompts](https://auth0.com/docs/api/management/v2#!/Prompts/get_prompts)
 - [x] [Resource Servers (APIs)](https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers)
 - [x] [Roles](https://auth0.com/docs/api/management/v2#!/Roles)
 - [x] [Rules](https://auth0.com/docs/api/management/v2#!/Rules/get_rules)

--- a/src/context/directory/handlers/index.js
+++ b/src/context/directory/handlers/index.js
@@ -3,6 +3,7 @@ import rules from './rules';
 import hooks from './hooks';
 import clients from './clients';
 import tenant from './tenant';
+import prompts from './prompts';
 import emailProvider from './emailProvider';
 import connections from './connections';
 import databases from './databases';
@@ -33,6 +34,7 @@ export default {
   clients,
   connections,
   tenant,
+  prompts,
   emailProvider,
   emailTemplates,
   guardianFactors,

--- a/src/context/directory/handlers/prompts.js
+++ b/src/context/directory/handlers/prompts.js
@@ -1,0 +1,37 @@
+import path from 'path';
+import {
+  existsMustBeDir, isFile, dumpJSON, loadJSON
+} from '../../../utils';
+
+function parse(context) {
+  const baseFolder = path.join(context.filePath);
+  if (!existsMustBeDir(baseFolder)) return {}; // Skip
+
+  const promptsFile = path.join(baseFolder, 'prompts.json');
+
+  if (isFile(promptsFile)) {
+    /* eslint-disable camelcase */
+    const prompts = loadJSON(promptsFile, context.mappings);
+
+    return {
+      prompts: prompts
+    };
+    /* eslint-enable camelcase */
+  }
+
+  return {};
+}
+
+async function dump(context) {
+  const { prompts } = context.assets;
+
+  if (!prompts) return; // Skip, nothing to dump
+
+  const promptsFile = path.join(context.filePath, 'prompts.json');
+  dumpJSON(promptsFile, prompts);
+}
+
+export default {
+  parse,
+  dump
+};

--- a/src/context/yaml/handlers/index.js
+++ b/src/context/yaml/handlers/index.js
@@ -3,6 +3,7 @@ import rules from './rules';
 import hooks from './hooks';
 import clients from './clients';
 import tenant from './tenant';
+import prompts from './prompts';
 import emailProvider from './emailProvider';
 import connections from './connections';
 import databases from './databases';
@@ -33,6 +34,7 @@ export default {
   clients,
   connections,
   tenant,
+  prompts,
   emailProvider,
   emailTemplates,
   guardianFactors,

--- a/src/context/yaml/handlers/prompts.js
+++ b/src/context/yaml/handlers/prompts.js
@@ -1,0 +1,22 @@
+async function parse(context) {
+  // Nothing to do
+  if (!context.assets.prompts) return {};
+
+  /* eslint-disable camelcase */
+  const { prompts } = context.assets;
+
+  return {
+    prompts: prompts
+  };
+  /* eslint-enable camelcase */
+}
+
+async function dump(context) {
+  const prompts = { ...context.assets.prompts || {} };
+  return { prompts };
+}
+
+export default {
+  parse,
+  dump
+};

--- a/test/context/directory/prompts.test.js
+++ b/test/context/directory/prompts.test.js
@@ -1,0 +1,55 @@
+import path from 'path';
+import { expect } from 'chai';
+
+import Context from '../../../src/context/directory';
+import {
+  testDataDir, createDir, mockMgmtClient, cleanThenMkdir
+} from '../../utils';
+import handler from '../../../src/context/directory/handlers/prompts';
+import { loadJSON } from '../../../src/utils';
+
+const promptsTest = {
+  'prompts.json': `{
+    "universal_login_experience": "##universal_login_experience##",
+    "identifier_first": true,
+    "webauthn_platform_first_factor": false
+  }`
+};
+
+const promptsTarget = {
+  universal_login_experience: 'new',
+  identifier_first: true,
+  webauthn_platform_first_factor: false
+};
+
+describe('#directory context prompts', () => {
+  it('should process prompts', async () => {
+    createDir(path.join(testDataDir, 'directory'), { prompts1: promptsTest });
+
+    const config = {
+      AUTH0_INPUT_FILE: path.join(testDataDir, 'directory', 'prompts1'),
+      AUTH0_KEYWORD_REPLACE_MAPPINGS: { universal_login_experience: 'new' }
+    };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    expect(context.assets.prompts).to.deep.equal(promptsTarget);
+  });
+
+  it('should dump prompts', async () => {
+    const dir = path.join(testDataDir, 'directory', 'promptsDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.prompts = {
+      universal_login_experience: 'new',
+      identifier_first: true,
+      webauthn_platform_first_factor: false
+    };
+
+    await handler.dump(context);
+    const dumped = loadJSON(path.join(dir, 'prompts.json'));
+
+    expect(dumped).to.deep.equal(context.assets.prompts);
+  });
+});

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -148,7 +148,10 @@ describe('#YAML context validation', () => {
       guardianPhoneFactorMessageTypes: { message_types: [ 'sms' ] },
       guardianPhoneFactorSelectedProvider: { provider: 'twilio' },
       guardianPolicies: { policies: [] },
-      prompts: {},
+      prompts: {
+        universal_login_experience: 'classic',
+        identifier_first: false
+      },
       resourceServers: [],
       rules: [],
       hooks: [],
@@ -223,7 +226,10 @@ describe('#YAML context validation', () => {
       guardianPhoneFactorMessageTypes: { message_types: [ 'sms' ] },
       guardianPhoneFactorSelectedProvider: { provider: 'twilio' },
       guardianPolicies: { policies: [] },
-      prompts: {},
+      prompts: {
+        universal_login_experience: 'classic',
+        identifier_first: false
+      },
       resourceServers: [],
       rules: [],
       hooks: [],
@@ -299,7 +305,10 @@ describe('#YAML context validation', () => {
       guardianPhoneFactorMessageTypes: { message_types: [ 'sms' ] },
       guardianPhoneFactorSelectedProvider: { provider: 'twilio' },
       guardianPolicies: { policies: [] },
-      prompts: {},
+      prompts: {
+        universal_login_experience: 'classic',
+        identifier_first: false
+      },
       resourceServers: [],
       rules: [],
       hooks: [],

--- a/test/context/yaml/prompts.test.js
+++ b/test/context/yaml/prompts.test.js
@@ -1,0 +1,47 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { expect } from 'chai';
+
+import Context from '../../../src/context/yaml';
+import handler from '../../../src/context/yaml/handlers/prompts';
+import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
+
+describe('#YAML context prompts settings', () => {
+  it('should process prompts settings', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'prompts');
+    cleanThenMkdir(dir);
+
+    const yaml = `
+    prompts:
+      universal_login_experience: '##universal_login_experience##'
+      identifier_first: true
+      webauthn_platform_first_factor: false
+    `;
+    const yamlFile = path.join(dir, 'config.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const target = {
+      universal_login_experience: 'new',
+      identifier_first: true,
+      webauthn_platform_first_factor: false
+    };
+
+    const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { universal_login_experience: 'new' } };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    expect(context.assets.prompts).to.deep.equal(target);
+  });
+
+  it('should dump prompts', async () => {
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
+    const prompts = {
+      universal_login_experience: 'classic',
+      identifier_first: false
+    };
+    context.assets.prompts = prompts;
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({ prompts });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -94,6 +94,12 @@ export function mockMgmtClient() {
         default_directory: 'users'
       })
     },
+    prompts: {
+      getSettings: () => ({
+        universal_login_experience: 'classic',
+        identifier_first: false
+      })
+    },
     migrations: {
       getMigrations: () => ({
         migration_flag: true


### PR DESCRIPTION
## ✏️ Changes

This pull request aims to add support for prompts settings.

The "tools" part for prompts settings was already implemented to load / save configuration through API V2 which explain the need in read:prompts scope as stated in documentation.
This pull request implement the "context" side of prompts settings management which aims to dump / load data from json directory or yaml source.

see: https://auth0.com/docs/api/management/v2/#!/Prompts/get_prompts

## 🔗 References

Fixes #229 

## 🎯 Testing

Unit tests has been implemented.
You can try it out on a real Auth0 tenant the following way:

- run **export cli** on existing freshly created tenant in **directory output mode**
- you should retrieve a `prompts.json` file at root of output directory which should contains the following configuration 

```json
{
  "universal_login_experience":"classic",
  "identifier_first":false
}
```

- Go to the "Universal Login" settings page on your tenant, and ensure you see **classic mode enabled** (which is coherent with previously retrieved configuration)
https://manage.auth0.com/dashboard/<region>/<tenant_name>/login_settings

- Update the `prompts.json` file with the following content which aims to enable new universal login experience with identifier first flow

```
{
  "universal_login_experience": "new",
  "identifier_first": true,
  "webauthn_platform_first_factor": false
}
```

- run **import cli** on the same tenant in **directory mode**


- Go to the "Universal Login" settings page on your tenant, and ensure you see **new mode enabled** (which is coherent with previously updated configuration)
https://manage.auth0.com/dashboard/<region>/<tenant_name>/login_settings
- Then go to the "Authentication Profile" settings page on your tenant, and ensure you see "identifier first" enabled


Repeat the same operation in **yaml output mode**

✅🚫 This change has unit test coverage

✅🚫 This change has integration test coverage

✅🚫 This change has been tested for performance
