### PR TITLE
Skip org deployment when org entity is not present in yaml

### DIFF
--- a/src/context/yaml/handlers/organizations.js
+++ b/src/context/yaml/handlers/organizations.js
@@ -1,10 +1,8 @@
 async function parse(context) {
   const { organizations } = context.assets;
 
-  if (!organizations) return {};
-
   return {
-    organizations: organizations || []
+    organizations: organizations
   };
 }
 

--- a/src/context/yaml/handlers/organizations.js
+++ b/src/context/yaml/handlers/organizations.js
@@ -1,6 +1,8 @@
 async function parse(context) {
   const { organizations } = context.assets;
 
+  if (!organizations) return {};
+
   return {
     organizations: organizations || []
   };

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -26,6 +26,7 @@ describe('#YAML context validation', () => {
     expect(context.assets.clientGrants).to.deep.equal(undefined);
     expect(context.assets.connections).to.deep.equal(undefined);
     expect(context.assets.rulesConfigs).to.deep.equal(undefined);
+    expect(context.assets.organizations).to.deep.equal(undefined);
   });
 
   it('should load excludes', async () => {


### PR DESCRIPTION
## ✏️ Changes

When `organizations` isn't present in the yaml, returns `undefined` instead of `[]` so the deployment for organizations doesn't trigger.

## 🔗 References

#387 

## 🎯 Testing

✅ This change has unit test coverage
