### PR TITLE
Node <14 compatibility fix with getting access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.1] - 2021-09-21
+### Fixed
+- Error when authenticating with AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET with Node.js prior to v14
+
 ## [7.3.0] - 2021-09-20
 ### Added
 - Allow set of AUTH0_AUDIENCE for custom domain [#379] (credit @AliBazzi)
@@ -385,7 +389,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#367]: https://github.com/auth0/auth0-deploy-cli/issues/367
 [#379]: https://github.com/auth0/auth0-deploy-cli/issues/379
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.0...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.1...HEAD
+[7.3.1]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.0...v7.3.1
 [7.3.0]: https://github.com/auth0/auth0-deploy-cli/compare/v7.2.1...v7.3.0
 [7.2.1]: https://github.com/auth0/auth0-deploy-cli/compare/v7.2.0...v7.2.1
 [7.2.0]: https://github.com/auth0/auth0-deploy-cli/compare/v7.1.1...v7.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth0-deploy-cli",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -43,7 +43,7 @@ export default async function(config) {
     });
 
     const clientCredentials = await authClient.clientCredentialsGrant({
-      audience: config.AUTH0_AUDIENCE ?? `https://${config.AUTH0_DOMAIN}/api/v2/`
+      audience: config.AUTH0_AUDIENCE ? config.AUTH0_AUDIENCE : `https://${config.AUTH0_DOMAIN}/api/v2/`
     });
     accessToken = clientCredentials.access_token;
   }


### PR DESCRIPTION
## ✏️ Changes

#379 introduced incompatibility with Node.js prior to v14 as the Nullish coalescing operator (??) is not supported.
This PR fixes the issue and bumps to v7.3.1

## 🔗 References

n/a

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
