### PR TITLE
[IDS-3074] Updated structure when dumping orgs

### DIFF
--- a/src/context/directory/handlers/organizations.js
+++ b/src/context/directory/handlers/organizations.js
@@ -35,6 +35,21 @@ async function dump(context) {
   organizations.forEach((organization) => {
     const organizationFile = path.join(organizationsFolder, sanitize(`${organization.name}.json`));
     log.info(`Writing ${organizationFile}`);
+
+    if (organization.connections.length > 0) {
+      organization.connections = organization.connections.map((c) => {
+        // connection is a computed field
+        const name = c.connection && c.connection.name;
+        delete c.connection_id;
+        delete c.connection;
+
+        return {
+          name,
+          ...c
+        };
+      });
+    }
+
     dumpJSON(organizationFile, organization);
   });
 }

--- a/src/context/directory/handlers/organizations.js
+++ b/src/context/directory/handlers/organizations.js
@@ -41,12 +41,15 @@ async function dump(context) {
         // connection is a computed field
         const name = c.connection && c.connection.name;
 
-        return {
+        const conn = {
           name,
-          ...c,
-          connection_id: undefined,
-          connection: undefined
+          ...c
         };
+
+        delete conn.connection_id;
+        delete conn.connection;
+
+        return conn;
       });
     }
 

--- a/src/context/directory/handlers/organizations.js
+++ b/src/context/directory/handlers/organizations.js
@@ -40,12 +40,12 @@ async function dump(context) {
       organization.connections = organization.connections.map((c) => {
         // connection is a computed field
         const name = c.connection && c.connection.name;
-        delete c.connection_id;
-        delete c.connection;
 
         return {
           name,
           ...c
+          connection_id: undefined,
+          connection: undefined,
         };
       });
     }

--- a/src/context/directory/handlers/organizations.js
+++ b/src/context/directory/handlers/organizations.js
@@ -43,9 +43,9 @@ async function dump(context) {
 
         return {
           name,
-          ...c
+          ...c,
           connection_id: undefined,
-          connection: undefined,
+          connection: undefined
         };
       });
     }

--- a/test/context/directory/organizations.test.js
+++ b/test/context/directory/organizations.test.js
@@ -14,8 +14,8 @@ describe('#directory context organizations', () => {
   it('should process organizations', async () => {
     const files = {
       organizations: {
-        'acme.json': '{ "name": "acme", "display_name": "acme", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "connection_id": "con_123", "assign_membership_on_login": false }]}',
-        'contoso.json': '{ "name": "contoso", "display_name": "contoso", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "connection_id": "con_123", "assign_membership_on_login": false }]}'
+        'acme.json': '{ "name": "acme", "display_name": "acme", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "name": "google", "assign_membership_on_login": false }]}',
+        'contoso.json': '{ "name": "contoso", "display_name": "contoso", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "name": "google", "assign_membership_on_login": false }]}'
       }
     };
 
@@ -37,7 +37,7 @@ describe('#directory context organizations', () => {
           }
         },
         connections: [ {
-          connection_id: 'con_123',
+          name: 'google',
           assign_membership_on_login: false
         } ]
       },
@@ -51,7 +51,7 @@ describe('#directory context organizations', () => {
           }
         },
         connections: [ {
-          connection_id: 'con_123',
+          name: 'google',
           assign_membership_on_login: false
         } ]
       }
@@ -106,7 +106,7 @@ describe('#directory context organizations', () => {
           }
         },
         connections: [ {
-          connection_id: 'con_123',
+          name: 'google',
           assign_membership_on_login: false
         } ]
       },
@@ -120,7 +120,7 @@ describe('#directory context organizations', () => {
           }
         },
         connections: [ {
-          connection_id: 'con_123',
+          name: 'google',
           assign_membership_on_login: false
         } ]
       }


### PR DESCRIPTION
## ✏️ Changes

Fixes an issue when exporting organizations as a directory, connections are not structured in the right way, causing the import to remove any connection on the organizations

## 🎯 Testing

✅ This change has unit test coverage
🚫  This change has integration test coverage
🚫 This change has been tested for performance
