### PR TITLE
Issue#367 - Load file configured in customScripts

### DIFF
--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -8,7 +8,6 @@ import {
   existsMustBeDir,
   dumpJSON,
   loadJSON,
-  getFiles,
   sanitize,
   mapClientID2NameSorted
 } from '../../../utils';
@@ -41,14 +40,20 @@ function getDatabase(folder, mappings) {
     }
   };
 
-  getFiles(folder, [ '.js' ]).forEach((file) => {
-    const { name } = path.parse(file);
-    if (!constants.DATABASE_SCRIPTS.includes(name)) {
-      log.warn('Skipping invalid database script file: ' + file);
-    } else {
-      database.options.customScripts[name] = loadFile(file, mappings);
-    }
-  });
+  // If any customScripts configured then load content of files
+  if (database.options.customScripts) {
+    Object.entries(database.options.customScripts).forEach(([name, script]) => {
+      if (!constants.DATABASE_SCRIPTS.includes(name)) {
+        // skip invalid keys in customScripts object
+        log.warn('Skipping invalid database configuration: ' + name);
+      } else {
+        database.options.customScripts[name] = loadFile(
+          path.join(folder, script),
+          mappings
+        )
+      }
+    })
+  }
 
   return database;
 }

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -42,7 +42,7 @@ function getDatabase(folder, mappings) {
 
   // If any customScripts configured then load content of files
   if (database.options.customScripts) {
-    Object.entries(database.options.customScripts).forEach(([name, script]) => {
+    Object.entries(database.options.customScripts).forEach(([ name, script ]) => {
       if (!constants.DATABASE_SCRIPTS.includes(name)) {
         // skip invalid keys in customScripts object
         log.warn('Skipping invalid database configuration: ' + name);
@@ -50,9 +50,9 @@ function getDatabase(folder, mappings) {
         database.options.customScripts[name] = loadFile(
           path.join(folder, script),
           mappings
-        )
+        );
       }
-    })
+    });
   }
 
   return database;

--- a/test/context/directory/databases.test.js
+++ b/test/context/directory/databases.test.js
@@ -85,13 +85,13 @@ describe('#directory context databases', () => {
         "options": {
           "enabledDatabaseCustomization": true,
           "customScripts": {
-            "login": "./login.js",
+            "login": "./custom-login.js",
             "create": "./create.js",
-            "delete": "databases/users/delete.js",
-            "get_user": "databases/users/get_user.js",
-            "change_email": "databases/users/change_email.js",
-            "change_password": "databases/users/change_password.js",
-            "verify": "databases/users/verify.js"
+            "delete": "./delete.js",
+            "get_user": "./get_user.js",
+            "change_email": "./change_email.js",
+            "change_password": "./change_password.js",
+            "verify": "./verify.js"
           }
         }
       }
@@ -101,7 +101,7 @@ describe('#directory context databases', () => {
     'create.js': 'function test(email, callback) {var env = @@env@@};',
     'delete.js': 'function test(email, callback) {var env = @@env@@};',
     'get_user.js': 'function test(email, callback) {var env = @@env@@};',
-    'login.js': 'function test(email, callback) {var env = @@env@@};',
+    'custom-login.js': 'function test(email, callback) {var env = @@env@@};',
     'verify.js': 'function test(email, callback) {var env = @@env@@};'
   };
 


### PR DESCRIPTION
The customScripts in the directory context is not loading the configured
script paths. Rather it is loading the default paths within the
directory. To maintain configurability, update the getDatbase function
to load the path from the configured path location defined in
customScripts.

## ✏️ Changes

This applies a similar pattern done with the [YAML context](https://github.com/auth0/auth0-deploy-cli/blob/614b5158011b33686aaf28d8e963b2bc5f6cef74/src/context/yaml/handlers/databases.js#L19-L22)

- Update the `getDatabase` function within the databases module
- Change how custom scripts are loaded. Rather than loading files within the root of the folder, respect the path configured within the `customScripts` object.
- Rather than rejecting the file by name, only reject invalid properties within `customScripts` object.
- Updated tests because no matter the configured script path in the main config, the same file was loaded every time. This meant tests would fail after the change due to the file not exiting when trying to load.

## 🔗 References

Issue #367 

## 🎯 Testing

This change is covered by unit tests already. I've updated some names in the test to demonstrate custom named scripts. If the configured path or file doesn't exist then the script should fail.

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
