### PR TITLE
Fall back to hook id when no name set

### DIFF
--- a/src/tools/auth0/handlers/hooks.js
+++ b/src/tools/auth0/handlers/hooks.js
@@ -150,7 +150,7 @@ export default class HooksHandler extends DefaultHandler {
       // hooks.getAll does not return code and secrets, we have to fetch hooks one-by-one
       this.existing = await Promise.all(hooks.map((hook) => this.client.hooks.get({ id: hook.id })
         .then((hookWithCode) => this.client.hooks.getSecrets({ id: hook.id })
-          .then((secrets) => ({ ...hookWithCode, secrets })))));
+          .then((secrets) => ({ name: hook.id, ...hookWithCode, secrets })))));
 
       return this.existing;
     } catch (err) {


### PR DESCRIPTION
## ✏️ Changes

Fixes an issue where a tenant having an old hook without the `hook-name` metadata property would be unable to use `deploy-cli`'s directory dump mode. It seems that between the API2 hooks facade and the CLI there's an impedence mismatch such that no `.name` property will come back. To work around this, we default the internal name representation to the hook's `.id`.

## 🔗 References

https://auth0team.atlassian.net/browse/DXEX-1940

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

✅ This change has been tested for performance
