### PR TITLE
ESD-17871: Binding function context of database methods after losing with SDK update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
-        "auth0": "2.37.0",
+        "auth0": "^2.40.0",
         "dot-prop": "^5.2.0",
         "fs-extra": "^7.0.0",
         "global-agent": "^2.1.12",
@@ -2238,18 +2238,28 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.40.0.tgz",
+      "integrity": "sha512-xrnyLpKw+BP7u6OqHMYcSkLA2yDbTDefMeqArpwAU8UG5MPkhsTFQGPMXLzxHr2M5mV+elJOQ6w1acSY/2uRbA==",
       "dependencies": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.25.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/auth0/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/axios": {
@@ -3729,11 +3739,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -10023,18 +10028,27 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.40.0.tgz",
+      "integrity": "sha512-xrnyLpKw+BP7u6OqHMYcSkLA2yDbTDefMeqArpwAU8UG5MPkhsTFQGPMXLzxHr2M5mV+elJOQ6w1acSY/2uRbA==",
       "requires": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.25.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        }
       }
     },
     "axios": {
@@ -11330,11 +11344,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/auth0/auth0-deploy-cli#readme",
   "dependencies": {
     "ajv": "^6.12.6",
-    "auth0": "2.37.0",
+    "auth0": "^2.40.0",
     "dot-prop": "^5.2.0",
     "fs-extra": "^7.0.0",
     "global-agent": "^2.1.12",

--- a/src/tools/auth0/handlers/databases.js
+++ b/src/tools/auth0/handlers/databases.js
@@ -49,7 +49,7 @@ export default class DatabaseHandler extends DefaultHandler {
         });
     }
 
-    return Reflect.get(this.client.connections, fn, this.client.connections);
+    return this.client.connections[fn].bind(this.client.connections)
   }
 
   async getType() {

--- a/src/tools/auth0/handlers/databases.js
+++ b/src/tools/auth0/handlers/databases.js
@@ -49,7 +49,7 @@ export default class DatabaseHandler extends DefaultHandler {
         });
     }
 
-    return this.client.connections[fn].bind(this.client.connections)
+    return this.client.connections[fn].bind(this.client.connections);
   }
 
   async getType() {

--- a/src/tools/auth0/handlers/default.js
+++ b/src/tools/auth0/handlers/default.js
@@ -40,8 +40,8 @@ export default class DefaultHandler {
 
   getClientFN(fn) {
     if (typeof fn === 'string') {
-      const client = Reflect.get(this.client, this.type);
-      return Reflect.get(client, fn).bind(client);
+      const client = this.client[this.type]
+      return client[fn].bind(client);
     }
     return fn;
   }

--- a/src/tools/auth0/handlers/default.js
+++ b/src/tools/auth0/handlers/default.js
@@ -40,7 +40,7 @@ export default class DefaultHandler {
 
   getClientFN(fn) {
     if (typeof fn === 'string') {
-      const client = this.client[this.type]
+      const client = this.client[this.type];
       return client[fn].bind(client);
     }
     return fn;

--- a/test/tools/auth0/handlers/actions.tests.js
+++ b/test/tools/auth0/handlers/actions.tests.js
@@ -127,8 +127,8 @@ describe('#actions handler', () => {
             expect(params.id).to.equal(actionId);
             return Promise.resolve({ ...action, id: actionId });
           },
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('action-test');
             expect(data.supported_triggers[0].id).to.equal('post-login');

--- a/test/tools/auth0/handlers/actions.tests.js
+++ b/test/tools/auth0/handlers/actions.tests.js
@@ -127,7 +127,8 @@ describe('#actions handler', () => {
             expect(params.id).to.equal(actionId);
             return Promise.resolve({ ...action, id: actionId });
           },
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('action-test');
             expect(data.supported_triggers[0].id).to.equal('post-login');

--- a/test/tools/auth0/handlers/clientGrants.tests.js
+++ b/test/tools/auth0/handlers/clientGrants.tests.js
@@ -11,7 +11,7 @@ const pool = {
 };
 
 describe('#clientGrants handler', () => {
-  const config = function(key) {
+  const config = function (key) {
     return config.data && config.data[key];
   };
 
@@ -34,7 +34,7 @@ describe('#clientGrants handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [ { clientGrants: data } ]);
+        await stageFn.apply(handler, [{ clientGrants: data }]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -50,7 +50,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
   });
 
@@ -58,7 +58,8 @@ describe('#clientGrants handler', () => {
     it('should create client grants', async () => {
       const auth0 = {
         clientGrants: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             return Promise.resolve(data);
@@ -81,7 +82,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
 
     it('should get client grants', async () => {
@@ -96,7 +97,7 @@ describe('#clientGrants handler', () => {
       };
       const auth0 = {
         clientGrants: {
-          getAll: () => [ clientGrant ]
+          getAll: () => [clientGrant]
         },
         clients: {
           getAll: () => [
@@ -108,13 +109,14 @@ describe('#clientGrants handler', () => {
 
       const handler = new clientGrants.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([ clientGrant ]);
+      expect(data).to.deep.equal([clientGrant]);
     });
 
     it('should convert client_name to client_id', async () => {
       const auth0 = {
         clientGrants: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             expect(data.client_id).to.equal('client_id');
@@ -125,7 +127,7 @@ describe('#clientGrants handler', () => {
           getAll: () => []
         },
         clients: {
-          getAll: () => [ { client_id: 'client_id', name: 'client_name' } ]
+          getAll: () => [{ client_id: 'client_id', name: 'client_name' }]
         },
         pool
       };
@@ -139,18 +141,20 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
 
     it('should update client grant', async () => {
       const auth0 = {
         clientGrants: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('object');
             expect(data).to.equal({});
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
             expect(data).to.be.an('object');
@@ -160,7 +164,7 @@ describe('#clientGrants handler', () => {
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience' } ]
+          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience' }]
         },
         clients: {
           getAll: () => []
@@ -174,30 +178,32 @@ describe('#clientGrants handler', () => {
         {
           client_id: 'client1',
           audience: 'audience',
-          scope: [ 'read:messages' ]
+          scope: ['read:messages']
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
 
     it('should delete client grant and create another one instead', async () => {
       const auth0 = {
         clientGrants: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             expect(data.client_id).to.equal('client2');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
+          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
         },
         clients: {
           getAll: () => []
@@ -215,7 +221,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
 
     it('should not delete nor create client grant for own client', async () => {
@@ -231,12 +237,13 @@ describe('#clientGrants handler', () => {
 
             return Promise.resolve([]);
           },
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'id', client_id: 'client_id', audience: 'audience' } ]
+          getAll: () => [{ id: 'id', client_id: 'client_id', audience: 'audience' }]
         },
         clients: {
           getAll: () => []
@@ -254,7 +261,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { clientGrants: data } ]);
+      await stageFn.apply(handler, [{ clientGrants: data }]);
     });
 
     it('should delete all client grants', async () => {
@@ -263,13 +270,14 @@ describe('#clientGrants handler', () => {
         clientGrants: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
+          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
         },
         clients: {
           getAll: () => []
@@ -280,7 +288,7 @@ describe('#clientGrants handler', () => {
       const handler = new clientGrants.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { clientGrants: [] } ]);
+      await stageFn.apply(handler, [{ clientGrants: [] }]);
       expect(removed).to.equal(true);
     });
 
@@ -293,12 +301,13 @@ describe('#clientGrants handler', () => {
         clientGrants: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
+          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
         },
         clients: {
           getAll: () => []
@@ -309,7 +318,7 @@ describe('#clientGrants handler', () => {
       const handler = new clientGrants.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { clientGrants: [] } ]);
+      await stageFn.apply(handler, [{ clientGrants: [] }]);
     });
 
     it('should not touch client grants of excluded clients', async () => {
@@ -329,7 +338,8 @@ describe('#clientGrants handler', () => {
 
             return Promise.resolve([]);
           },
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
@@ -360,10 +370,10 @@ describe('#clientGrants handler', () => {
             audience: 'audience3'
           }
         ],
-        exclude: { clients: [ 'client_delete', 'client_update', 'client_create' ] }
+        exclude: { clients: ['client_delete', 'client_update', 'client_create'] }
       };
 
-      await stageFn.apply(handler, [ assets ]);
+      await stageFn.apply(handler, [assets]);
     });
   });
   it('should not delete client grants of excluded clients with multiple instances', async () => {
@@ -384,7 +394,8 @@ describe('#clientGrants handler', () => {
 
           return Promise.resolve([]);
         },
-        delete: (params) => {
+        delete: function(params){
+            expect(this).to.not.be.undefined;
           expect(params).to.be.an('undefined');
 
           return Promise.resolve([]);
@@ -470,9 +481,9 @@ describe('#clientGrants handler', () => {
           audience: 'https://example.com'
         }
       ],
-      exclude: { clients: [ 'foo_client' ] }
+      exclude: { clients: ['foo_client'] }
     };
 
-    await stageFn.apply(handler, [ assets ]);
+    await stageFn.apply(handler, [assets]);
   });
 });

--- a/test/tools/auth0/handlers/clientGrants.tests.js
+++ b/test/tools/auth0/handlers/clientGrants.tests.js
@@ -11,7 +11,7 @@ const pool = {
 };
 
 describe('#clientGrants handler', () => {
-  const config = function (key) {
+  const config = function(key) {
     return config.data && config.data[key];
   };
 
@@ -34,7 +34,7 @@ describe('#clientGrants handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ clientGrants: data }]);
+        await stageFn.apply(handler, [ { clientGrants: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -50,7 +50,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
   });
 
@@ -58,8 +58,8 @@ describe('#clientGrants handler', () => {
     it('should create client grants', async () => {
       const auth0 = {
         clientGrants: {
-          create: function (data) {
-            expect(this).to.not.be.undefined;
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             return Promise.resolve(data);
@@ -82,7 +82,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
     it('should get client grants', async () => {
@@ -97,7 +97,7 @@ describe('#clientGrants handler', () => {
       };
       const auth0 = {
         clientGrants: {
-          getAll: () => [clientGrant]
+          getAll: () => [ clientGrant ]
         },
         clients: {
           getAll: () => [
@@ -109,14 +109,14 @@ describe('#clientGrants handler', () => {
 
       const handler = new clientGrants.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([clientGrant]);
+      expect(data).to.deep.equal([ clientGrant ]);
     });
 
     it('should convert client_name to client_id', async () => {
       const auth0 = {
         clientGrants: {
-          create: function (data) {
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             expect(data.client_id).to.equal('client_id');
@@ -127,7 +127,7 @@ describe('#clientGrants handler', () => {
           getAll: () => []
         },
         clients: {
-          getAll: () => [{ client_id: 'client_id', name: 'client_name' }]
+          getAll: () => [ { client_id: 'client_id', name: 'client_name' } ]
         },
         pool
       };
@@ -141,20 +141,20 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
     it('should update client grant', async () => {
       const auth0 = {
         clientGrants: {
-          create: function (data) {
-            expect(this).to.not.be.undefined;
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data).to.equal({});
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
             expect(data).to.be.an('object');
@@ -164,7 +164,7 @@ describe('#clientGrants handler', () => {
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience' }]
+          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience' } ]
         },
         clients: {
           getAll: () => []
@@ -178,32 +178,32 @@ describe('#clientGrants handler', () => {
         {
           client_id: 'client1',
           audience: 'audience',
-          scope: ['read:messages']
+          scope: [ 'read:messages' ]
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
     it('should delete client grant and create another one instead', async () => {
       const auth0 = {
         clientGrants: {
-          create: function (data) {
-            expect(this).to.not.be.undefined;
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClientGrant');
             expect(data.client_id).to.equal('client2');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
+          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
         },
         clients: {
           getAll: () => []
@@ -221,7 +221,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
     it('should not delete nor create client grant for own client', async () => {
@@ -237,13 +237,13 @@ describe('#clientGrants handler', () => {
 
             return Promise.resolve([]);
           },
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'id', client_id: 'client_id', audience: 'audience' }]
+          getAll: () => [ { id: 'id', client_id: 'client_id', audience: 'audience' } ]
         },
         clients: {
           getAll: () => []
@@ -261,7 +261,7 @@ describe('#clientGrants handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ clientGrants: data }]);
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
     it('should delete all client grants', async () => {
@@ -270,14 +270,14 @@ describe('#clientGrants handler', () => {
         clientGrants: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('cg1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
+          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
         },
         clients: {
           getAll: () => []
@@ -288,7 +288,7 @@ describe('#clientGrants handler', () => {
       const handler = new clientGrants.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ clientGrants: [] }]);
+      await stageFn.apply(handler, [ { clientGrants: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -301,13 +301,13 @@ describe('#clientGrants handler', () => {
         clientGrants: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'cg1', client_id: 'client1', audience: 'audience1' }]
+          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
         },
         clients: {
           getAll: () => []
@@ -318,7 +318,7 @@ describe('#clientGrants handler', () => {
       const handler = new clientGrants.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ clientGrants: [] }]);
+      await stageFn.apply(handler, [ { clientGrants: [] } ]);
     });
 
     it('should not touch client grants of excluded clients', async () => {
@@ -338,8 +338,8 @@ describe('#clientGrants handler', () => {
 
             return Promise.resolve([]);
           },
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
 
             return Promise.resolve([]);
@@ -370,10 +370,10 @@ describe('#clientGrants handler', () => {
             audience: 'audience3'
           }
         ],
-        exclude: { clients: ['client_delete', 'client_update', 'client_create'] }
+        exclude: { clients: [ 'client_delete', 'client_update', 'client_create' ] }
       };
 
-      await stageFn.apply(handler, [assets]);
+      await stageFn.apply(handler, [ assets ]);
     });
   });
   it('should not delete client grants of excluded clients with multiple instances', async () => {
@@ -394,8 +394,8 @@ describe('#clientGrants handler', () => {
 
           return Promise.resolve([]);
         },
-        delete: function(params){
-            expect(this).to.not.be.undefined;
+        delete: function(params) {
+          (() => expect(this).to.not.be.undefined)();
           expect(params).to.be.an('undefined');
 
           return Promise.resolve([]);
@@ -481,9 +481,9 @@ describe('#clientGrants handler', () => {
           audience: 'https://example.com'
         }
       ],
-      exclude: { clients: ['foo_client'] }
+      exclude: { clients: [ 'foo_client' ] }
     };
 
-    await stageFn.apply(handler, [assets]);
+    await stageFn.apply(handler, [ assets ]);
   });
 });

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -58,8 +58,8 @@ describe('#clients handler', () => {
     it('should create client', async () => {
       const auth0 = {
         clients: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClient');
             return Promise.resolve(data);
@@ -99,14 +99,14 @@ describe('#clients handler', () => {
     it('should update client', async () => {
       const auth0 = {
         clients: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('array');
             expect(data.length).to.equal(0);
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             expect(data).to.be.an('object');
@@ -137,15 +137,15 @@ describe('#clients handler', () => {
     it('should delete client and create another one instead', async () => {
       const auth0 = {
         clients: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClient');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             return Promise.resolve([]);
@@ -168,8 +168,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             removed = true;
@@ -193,8 +193,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -221,8 +221,8 @@ describe('#clients handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -263,8 +263,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -58,7 +58,8 @@ describe('#clients handler', () => {
     it('should create client', async () => {
       const auth0 = {
         clients: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClient');
             return Promise.resolve(data);
@@ -98,12 +99,14 @@ describe('#clients handler', () => {
     it('should update client', async () => {
       const auth0 = {
         clients: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('array');
             expect(data.length).to.equal(0);
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             expect(data).to.be.an('object');
@@ -134,13 +137,15 @@ describe('#clients handler', () => {
     it('should delete client and create another one instead', async () => {
       const auth0 = {
         clients: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someClient');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             return Promise.resolve([]);
@@ -163,7 +168,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.client_id).to.equal('client1');
             removed = true;
@@ -187,7 +193,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -214,7 +221,8 @@ describe('#clients handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -255,7 +263,8 @@ describe('#clients handler', () => {
         clients: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -58,7 +58,8 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
@@ -105,11 +106,13 @@ describe('#connections handler', () => {
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -147,7 +150,8 @@ describe('#connections handler', () => {
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.deep.equal({
               enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
@@ -163,7 +167,8 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -231,7 +236,8 @@ describe('#connections handler', () => {
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.deep.equal({
               enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
@@ -247,7 +253,8 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -317,11 +324,13 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -365,13 +374,15 @@ describe('#connections handler', () => {
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
@@ -403,7 +414,8 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
@@ -428,9 +440,13 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: (data) => Promise.resolve(data),
+          create: function(data){
+            expect(this).to.not.be.undefined;
+            return Promise.resolve(data) 
+          },
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -462,7 +478,8 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -495,7 +512,8 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: (params) => {
+          delete: function(params){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -58,8 +58,8 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
@@ -106,13 +106,13 @@ describe('#connections handler', () => {
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -150,8 +150,8 @@ describe('#connections handler', () => {
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
               enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
@@ -167,8 +167,8 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -236,8 +236,8 @@ describe('#connections handler', () => {
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
               enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
@@ -253,8 +253,8 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -324,13 +324,13 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -374,15 +374,15 @@ describe('#connections handler', () => {
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
@@ -414,8 +414,8 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
@@ -440,13 +440,13 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined;
-            return Promise.resolve(data) 
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
+            return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -478,8 +478,8 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -512,8 +512,8 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },

--- a/test/tools/auth0/handlers/databases.tests.js
+++ b/test/tools/auth0/handlers/databases.tests.js
@@ -11,7 +11,7 @@ const pool = {
 };
 
 describe('#databases handler', () => {
-  const config = function (key) {
+  const config = function(key) {
     return config.data && config.data[key];
   };
 
@@ -34,7 +34,7 @@ describe('#databases handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ databases: data }]);
+        await stageFn.apply(handler, [ { databases: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -45,7 +45,7 @@ describe('#databases handler', () => {
       const handler = new databases.default({ client: {}, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
 
-      await stageFn.apply(handler, [{ databases: [{ name: 'someDatabase' }] }]);
+      await stageFn.apply(handler, [ { databases: [ { name: 'someDatabase' } ] } ]);
     });
   });
 
@@ -53,8 +53,8 @@ describe('#databases handler', () => {
     it('should create database', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someDatabase');
             return Promise.resolve(data);
@@ -72,26 +72,26 @@ describe('#databases handler', () => {
       const handler = new databases.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ databases: [{ name: 'someDatabase' }] }]);
+      await stageFn.apply(handler, [ { databases: [ { name: 'someDatabase' } ] } ]);
     });
 
     it('should get databases', async () => {
       const clientId = 'rFeR6vyzQcDEgSUsASPeF4tXr3xbZhxE';
       const auth0 = {
         connections: {
-          getAll: function () {
-            expect(this).to.not.be.undefined
+          getAll: function() {
+            (() => expect(this).to.not.be.undefined)();
             return [
-              { strategy: 'auth0', name: 'db', enabled_clients: [clientId] }
-            ]
+              { strategy: 'auth0', name: 'db', enabled_clients: [ clientId ] }
+            ];
           }
         },
         clients: {
-          getAll: function () {
-            expect(this).to.not.be.undefined
+          getAll: function() {
+            (() => expect(this).to.not.be.undefined)();
             return [
               { name: 'test client', client_id: clientId }
-            ]
+            ];
           }
         },
         pool
@@ -99,39 +99,39 @@ describe('#databases handler', () => {
 
       const handler = new databases.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([{ strategy: 'auth0', name: 'db', enabled_clients: [clientId] }]);
+      expect(data).to.deep.equal([ { strategy: 'auth0', name: 'db', enabled_clients: [ clientId ] } ]);
     });
 
     it('should update database', async () => {
       const auth0 = {
         connections: {
-          get: function (params) {
-            expect(this).to.not.be.undefined
+          get: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             return Promise.resolve({ options: { someOldOption: true } });
           },
-          create: function (data) {
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
-            expect(this).to.not.be.undefined
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: { passwordPolicy: 'testPolicy', someOldOption: true }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ name: 'someDatabase', id: 'con1', strategy: 'auth0' }]
+          getAll: () => [ { name: 'someDatabase', id: 'con1', strategy: 'auth0' } ]
         },
         clients: {
-          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -143,11 +143,11 @@ describe('#databases handler', () => {
           name: 'someDatabase',
           strategy: 'auth0',
           options: { passwordPolicy: 'testPolicy' },
-          enabled_clients: ['client1']
+          enabled_clients: [ 'client1' ]
         }
       ];
 
-      await stageFn.apply(handler, [{ databases: data }]);
+      await stageFn.apply(handler, [ { databases: data } ]);
     });
 
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -160,26 +160,26 @@ describe('#databases handler', () => {
             expect(params.id).to.equal('con1');
             return Promise.resolve({ options: { someOldOption: true } });
           },
-          create: function(data){
-            expect(this).to.not.be.undefined;
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['client1-id', 'excluded-one-id'],
+              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
               options: { passwordPolicy: 'testPolicy', someOldOption: true }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{
-            name: 'someDatabase', id: 'con1', strategy: 'auth0', enabled_clients: ['excluded-one-id']
-          }]
+          getAll: () => [ {
+            name: 'someDatabase', id: 'con1', strategy: 'auth0', enabled_clients: [ 'excluded-one-id' ]
+          } ]
         },
         clients: {
           getAll: () => [
@@ -198,11 +198,11 @@ describe('#databases handler', () => {
           name: 'someDatabase',
           strategy: 'auth0',
           options: { passwordPolicy: 'testPolicy' },
-          enabled_clients: ['client1', 'excluded-one', 'excluded-two']
+          enabled_clients: [ 'client1', 'excluded-one', 'excluded-two' ]
         }
       ];
 
-      await stageFn.apply(handler, [{ databases: data, exclude: { clients: ['excluded-one', 'excluded-two'] } }]);
+      await stageFn.apply(handler, [ { databases: data, exclude: { clients: [ 'excluded-one', 'excluded-two' ] } } ]);
     });
 
     it('should update database without "enabled_clients" setting', async () => {
@@ -213,13 +213,13 @@ describe('#databases handler', () => {
             expect(params.id).to.equal('con1');
             return Promise.resolve({});
           },
-          create: function(data){
-            expect(this).to.not.be.undefined;
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params, data){
-            expect(this).to.not.be.undefined
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
@@ -229,10 +229,10 @@ describe('#databases handler', () => {
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ name: 'someDatabase', id: 'con1', strategy: 'auth0' }]
+          getAll: () => [ { name: 'someDatabase', id: 'con1', strategy: 'auth0' } ]
         },
         clients: {
-          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -247,27 +247,27 @@ describe('#databases handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ databases: data }]);
+      await stageFn.apply(handler, [ { databases: data } ]);
     });
 
     it('should delete database and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someDatabase');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'auth0' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'auth0' } ]
         },
         clients: {
           getAll: () => []
@@ -284,7 +284,7 @@ describe('#databases handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ databases: data }]);
+      await stageFn.apply(handler, [ { databases: data } ]);
     });
 
     it('should delete all databases', async () => {
@@ -294,13 +294,13 @@ describe('#databases handler', () => {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
           delete: function(params) {
-            expect(this).to.not.be.undefined;
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'auth0' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'auth0' } ]
         },
         clients: {
           getAll: () => []
@@ -311,7 +311,7 @@ describe('#databases handler', () => {
       const handler = new databases.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ databases: [] }]);
+      await stageFn.apply(handler, [ { databases: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -321,12 +321,12 @@ describe('#databases handler', () => {
         connections: {
           create: (data) => Promise.resolve(data),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'auth0' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'auth0' } ]
         },
         clients: {
           getAll: () => []
@@ -343,7 +343,7 @@ describe('#databases handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ databases: data }]);
+      await stageFn.apply(handler, [ { databases: data } ]);
     });
 
     it('should not remove databases if run by extension', async () => {
@@ -354,12 +354,12 @@ describe('#databases handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'auth0' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'auth0' } ]
         },
         clients: {
           getAll: () => []
@@ -370,7 +370,7 @@ describe('#databases handler', () => {
       const handler = new databases.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ databases: [] }]);
+      await stageFn.apply(handler, [ { databases: [] } ]);
     });
 
     it('should not remove/create/update excluded connections', async () => {
@@ -388,8 +388,8 @@ describe('#databases handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function(params){
-            expect(this).to.not.be.undefined;
+          delete: function(params) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
@@ -408,12 +408,12 @@ describe('#databases handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const assets = {
         exclude: {
-          databases: ['existing1', 'existing2', 'existing3']
+          databases: [ 'existing1', 'existing2', 'existing3' ]
         },
-        databases: [{ name: 'existing3', strategy: 'auth0' }]
+        databases: [ { name: 'existing3', strategy: 'auth0' } ]
       };
 
-      await stageFn.apply(handler, [assets]);
+      await stageFn.apply(handler, [ assets ]);
     });
   });
 });

--- a/test/tools/auth0/handlers/emailTemplates.tests.js
+++ b/test/tools/auth0/handlers/emailTemplates.tests.js
@@ -10,12 +10,12 @@ describe('#emailTemplates handler', () => {
     it('should update email template', async () => {
       const auth0 = {
         emailTemplates: {
-          create: function(data){
-            expect(this).to.not.be.undefined 
-            return Promise.resolve(data)
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
+            return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.name).to.equal('verify_email');
@@ -57,8 +57,8 @@ describe('#emailTemplates handler', () => {
     it('should create email template', async () => {
       const auth0 = {
         emailTemplates: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.template).to.equal('verify_email');
             expect(data.body).to.equal('body');

--- a/test/tools/auth0/handlers/emailTemplates.tests.js
+++ b/test/tools/auth0/handlers/emailTemplates.tests.js
@@ -10,8 +10,12 @@ describe('#emailTemplates handler', () => {
     it('should update email template', async () => {
       const auth0 = {
         emailTemplates: {
-          create: (data) => Promise.resolve(data),
-          update: (params, data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined 
+            return Promise.resolve(data)
+          },
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.name).to.equal('verify_email');
@@ -53,7 +57,8 @@ describe('#emailTemplates handler', () => {
     it('should create email template', async () => {
       const auth0 = {
         emailTemplates: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.template).to.equal('verify_email');
             expect(data.body).to.equal('body');

--- a/test/tools/auth0/handlers/hooks.tests.js
+++ b/test/tools/auth0/handlers/hooks.tests.js
@@ -161,8 +161,8 @@ describe('#hooks handler', () => {
             expect(params.id).to.equal(hookId);
             return Promise.resolve({ ...hook, id: hookId, secrets: undefined });
           },
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('Hook');
             expect(data.code).to.equal('code');
@@ -279,8 +279,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('1');
@@ -349,13 +349,13 @@ describe('#hooks handler', () => {
     it.skip('should not touch excluded hooks', async () => {
       const auth0 = {
         hooks: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(data){
-            expect(this).to.not.be.undefined;
+          update: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
@@ -418,8 +418,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal(hook.id);
@@ -493,8 +493,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal(hook.id);

--- a/test/tools/auth0/handlers/hooks.tests.js
+++ b/test/tools/auth0/handlers/hooks.tests.js
@@ -161,7 +161,8 @@ describe('#hooks handler', () => {
             expect(params.id).to.equal(hookId);
             return Promise.resolve({ ...hook, id: hookId, secrets: undefined });
           },
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('Hook');
             expect(data.code).to.equal('code');
@@ -278,7 +279,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('1');
@@ -347,11 +349,13 @@ describe('#hooks handler', () => {
     it.skip('should not touch excluded hooks', async () => {
       const auth0 = {
         hooks: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: (data) => {
+          update: function(data){
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
@@ -414,7 +418,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal(hook.id);
@@ -488,7 +493,8 @@ describe('#hooks handler', () => {
       const auth0 = {
         hooks: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal(hook.id);

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -115,8 +115,8 @@ describe('#organizations handler', () => {
     it('should create organization', async () => {
       const auth0 = {
         organizations: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('acme');
             expect(data.display_name).to.equal('Acme');
@@ -297,8 +297,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -369,8 +369,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -423,8 +423,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -472,8 +472,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -115,7 +115,8 @@ describe('#organizations handler', () => {
     it('should create organization', async () => {
       const auth0 = {
         organizations: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('acme');
             expect(data.display_name).to.equal('Acme');
@@ -296,7 +297,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -367,7 +369,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -420,7 +423,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');
@@ -468,7 +472,8 @@ describe('#organizations handler', () => {
       const auth0 = {
         organizations: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('123');
             expect(data.display_name).to.equal('Acme 2');

--- a/test/tools/auth0/handlers/pages.tests.js
+++ b/test/tools/auth0/handlers/pages.tests.js
@@ -6,7 +6,8 @@ describe('#pages handler', () => {
     it('should update login page', async () => {
       const auth0 = {
         clients: {
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.client_id).to.equal('global1');

--- a/test/tools/auth0/handlers/pages.tests.js
+++ b/test/tools/auth0/handlers/pages.tests.js
@@ -6,8 +6,8 @@ describe('#pages handler', () => {
     it('should update login page', async () => {
       const auth0 = {
         clients: {
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.client_id).to.equal('global1');

--- a/test/tools/auth0/handlers/resourceServers.tests.js
+++ b/test/tools/auth0/handlers/resourceServers.tests.js
@@ -11,7 +11,7 @@ const pool = {
 };
 
 describe('#resourceServers handler', () => {
-  const config = function(key) {
+  const config = function (key) {
     return config.data && config.data[key];
   };
 
@@ -33,7 +33,7 @@ describe('#resourceServers handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [ { resourceServers: data } ]);
+        await stageFn.apply(handler, [{ resourceServers: data }]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -50,7 +50,7 @@ describe('#resourceServers handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [ { resourceServers: data } ]);
+        await stageFn.apply(handler, [{ resourceServers: data }]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('You can not configure the \'Auth0 Management API\'.');
@@ -66,7 +66,7 @@ describe('#resourceServers handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { resourceServers: data } ]);
+      await stageFn.apply(handler, [{ resourceServers: data }]);
     });
   });
 
@@ -74,7 +74,8 @@ describe('#resourceServers handler', () => {
     it('should create resource server', async () => {
       const auth0 = {
         resourceServers: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someAPI');
             return Promise.resolve(data);
@@ -89,7 +90,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI' } ] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI' }] }]);
     });
 
     it('should get resource servers', async () => {
@@ -104,14 +105,14 @@ describe('#resourceServers handler', () => {
 
       const handler = new resourceServers.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([ { name: 'Company API', identifier: 'http://company.com/api' } ]);
+      expect(data).to.deep.equal([{ name: 'Company API', identifier: 'http://company.com/api' }]);
     });
 
     it('should update resource server', async () => {
       const auth0 = {
         resourceServers: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function (params, data) {
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('rs1');
@@ -119,7 +120,7 @@ describe('#resourceServers handler', () => {
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
         },
         pool
       };
@@ -127,26 +128,28 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI', identifier: 'some-api', scope: 'new:scope' }] }]);
     });
 
     it('should create new resource server with same name but different identifier', async () => {
       const auth0 = {
         resourceServers: {
-          create: (data) => {
+          create: function (data) {
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someAPI');
             expect(data.scope).to.equal('new:scope');
             expect(data.identifier).to.equal('another-api');
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function (params, data) {
+            expect(this).to.not.be.undefined;
             expect(params).to.be('undefined');
             expect(data).to.be('undefined');
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
         },
         pool
       };
@@ -154,7 +157,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'another-api', scope: 'new:scope' } ] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI', identifier: 'another-api', scope: 'new:scope' }] }]);
     });
 
     it('should remove resource server', async () => {
@@ -167,7 +170,7 @@ describe('#resourceServers handler', () => {
             expect(data.id).to.equal('rs1');
             return Promise.resolve(data);
           },
-          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
         },
         pool
       };
@@ -175,7 +178,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [ {} ] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [{}] }]);
     });
 
     it('should remove all resource servers', async () => {
@@ -190,7 +193,7 @@ describe('#resourceServers handler', () => {
             removed = true;
             return Promise.resolve(data);
           },
-          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
         },
         pool
       };
@@ -198,7 +201,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [] }]);
       expect(removed).to.equal(true);
     });
 
@@ -218,7 +221,7 @@ describe('#resourceServers handler', () => {
             removed = true;
             return Promise.resolve(data);
           },
-          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
         },
         pool
       };
@@ -226,7 +229,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { resourceServers: [] } ]);
+      await stageFn.apply(handler, [{ resourceServers: [] }]);
       expect(removed).to.equal(true);
     });
 
@@ -234,7 +237,8 @@ describe('#resourceServers handler', () => {
       const auth0 = {
         resourceServers: {
           create: () => Promise.resolve([]),
-          update: (data) => {
+          update: function (data) {
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
@@ -253,7 +257,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const data = {
-        resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ],
+        resourceServers: [{ name: 'someAPI', identifier: 'some-api', scope: 'new:scope' }],
         exclude: {
           resourceServers: [
             'someOtherAPI',
@@ -262,7 +266,7 @@ describe('#resourceServers handler', () => {
         }
       };
 
-      await stageFn.apply(handler, [ data ]);
+      await stageFn.apply(handler, [data]);
     });
   });
 });

--- a/test/tools/auth0/handlers/resourceServers.tests.js
+++ b/test/tools/auth0/handlers/resourceServers.tests.js
@@ -11,7 +11,7 @@ const pool = {
 };
 
 describe('#resourceServers handler', () => {
-  const config = function (key) {
+  const config = function(key) {
     return config.data && config.data[key];
   };
 
@@ -33,7 +33,7 @@ describe('#resourceServers handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ resourceServers: data }]);
+        await stageFn.apply(handler, [ { resourceServers: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -50,7 +50,7 @@ describe('#resourceServers handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ resourceServers: data }]);
+        await stageFn.apply(handler, [ { resourceServers: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('You can not configure the \'Auth0 Management API\'.');
@@ -66,7 +66,7 @@ describe('#resourceServers handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ resourceServers: data }]);
+      await stageFn.apply(handler, [ { resourceServers: data } ]);
     });
   });
 
@@ -74,8 +74,8 @@ describe('#resourceServers handler', () => {
     it('should create resource server', async () => {
       const auth0 = {
         resourceServers: {
-          create: function (data) {
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someAPI');
             return Promise.resolve(data);
@@ -90,7 +90,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI' }] }]);
+      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI' } ] } ]);
     });
 
     it('should get resource servers', async () => {
@@ -105,14 +105,14 @@ describe('#resourceServers handler', () => {
 
       const handler = new resourceServers.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([{ name: 'Company API', identifier: 'http://company.com/api' }]);
+      expect(data).to.deep.equal([ { name: 'Company API', identifier: 'http://company.com/api' } ]);
     });
 
     it('should update resource server', async () => {
       const auth0 = {
         resourceServers: {
           create: () => Promise.resolve([]),
-          update: function (params, data) {
+          update: function(params, data) {
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('rs1');
@@ -120,7 +120,7 @@ describe('#resourceServers handler', () => {
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
         },
         pool
       };
@@ -128,28 +128,28 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI', identifier: 'some-api', scope: 'new:scope' }] }]);
+      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ] } ]);
     });
 
     it('should create new resource server with same name but different identifier', async () => {
       const auth0 = {
         resourceServers: {
-          create: function (data) {
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someAPI');
             expect(data.scope).to.equal('new:scope');
             expect(data.identifier).to.equal('another-api');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be('undefined');
             expect(data).to.be('undefined');
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
         },
         pool
       };
@@ -157,7 +157,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [{ name: 'someAPI', identifier: 'another-api', scope: 'new:scope' }] }]);
+      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'another-api', scope: 'new:scope' } ] } ]);
     });
 
     it('should remove resource server', async () => {
@@ -170,7 +170,7 @@ describe('#resourceServers handler', () => {
             expect(data.id).to.equal('rs1');
             return Promise.resolve(data);
           },
-          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
         },
         pool
       };
@@ -178,7 +178,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [{}] }]);
+      await stageFn.apply(handler, [ { resourceServers: [ {} ] } ]);
     });
 
     it('should remove all resource servers', async () => {
@@ -193,7 +193,7 @@ describe('#resourceServers handler', () => {
             removed = true;
             return Promise.resolve(data);
           },
-          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
         },
         pool
       };
@@ -201,7 +201,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [] }]);
+      await stageFn.apply(handler, [ { resourceServers: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -221,7 +221,7 @@ describe('#resourceServers handler', () => {
             removed = true;
             return Promise.resolve(data);
           },
-          getAll: () => [{ id: 'rs1', identifier: 'some-api', name: 'someAPI' }]
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
         },
         pool
       };
@@ -229,7 +229,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ resourceServers: [] }]);
+      await stageFn.apply(handler, [ { resourceServers: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -237,8 +237,8 @@ describe('#resourceServers handler', () => {
       const auth0 = {
         resourceServers: {
           create: () => Promise.resolve([]),
-          update: function (data) {
-            expect(this).to.not.be.undefined;
+          update: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
@@ -257,7 +257,7 @@ describe('#resourceServers handler', () => {
       const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const data = {
-        resourceServers: [{ name: 'someAPI', identifier: 'some-api', scope: 'new:scope' }],
+        resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ],
         exclude: {
           resourceServers: [
             'someOtherAPI',
@@ -266,7 +266,7 @@ describe('#resourceServers handler', () => {
         }
       };
 
-      await stageFn.apply(handler, [data]);
+      await stageFn.apply(handler, [ data ]);
     });
   });
 });

--- a/test/tools/auth0/handlers/roles.tests.js
+++ b/test/tools/auth0/handlers/roles.tests.js
@@ -58,7 +58,8 @@ describe('#roles handler', () => {
     it('should create role', async () => {
       const auth0 = {
         roles: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('myRole');
             expect(data.description).to.equal('myDescription');
@@ -192,12 +193,14 @@ describe('#roles handler', () => {
     it('should update role', async () => {
       const auth0 = {
         roles: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.length).to.equal(0);
             return Promise.resolve(data);
           },
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(params.id).to.equal('myRoleId');
             expect(data).to.be.an('object');
@@ -226,7 +229,8 @@ describe('#roles handler', () => {
               expect(data.permissions).to.be.an('Array');
               return Promise.resolve(data);
             },
-            delete: (params, data) => {
+            delete: function(params,data){
+              expect(this).to.not.be.undefined;
               expect(params).to.be.an('object');
               expect(params.id).to.equal('myRoleId');
               expect(data.permissions).to.be.an('Array');

--- a/test/tools/auth0/handlers/roles.tests.js
+++ b/test/tools/auth0/handlers/roles.tests.js
@@ -58,8 +58,8 @@ describe('#roles handler', () => {
     it('should create role', async () => {
       const auth0 = {
         roles: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('myRole');
             expect(data.description).to.equal('myDescription');
@@ -193,14 +193,14 @@ describe('#roles handler', () => {
     it('should update role', async () => {
       const auth0 = {
         roles: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.length).to.equal(0);
             return Promise.resolve(data);
           },
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('myRoleId');
             expect(data).to.be.an('object');
@@ -229,8 +229,8 @@ describe('#roles handler', () => {
               expect(data.permissions).to.be.an('Array');
               return Promise.resolve(data);
             },
-            delete: function(params,data){
-              expect(this).to.not.be.undefined;
+            delete: function(params, data) {
+              (() => expect(this).to.not.be.undefined)();
               expect(params).to.be.an('object');
               expect(params.id).to.equal('myRoleId');
               expect(data.permissions).to.be.an('Array');

--- a/test/tools/auth0/handlers/rules.tests.js
+++ b/test/tools/auth0/handlers/rules.tests.js
@@ -200,8 +200,8 @@ describe('#rules handler', () => {
     it('should create rule', async () => {
       const auth0 = {
         rules: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someRule');
             expect(data.script).to.equal('rule_script');
@@ -245,8 +245,8 @@ describe('#rules handler', () => {
       const auth0 = {
         rules: {
           create: () => Promise.resolve([]),
-          update: function(params,data){
-            expect(this).to.not.be.undefined;
+          update: function(params, data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('rule1');
@@ -341,13 +341,13 @@ describe('#rules handler', () => {
     it('should not touch excluded rules', async () => {
       const auth0 = {
         rules: {
-          create: function(data){
-            expect(this).to.not.be.undefined
+          create: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(data){
-            expect(this).to.not.be.undefined;
+          update: function(data) {
+            (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },

--- a/test/tools/auth0/handlers/rules.tests.js
+++ b/test/tools/auth0/handlers/rules.tests.js
@@ -200,7 +200,8 @@ describe('#rules handler', () => {
     it('should create rule', async () => {
       const auth0 = {
         rules: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someRule');
             expect(data.script).to.equal('rule_script');
@@ -244,7 +245,8 @@ describe('#rules handler', () => {
       const auth0 = {
         rules: {
           create: () => Promise.resolve([]),
-          update: (params, data) => {
+          update: function(params,data){
+            expect(this).to.not.be.undefined;
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.id).to.equal('rule1');
@@ -339,11 +341,13 @@ describe('#rules handler', () => {
     it('should not touch excluded rules', async () => {
       const auth0 = {
         rules: {
-          create: (data) => {
+          create: function(data){
+            expect(this).to.not.be.undefined
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: (data) => {
+          update: function(data){
+            expect(this).to.not.be.undefined;
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },


### PR DESCRIPTION
## ✏️ Changes

A change went in to `node-auth0@2.38.0` where we refactored the way we defined the various services methods, changing them from being defined using [wrapPropertyMethod](https://github.com/auth0/node-auth0/blob/fc3d2060af577d108c022d0863b072620e5b1829/src/utils.js#L50-L64) to regular class methods. It's important to note that this was not a regression on the `node-auth0` side, but rather changes in implementation details that the deploy CLI relied on.

The issue could be observed when updating the `node-auth` package to 2.38.0 or later and then adding a new database configuration. Then during import, the import would fail and log the following:

```shell
2022-02-15T20:10:18.462Z - error: Problem running command import during stage processChanges when processing type databases
2022-02-15T20:10:18.462Z - error: Cannot read properties of undefined (reading 'resource')
```

This change is largely based off [@adamjmcgrath](https://github.com/adamjmcgrath)'s #405 where he correctly binds the correct scope to the dynamically run class methods. **However**, this PR also goes a step further and removes the two major references to `Reflect.get` and replaces with more conventional bracket syntax. This change was introduced because the `Reflect.get` didn't serve a functional purpose and increased cognitive overhead when debugging the code. Example:

```js
Reflect.get( client, 'create')() // Current method
// versus

client.create() // More intuitive and functionally equivalent
```

## 🔗 References

[ESD-17871: a0deploy import fails when database is not created (node-auth0 2.38.0 regression)](https://auth0team.atlassian.net/browse/ESD-17871) 

## 🎯 Testing

**The bulk of this PR is test changes**. The important bit is enforcing that the `this` keyword is defined in all the important class methods like `create`, `update` and `delete` (I don't believe `get` and `getAll` necessarily require this change). The most important testing change is the in `test/tools/auth0/handlers/databases.tests.js` file (pointed out below), but I just went ahead and added these tests.

I may have gone a bit overboard with the testing changes, but I wanted to err on the paranoid side as I'm still learning the inner workings of this project.

