### PR TITLE
DXCDT-53: Preventing benign warnings when diff'ing object fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "pretest": "rimraf ./.nyc_output",
     "test": "cross-env NODE_ENV=test nyc mocha --recursive --require @babel/register test",
+    "test:single": "npx mocha --require @babel/register",
     "build": "rimraf ./lib && babel src -d lib",
     "prepare": "npm run build",
     "preversion": "kacl prerelease",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint": "eslint --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "pretest": "rimraf ./.nyc_output",
     "test": "cross-env NODE_ENV=test nyc mocha --recursive --require @babel/register test",
-    "test:single": "npx mocha --require @babel/register",
     "build": "rimraf ./lib && babel src -d lib",
     "prepare": "npm run build",
     "preversion": "kacl prerelease",

--- a/src/tools/auth0/handlers/default.js
+++ b/src/tools/auth0/handlers/default.js
@@ -83,7 +83,7 @@ export default class DefaultHandler {
     const existing = await this.getType();
 
     // Figure out what needs to be updated vs created
-    return calcChanges(this, typeAssets, existing, this.identifiers, this.objectFields);
+    return calcChanges(this, typeAssets, existing, this.identifiers);
   }
 
   async validate(assets) {

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -72,12 +72,12 @@ export function dumpJSON(obj, spacing = 0) {
  * @returns T
  */
 export function processChangedObjectFields({
-  handler, desiredAssetState, currentAssetState, objectFields = [], allowDelete = false
+  handler, desiredAssetState, currentAssetState, allowDelete = false
 }) {
   const desiredAssetStateWithChanges = { ...desiredAssetState };
 
   // eslint-disable-next-line no-restricted-syntax
-  for (const fieldName of objectFields) {
+  for (const fieldName of handler.objectFields) {
     const areDesiredStateAndCurrentStateEmpty = Object.keys(desiredAssetState[fieldName] || {}).length === 0 && Object.keys(currentAssetState[fieldName] || {}).length === 0;
     if (areDesiredStateAndCurrentStateEmpty) {
       // If both the desired state and current state for a given object is empty, it is a no-op and can skip
@@ -136,7 +136,7 @@ export function processChangedObjectFields({
   return desiredAssetStateWithChanges;
 }
 
-export function calcChanges(handler, assets, existing, identifiers = [ 'id', 'name' ], objectFields = [], allowDelete = false) {
+export function calcChanges(handler, assets, existing, identifiers = [ 'id', 'name' ], allowDelete = false) {
   // Calculate the changes required between two sets of assets.
   const update = [];
   let del = [ ...existing ];
@@ -186,9 +186,9 @@ export function calcChanges(handler, assets, existing, identifiers = [ 'id', 'na
             // special treatment. When different metadata objects are passed to APIv2
             // properties must explicitly be marked for deletion by indicating a `null`
             // value.
-            ...(objectFields.length
+            ...(handler.objectFields.length
               ? processChangedObjectFields({
-                handler, asset, found, objectFields, allowDelete
+                handler, desiredAssetState: asset, currentAssetState: found, allowDelete
               })
               : asset)
           });

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -71,7 +71,9 @@ export function dumpJSON(obj, spacing = 0) {
  * @param {boolean} [allowDelete=false]
  * @returns T
  */
-function processChangedObjectFields(handler, desiredAssetState, currentAssetState, objectFields = [], allowDelete = false) {
+export function processChangedObjectFields({
+  handler, desiredAssetState, currentAssetState, objectFields = [], allowDelete = false
+}) {
   const desiredAssetStateWithChanges = { ...desiredAssetState };
 
   // eslint-disable-next-line no-restricted-syntax
@@ -185,7 +187,9 @@ export function calcChanges(handler, assets, existing, identifiers = [ 'id', 'na
             // properties must explicitly be marked for deletion by indicating a `null`
             // value.
             ...(objectFields.length
-              ? processChangedObjectFields(handler, asset, found, objectFields, allowDelete)
+              ? processChangedObjectFields({
+                handler, asset, found, objectFields, allowDelete
+              })
               : asset)
           });
         }


### PR DESCRIPTION
## ✏️ Changes

As reported by #373, there was the following warning that was popping up when pushing clients to remote tenants:

```
2021-08-23T21:15:21.278Z - warn: Detected that the client_metadata of the following undefined should be emptied. Doing so may be destructive.
You can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config
{"name":"Test Application","client_id":"siSPR......U1Dh"}
2021-08-23T21:15:21.280Z - debug: Start processChanges for clients [delete:0] [update:1], [create:0], [conflicts:0]
2021-08-23T21:15:21.624Z - debug: Stripping "Test Application" read-only fields ["jwt_configuration.secret_encoded","client_id"]
2021-08-23T21:15:23.531Z - info: Updated [clients]: {"name":"Test Application","client_id":"siSPR......U1Dh"}
```

It's a warning, but a scary one at that. And worse, it's not actionable because contrary to the messaging, it would occur despite `AUTH0_ALLOW_DELETE` being set to true. I ultimately determined this warning to be benign, as in, it would never have caused any destructive changes. But it may have prevented some client metadata from being deleted properly.


The issue here was the logic in the `processChangedObjectFields` which would throw the warning about the `metadata` **object field**. An object field is an abstraction that seems to have been created to deal with key-value object properties, such as client metadata, and determining if these object properties should be deleted. Currently, the only place this is implemented is on client metadata, but in theory, it could be applied to any resource field that is a key-value object.

The fix here is to check to see if both the propose and current state of that object property are both empty, chalking it up as a no-op and then continuing to check the other object fields. The rest of the logic in the function is sound.

One issue that I discovered while working on this is that the `allowDelete` argument is never actually passed when calculating the diff, which is why this bug occurred regardless of what the `AUTH0_ALLOW_DELETE` config var was set to. This will need to be fixed in a following PR.

## 🎯 Testing

Exposed the `processChangedObjectFields` through an export and added unit tests to assert the expected behavior.