### PR TITLE
[DXEX-1721] Fix client metadata property deletion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,15 @@
 {
   "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "extends": [
     "airbnb-base",
     "plugin:import/errors",
     "plugin:import/warnings"
   ],
   "env": {
+    "es2020": true,
     "node": true,
     "mocha": true
   },

--- a/src/tools/auth0/handlers/clients.js
+++ b/src/tools/auth0/handlers/clients.js
@@ -18,7 +18,7 @@ export default class ClientHandler extends DefaultHandler {
       type: 'clients',
       id: 'client_id',
       identifiers: [ 'client_id', 'name' ],
-      objectFields: ['client_metadata'],
+      objectFields: [ 'client_metadata' ],
       stripUpdateFields: [
         // Fields not allowed during updates
         'callback_url_template', 'signing_keys', 'global', 'tenant', 'jwt_configuration.secret_encoded'

--- a/src/tools/auth0/handlers/clients.js
+++ b/src/tools/auth0/handlers/clients.js
@@ -18,6 +18,7 @@ export default class ClientHandler extends DefaultHandler {
       type: 'clients',
       id: 'client_id',
       identifiers: [ 'client_id', 'name' ],
+      objectFields: ['client_metadata'],
       stripUpdateFields: [
         // Fields not allowed during updates
         'callback_url_template', 'signing_keys', 'global', 'tenant', 'jwt_configuration.secret_encoded'

--- a/src/tools/auth0/handlers/default.js
+++ b/src/tools/auth0/handlers/default.js
@@ -20,6 +20,7 @@ export default class DefaultHandler {
     this.client = options.client;
     this.existing = null;
     this.identifiers = options.identifiers || [ 'id', 'name' ];
+    this.objectFields = options.objectFields || [];
     this.stripUpdateFields = [
       ...options.stripUpdateFields || [],
       this.id
@@ -82,7 +83,7 @@ export default class DefaultHandler {
     const existing = await this.getType();
 
     // Figure out what needs to be updated vs created
-    return calcChanges(typeAssets, existing, this.identifiers);
+    return calcChanges(typeAssets, existing, this.identifiers, this.objectFields);
   }
 
   async validate(assets) {

--- a/src/tools/auth0/handlers/default.js
+++ b/src/tools/auth0/handlers/default.js
@@ -83,7 +83,7 @@ export default class DefaultHandler {
     const existing = await this.getType();
 
     // Figure out what needs to be updated vs created
-    return calcChanges(typeAssets, existing, this.identifiers, this.objectFields);
+    return calcChanges(this, typeAssets, existing, this.identifiers, this.objectFields);
   }
 
   async validate(assets) {

--- a/src/tools/auth0/handlers/organizations.js
+++ b/src/tools/auth0/handlers/organizations.js
@@ -181,7 +181,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       }).filter((connection) => !!connection.connection_id);
     });
 
-    const changes = calcChanges(organizations, existing, [ 'id', 'name' ]);
+    const changes = calcChanges(this, organizations, existing, [ 'id', 'name' ]);
 
     log.debug(`Start processChanges for organizations [delete:${changes.del.length}] [update:${changes.update.length}], [create:${changes.create.length}]`);
 

--- a/src/tools/auth0/handlers/resourceServers.js
+++ b/src/tools/auth0/handlers/resourceServers.js
@@ -66,7 +66,7 @@ export default class ResourceServersHandler extends DefaultHandler {
     resourceServers = resourceServers.filter((r) => !excluded.includes(r.name));
     existing = existing.filter((r) => !excluded.includes(r.name));
 
-    return calcChanges(resourceServers, existing, [ 'id', 'identifier' ]);
+    return calcChanges(this, resourceServers, existing, [ 'id', 'identifier' ]);
   }
 
   async validate(assets) {

--- a/src/tools/auth0/handlers/roles.js
+++ b/src/tools/auth0/handlers/roles.js
@@ -153,7 +153,7 @@ export default class RoleHandler extends DefaultHandler {
     if (!roles) return;
     // Gets roles from destination tenant
     const existing = await this.getType();
-    const changes = calcChanges(roles, existing, [ 'id', 'name' ]);
+    const changes = calcChanges(this, roles, existing, [ 'id', 'name' ]);
     log.debug(`Start processChanges for roles [delete:${changes.del.length}] [update:${changes.update.length}], [create:${changes.create.length}]`);
     const myChanges = [ { del: changes.del }, { create: changes.create }, { update: changes.update } ];
     await Promise.all(myChanges.map(async (change) => {

--- a/src/tools/auth0/handlers/rules.js
+++ b/src/tools/auth0/handlers/rules.js
@@ -82,7 +82,7 @@ export default class RulesHandler extends DefaultHandler {
     // Figure out what needs to be updated vs created
     const {
       del, update, create, conflicts
-    } = calcChanges(rules, existing, [ 'id', 'name' ]);
+    } = calcChanges(this, rules, existing, [ 'id', 'name' ]);
 
     // Figure out the rules that need to be re-ordered
     const futureRules = [ ...create, ...update ];

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -65,6 +65,7 @@ export function dumpJSON(obj, spacing = 0) {
 function processChangedObjectFields(desiredAssetState, currentAssetState, objectFields = []) {
   const desiredAssetStateWithChanges = { ...desiredAssetState };
 
+  // eslint-disable-next-line no-restricted-syntax
   for (const fieldName of objectFields) {
     if (desiredAssetState[fieldName]) {
       // Both the current and desired state have the object field. Here's where we need to map
@@ -72,6 +73,7 @@ function processChangedObjectFields(desiredAssetState, currentAssetState, object
       // For new and modified properties of the object field, we can just pass them through to
       // APIv2.
       if (currentAssetState[fieldName]) {
+        // eslint-disable-next-line no-restricted-syntax
         for (const currentObjectFieldPropertyName of Object.keys(currentAssetState[fieldName])) {
           if (desiredAssetState[fieldName][currentObjectFieldPropertyName] === undefined) {
             desiredAssetStateWithChanges[fieldName][currentObjectFieldPropertyName] = null;
@@ -83,6 +85,7 @@ function processChangedObjectFields(desiredAssetState, currentAssetState, object
       // should mark *all* properties for deletion by specifying an empty object.
       //
       // See: https://auth0.com/docs/users/metadata/manage-metadata-api#delete-user-metadata
+      // eslint-disable-next-line no-lonely-if
       if (currentAssetState[fieldName]) {
         desiredAssetStateWithChanges[fieldName] = {};
       }

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -62,6 +62,36 @@ export function dumpJSON(obj, spacing = 0) {
   return JSON.stringify(obj, null, spacing);
 }
 
+function processChangedObjectFields(desiredAssetState, currentAssetState, objectFields = []) {
+  const desiredAssetStateWithChanges = { ...desiredAssetState };
+
+  for (const fieldName of objectFields) {
+    if (desiredAssetState[fieldName]) {
+      // Both the current and desired state have the object field. Here's where we need to map
+      // to the APIv2 protocol of setting `null` values for deleted fields.
+      // For new and modified properties of the object field, we can just pass them through to
+      // APIv2.
+      if (currentAssetState[fieldName]) {
+        for (const currentObjectFieldPropertyName of Object.keys(currentAssetState[fieldName])) {
+          if (desiredAssetState[fieldName][currentObjectFieldPropertyName] === undefined) {
+            desiredAssetStateWithChanges[fieldName][currentObjectFieldPropertyName] = null;
+          }
+        }
+      }
+    } else {
+      // If the desired state does not have the object field and the current state does, we
+      // should mark *all* properties for deletion by specifying an empty object.
+      //
+      // See: https://auth0.com/docs/users/metadata/manage-metadata-api#delete-user-metadata
+      if (currentAssetState[fieldName]) {
+        desiredAssetStateWithChanges[fieldName] = {};
+      }
+    }
+  }
+
+  return desiredAssetStateWithChanges;
+}
+
 export function calcChanges(assets, existing, identifiers = [ 'id', 'name' ], objectFields = []) {
   // Calculate the changes required between two sets of assets.
   const update = [];
@@ -114,7 +144,7 @@ export function calcChanges(assets, existing, identifiers = [ 'id', 'name' ], ob
             // value.
             ...(objectFields.length
               ? processChangedObjectFields(asset, found, objectFields)
-              : asset),
+              : asset)
           });
         }
       }
@@ -156,36 +186,6 @@ export function calcChanges(assets, existing, identifiers = [ 'id', 'name' ], ob
     conflicts,
     create
   };
-}
-
-function processChangedObjectFields(desiredAssetState, currentAssetState, objectFields = []) {
-  const desiredAssetStateWithChanges = { ...desiredAssetState };
-
-  for (const fieldName of objectFields) {
-    if (desiredAssetState[fieldName]) {
-      // Both the current and desired state have the object field. Here's where we need to map
-      // to the APIv2 protocol of setting `null` values for deleted fields.
-      // For new and modified properties of the object field, we can just pass them through to
-      // APIv2.
-      if (currentAssetState[fieldName]) {
-        for (const currentObjectFieldPropertyName of Object.keys(currentAssetState[fieldName])) {
-          if (desiredAssetState[fieldName][currentObjectFieldPropertyName] === undefined) {
-            desiredAssetStateWithChanges[fieldName][currentObjectFieldPropertyName] = null;
-          }
-        }
-      }
-    } else {
-      // If the desired state does not have the object field and the current state does, we
-      // should mark *all* properties for deletion by specifying an empty object.
-      //
-      // See: https://auth0.com/docs/users/metadata/manage-metadata-api#delete-user-metadata
-      if (currentAssetState[fieldName]) {
-        desiredAssetStateWithChanges[fieldName] = {};
-      }
-    }
-  }
-
-  return desiredAssetStateWithChanges;
 }
 
 export function stripFields(obj, fields) {

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -126,7 +126,7 @@ function processChangedObjectFields(handler, desiredAssetState, currentAssetStat
   return desiredAssetStateWithChanges;
 }
 
-export function calcChanges(assetType, assets, existing, identifiers = [ 'id', 'name' ], objectFields = [], allowDelete = false) {
+export function calcChanges(handler, assets, existing, identifiers = [ 'id', 'name' ], objectFields = [], allowDelete = false) {
   // Calculate the changes required between two sets of assets.
   const update = [];
   let del = [ ...existing ];
@@ -177,7 +177,7 @@ export function calcChanges(assetType, assets, existing, identifiers = [ 'id', '
             // properties must explicitly be marked for deletion by indicating a `null`
             // value.
             ...(objectFields.length
-              ? processChangedObjectFields(assetType, asset, found, objectFields, allowDelete)
+              ? processChangedObjectFields(handler, asset, found, objectFields, allowDelete)
               : asset)
           });
         }

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -64,14 +64,14 @@ export function dumpJSON(obj, spacing = 0) {
 
 /**
  * @template T
- * @param {typeof import('./auth0/handlers/default').default} assetType
+ * @param {typeof import('./auth0/handlers/default').default} handler
  * @param {T} desiredAssetState
  * @param {T} currentAssetState
  * @param {string[]} [objectFields=[]]
  * @param {boolean} [allowDelete=false]
  * @returns T
  */
-function processChangedObjectFields(assetType, desiredAssetState, currentAssetState, objectFields = [], allowDelete = false) {
+function processChangedObjectFields(handler, desiredAssetState, currentAssetState, objectFields = [], allowDelete = false) {
   const desiredAssetStateWithChanges = { ...desiredAssetState };
 
   // eslint-disable-next-line no-restricted-syntax
@@ -96,8 +96,8 @@ function processChangedObjectFields(assetType, desiredAssetState, currentAssetSt
             } else {
               log.warn(
                 `Detected that the ${fieldName} of the following ${
-                  assetType.name
-                } should be deleted. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config\n${assetType.objString(
+                  handler.name
+                } should be deleted. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config\n${handler.objString(
                   currentAssetState
                 )}`
               );
@@ -115,8 +115,8 @@ function processChangedObjectFields(assetType, desiredAssetState, currentAssetSt
       delete desiredAssetStateWithChanges[fieldName];
       log.warn(
         `Detected that the ${fieldName} of the following ${
-          assetType.name
-        } should be emptied. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config\n${assetType.objString(
+          handler.name
+        } should be emptied. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config\n${handler.objString(
           currentAssetState
         )}`
       );

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -108,11 +108,24 @@ describe('#clients handler', () => {
             expect(params.client_id).to.equal('client1');
             expect(data).to.be.an('object');
             expect(data.description).to.equal('new description');
+            expect(data.client_metadata).to.be.an('object');
+            expect(data.client_metadata.should_be_removed).to.equal(null);
+            expect(data.client_metadata.should_be_changed).to.equal('was_changed');
+            expect(data.client_metadata.should_be_added).to.equal('was_added');
+            expect(data.client_metadata.should_be_preserved).to.equal('should_be_preserved');
 
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { client_id: 'client1', name: 'someClient' } ]
+          getAll: () => [ {
+            client_id: 'client1',
+            name: 'someClient',
+            client_metadata: {
+              should_be_removed: 'should_be_removed',
+              should_be_changed: 'should_be_changed',
+              should_be_preserved: 'should_be_preserved'
+            }
+          } ]
         },
         pool
       };
@@ -120,7 +133,17 @@ describe('#clients handler', () => {
       const handler = new clients.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { clients: [ { name: 'someClient', description: 'new description' } ] } ]);
+      await stageFn.apply(handler, [ {
+        clients: [ {
+          name: 'someClient',
+          description: 'new description',
+          client_metadata: {
+            should_be_added: 'was_added',
+            should_be_changed: 'was_changed',
+            should_be_preserved: 'should_be_preserved'
+          }
+        } ]
+      } ]);
     });
 
     it('should delete client and create another one instead', async () => {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -108,23 +108,13 @@ describe('#clients handler', () => {
             expect(params.client_id).to.equal('client1');
             expect(data).to.be.an('object');
             expect(data.description).to.equal('new description');
-            expect(data.client_metadata).to.be.an('object');
-            expect(data.client_metadata.should_be_removed).to.equal(null);
-            expect(data.client_metadata.should_be_changed).to.equal('was_changed');
-            expect(data.client_metadata.should_be_added).to.equal('was_added');
-            expect(data.client_metadata.should_be_preserved).to.equal('should_be_preserved');
 
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
           getAll: () => [ {
             client_id: 'client1',
-            name: 'someClient',
-            client_metadata: {
-              should_be_removed: 'should_be_removed',
-              should_be_changed: 'should_be_changed',
-              should_be_preserved: 'should_be_preserved'
-            }
+            name: 'someClient'
           } ]
         },
         pool
@@ -136,12 +126,7 @@ describe('#clients handler', () => {
       await stageFn.apply(handler, [ {
         clients: [ {
           name: 'someClient',
-          description: 'new description',
-          client_metadata: {
-            should_be_added: 'was_added',
-            should_be_changed: 'was_changed',
-            should_be_preserved: 'should_be_preserved'
-          }
+          description: 'new description'
         } ]
       } ]);
     });


### PR DESCRIPTION
## Description

Fixes an inconsistency between how we calculate changes on deep metadata-like objects and with how APIv2 expects such changes to be expressed when a property is deleted.