### PR TITLE
ESD-17871: Pinning Auth0 Node SDK to 2.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix errors caused by incompatibilities introduced by new versions of Auth0 SDK [#406]
 
 ## [7.3.5] - 2022-01-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.3.6] - 2022-02-02
 ### Fixed
 - Fix errors caused by incompatibilities introduced by new versions of Auth0 SDK [#406]
 
@@ -412,8 +414,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#400]: https://github.com/auth0/auth0-deploy-cli/issues/400
 [#401]: https://github.com/auth0/auth0-deploy-cli/issues/401
 [#403]: https://github.com/auth0/auth0-deploy-cli/issues/403
+[#406]: https://github.com/auth0/auth0-deploy-cli/issues/406
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.5...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.6...HEAD
+[7.3.6]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.5...v7.3.6
 [7.3.5]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.4...v7.3.5
 [7.3.4]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.3...v7.3.4
 [7.3.3]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.2...v7.3.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
-        "auth0": "^2.37.0",
+        "auth0": "2.37.0",
         "dot-prop": "^5.2.0",
         "fs-extra": "^7.0.0",
         "global-agent": "^2.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth0-deploy-cli",
-      "version": "7.3.5",
+      "version": "7.3.6",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/auth0/auth0-deploy-cli#readme",
   "dependencies": {
     "ajv": "^6.12.6",
-    "auth0": "^2.37.0",
+    "auth0": "2.37.0",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
## ✏️ Changes

Pinning Node SDK to version 2.37.0. Versions after that include a refactor to the implementation of resource class implementations that this repo depends on. This can be seen in [ESD-17871](https://auth0team.atlassian.net/browse/ESD-17871) where users are unable to create database connections with fresh installs that pull later version of the Node SDK. 

@adamjmcgrath has already submitted a fix with for this specific ESD ticket with #405 , but it is likely that other bugs have been introduced. So for that reason, I recommend pinning the version as a safer and more wholistic fix until we can better understand the scope.

**This is very much a temporary fix.** A more longterm solution needs to be investigated with @shushen and @TwelveNights  and @adamjmcgrath to better understand the underlying abstractions that are at the core of ESD-17871. 

## 🔗 References

- [ESD-17871](https://auth0team.atlassian.net/browse/ESD-17871) Main ESD ticket
- [ESD-17791](https://auth0team.atlassian.net/browse/ESD-17791) Related ESD ticket


## 🎯 Testing

Testing was performed manually by applying test configuration provided by customer and changing the versions of the dependency back and forth. 

If any automated tests can be applied for this scenario, please advise!

✅🚫 This change has unit test coverage

✅🚫 This change has integration test coverage

✅🚫 This change has been tested for performance
