### PR TITLE
feat: expose error on actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.7] - 2022-02-03
+### Fixed
+- Expose errors that may be silently missed in Actions [#408]
+
 ## [7.3.6] - 2022-02-02
 ### Fixed
 - Fix errors caused by incompatibilities introduced by new versions of Auth0 SDK [#406]
@@ -415,8 +419,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#401]: https://github.com/auth0/auth0-deploy-cli/issues/401
 [#403]: https://github.com/auth0/auth0-deploy-cli/issues/403
 [#406]: https://github.com/auth0/auth0-deploy-cli/issues/406
+[#408]: https://github.com/auth0/auth0-deploy-cli/issues/408
 
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.6...HEAD
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.7...HEAD
+[7.3.7]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.6...v7.3.7
 [7.3.6]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.5...v7.3.6
 [7.3.5]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.4...v7.3.5
 [7.3.4]: https://github.com/auth0/auth0-deploy-cli/compare/v7.3.3...v7.3.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth0-deploy-cli",
-      "version": "7.3.6",
+      "version": "7.3.7",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {

--- a/src/tools/auth0/handlers/actions.js
+++ b/src/tools/auth0/handlers/actions.js
@@ -140,6 +140,8 @@ export default class ActionHandler extends DefaultHandler {
         await sleep(1000);
         action.retry_count += 1;
         await this.deployAction(action);
+      } else {
+        throw err;
       }
     }
   }


### PR DESCRIPTION
## ✏️ Changes

If there's an exception during the actions deploy stage, we do not expose the error. Instead, execution will continue (and perhaps fail in later steps). This pull request propagates any errors we may encounter in the deploy stage.

## 🔗 References

Work to support https://auth0team.atlassian.net/browse/ESD-17919

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
