### PR TITLE
Adding "dev" script to enable auto-build on file change

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pretest": "rimraf ./.nyc_output",
     "test": "cross-env NODE_ENV=test nyc mocha --recursive --require @babel/register test",
     "build": "rimraf ./lib && babel src -d lib",
+    "dev": "npm run build -- --watch",
     "prepare": "npm run build",
     "preversion": "kacl prerelease",
     "version": "kacl release && git add CHANGELOG.md"


### PR DESCRIPTION
## ✏️ Changes

Introducing the `dev` script that can be run with `npm run dev` to build automatically on source code change. This reduces the manual toil of building after modifying source code. Although this could have been accomplished previously by running `npm run build -- watch`, that functionality wasn't obvious to me so I'm deciding to expose it more clearly.