### PR TITLE
[ESD-17871] bind client.connections to get scope with class methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
-        "auth0": "^2.37.0",
+        "auth0": "^2.39.0",
         "dot-prop": "^5.2.0",
         "fs-extra": "^7.0.0",
         "global-agent": "^2.1.12",
@@ -2238,18 +2238,28 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.39.0.tgz",
+      "integrity": "sha512-jWYnjbduQATY2QXNsrkz4ciInG7tDORUOCQz6bfww3ZQWlY1Itwe9y6vzWtfQbGEAK4D8psLnDnRLSdglBSWIA==",
       "dependencies": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.24.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/auth0/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/axios": {
@@ -3729,11 +3739,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -10023,18 +10028,27 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.39.0.tgz",
+      "integrity": "sha512-jWYnjbduQATY2QXNsrkz4ciInG7tDORUOCQz6bfww3ZQWlY1Itwe9y6vzWtfQbGEAK4D8psLnDnRLSdglBSWIA==",
       "requires": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.24.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
       }
     },
     "axios": {
@@ -11330,11 +11344,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/auth0/auth0-deploy-cli#readme",
   "dependencies": {
     "ajv": "^6.12.6",
-    "auth0": "^2.37.0",
+    "auth0": "^2.39.0",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/src/tools/auth0/handlers/databases.js
+++ b/src/tools/auth0/handlers/databases.js
@@ -48,8 +48,7 @@ export default class DatabaseHandler extends DefaultHandler {
           return this.client.connections.update(params, payload);
         });
     }
-
-    return Reflect.get(this.client.connections, fn, this.client.connections);
+    return Reflect.get(this.client.connections, fn).bind(this.client.connections);
   }
 
   async getType() {

--- a/src/tools/auth0/handlers/databases.js
+++ b/src/tools/auth0/handlers/databases.js
@@ -48,6 +48,7 @@ export default class DatabaseHandler extends DefaultHandler {
           return this.client.connections.update(params, payload);
         });
     }
+
     return Reflect.get(this.client.connections, fn).bind(this.client.connections);
   }
 

--- a/test/tools/auth0/handlers/databases.tests.js
+++ b/test/tools/auth0/handlers/databases.tests.js
@@ -53,7 +53,8 @@ describe('#databases handler', () => {
     it('should create database', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data) {
+            expect(this).not.to.be.an('undefined');
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someDatabase');
             return Promise.resolve(data);


### PR DESCRIPTION
## ✏️ Changes

A change went in to `node-auth0@2.38.0` where we refactored the way we defined the various services methods, changing them from being defined using [wrapPropertyMethod](https://github.com/auth0/node-auth0/blob/fc3d2060af577d108c022d0863b072620e5b1829/src/utils.js#L50-L64) to regular class methods.

`wrapPropertyMethod` used to create getters and this code in `auth0-deploy-cli` relied on the method being defined as a getter rather than a class method and lost it's context with the latest version of node-auth0 https://github.com/auth0/auth0-deploy-cli/blob/6a7913d7409561878dc8c7dc7f6afa1e40efbccc/src/tools/auth0/handlers/databases.js#L52

Because the receiver in `Reflect.get(target, propertyKey, receiver)` is the value of `this` provided for the call to target if a getter is encountered (_not_ when a class method is encountered).

eg. 

```js
const oldAuth0 = Object.defineProperty(new function() {}, 'create', {
  get: function() { return () => console.log('this ->', this) }
})
const newAuth0 = new class { create() { console.log('this ->', this) } }

Reflect.get(oldAuth0, 'create', 'foo')()
// this -> 'foo'

Reflect.get(newAuth0, 'create', 'foo')()
// this -> undefined
```

Changing how we bind the method to [match the base getClientFN](https://github.com/auth0/auth0-deploy-cli/blob/99fe955c31e6d99c88c64a3992c610b9b7113395/src/tools/auth0/handlers/default.js#L44) fixes the issue.

Apologies for the disruption - we can't support this behaviour on `node-auth0` and we think it's unique enough to fix here.

## 🔗 References

Fixes https://auth0team.atlassian.net/browse/ESD-17871

## 🎯 Testing

> Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why.

Make sure you have a dependency on node-auth0 >= 2.38.0
Import a yml like the one described in [ESD-17871](https://auth0team.atlassian.net/browse/ESD-17871)

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
