### PR TITLE
DXCDT-56: Fixing @@ array replacement to work with and without wrapped quotes

### DIFF
--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -21,7 +21,7 @@ function parse(context) {
         const htmlFileName = path.join(clientsFolder, client.custom_login_page);
 
         if (isFile(htmlFileName)) {
-          client.custom_login_page = loadFile(htmlFileName, context.mappings);
+          client.custom_login_page = loadFileAndReplaceKeywords(htmlFileName, context.mappings);
         }
       }
 

--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -30,7 +30,7 @@ function parse(context) {
         const htmlFileName = path.join(connectionsFolder, connection.options.email.body);
 
         if (isFile(htmlFileName)) {
-          connection.options.email.body = loadFile(htmlFileName, context.mappings);
+          connection.options.email.body = loadFileAndReplaceKeywords(htmlFileName, context.mappings);
         }
       }
 

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -47,7 +47,7 @@ function getDatabase(folder, mappings) {
         // skip invalid keys in customScripts object
         log.warn('Skipping invalid database configuration: ' + name);
       } else {
-        database.options.customScripts[name] = loadFile(
+        database.options.customScripts[name] = loadFileAndReplaceKeywords(
           path.join(folder, script),
           mappings
         );

--- a/src/context/directory/handlers/emailTemplates.js
+++ b/src/context/directory/handlers/emailTemplates.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -31,7 +31,7 @@ function parse(context) {
     } else {
       emailTemplates.push({
         ...loadJSON(data.meta, context.mappings),
-        body: loadFile(data.html, context.mappings)
+        body: loadFileAndReplaceKeywords(data.html, context.mappings)
       });
     }
   });

--- a/src/context/directory/handlers/pages.js
+++ b/src/context/directory/handlers/pages.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -31,7 +31,7 @@ function parse(context) {
     } else {
       pages.push({
         ...loadJSON(data.meta, context.mappings),
-        html: loadFile(data.html, context.mappings)
+        html: loadFileAndReplaceKeywords(data.html, context.mappings)
       });
     }
   });

--- a/src/context/directory/index.js
+++ b/src/context/directory/index.js
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { loadFile, Auth0 } from '../../tools';
+import { loadFileAndReplaceKeywords, Auth0 } from '../../tools';
 
 import cleanAssets from '../../readonly';
 import log from '../../logger';
@@ -35,7 +35,7 @@ export default class {
       // try load not relative to yaml file
       toLoad = f;
     }
-    return loadFile(toLoad, this.mappings);
+    return loadFileAndReplaceKeywords(toLoad, this.mappings);
   }
 
   async load() {

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
 import path from 'path';
-import { loadFile, keywordReplace, Auth0 } from '../../tools';
+import { loadFileAndReplaceKeywords, keywordReplace, Auth0 } from '../../tools';
 
 import log from '../../logger';
 import {
@@ -41,7 +41,7 @@ export default class {
       // try load not relative to yaml file
       toLoad = f;
     }
-    return loadFile(path.resolve(toLoad), this.mappings);
+    return loadFileAndReplaceKeywords(path.resolve(toLoad), this.mappings);
   }
 
   async load() {

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -1,13 +1,13 @@
 import constants from './constants';
 import deploy from './deploy';
 import Auth0 from './auth0';
-import { keywordReplace, loadFile } from './utils';
+import { keywordReplace, loadFileAndReplaceKeywords } from './utils';
 
 export default {
   constants,
   deploy,
   keywordReplace,
-  loadFile,
+  loadFileAndReplaceKeywords,
   Auth0
 };
 
@@ -15,6 +15,6 @@ export {
   constants,
   deploy,
   keywordReplace,
-  loadFile,
+  loadFileAndReplaceKeywords,
   Auth0
 };

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -4,18 +4,32 @@ import dotProp from 'dot-prop';
 import _ from 'lodash';
 import log from './logger';
 
+export function keywordArrayReplace(input, mappings) {
+  Object.keys(mappings).forEach(function(key) {
+    // Matching against two sets of patterns because a developer may provide their array replacement keyword with or without wrapping quotes. It is not obvious to the developer which to do depending if they're operating in YAML or JSON.
+    const pattern = `@@${key}@@`;
+    const patternWithQuotes = `"${pattern}"`;
+
+    const regex = new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
+    input = input.replace(regex, JSON.stringify(mappings[key]));
+  });
+  return input;
+}
+
+export function keywordStringReplace(input, mappings) {
+  Object.keys(mappings).forEach(function(key) {
+    const regex = new RegExp(`##${key}##`, 'g');
+    input = input.replace(regex, mappings[key]);
+  });
+  return input;
+}
+
 export function keywordReplace(input, mappings) {
   // Replace keywords with mappings within input.
   if (mappings && Object.keys(mappings).length > 0) {
-    Object.keys(mappings).forEach(function(key) {
-      const re = new RegExp(`##${key}##`, 'g');
-      input = input.replace(re, mappings[key]);
-    });
+    input = keywordStringReplace(input, mappings);
 
-    Object.keys(mappings).forEach(function(key) {
-      const re = new RegExp(`@@${key}@@`, 'g');
-      input = input.replace(re, JSON.stringify(mappings[key]));
-    });
+    input = keywordArrayReplace(input, mappings);
   }
   return input;
 }

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -53,7 +53,7 @@ export function convertClientNamesToIds(names, clients) {
   return [ ...unresolved, ...result ];
 }
 
-export function loadFile(file, mappings) {
+export function loadFileAndReplaceKeywords(file, mappings) {
   // Load file and replace keyword mappings
   const f = path.resolve(file);
   try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import sanitizeName from 'sanitize-filename';
 import dotProp from 'dot-prop';
-import { loadFile } from './tools';
+import { loadFileAndReplaceKeywords } from './tools';
 import log from './logger';
 
 export function isDirectory(f) {
@@ -34,7 +34,7 @@ export function getFiles(folder, exts) {
 
 export function loadJSON(file, mappings) {
   try {
-    const content = loadFile(file, mappings);
+    const content = loadFileAndReplaceKeywords(file, mappings);
     return JSON.parse(content);
   } catch (e) {
     throw new Error(`Error parsing JSON from metadata file: ${file}, because: ${e.message}`);

--- a/test/tools/utils.tests.js
+++ b/test/tools/utils.tests.js
@@ -38,13 +38,13 @@ const expectations = {
 describe('#utils', function() {
   it('should load file', () => {
     const file = path.resolve(__dirname, 'test.file.json');
-    const loaded = utils.loadFile(file, mappings);
+    const loaded = utils.loadFileAndReplaceKeywords(file, mappings);
     expect(JSON.parse(loaded)).to.deep.equal(expectations);
   });
 
   it('should throw error if cannot load file', () => {
     expect(function() {
-      utils.loadFile('notexist.json', mappings);
+      utils.loadFileAndReplaceKeywords('notexist.json', mappings);
     }).to.throw(/Unable to load file.*/);
   });
 


### PR DESCRIPTION
## ✏️ Changes

The way that the `@@FOO@@` array variable replacement worked has caused a bit of confusion from users. Firstly, it's not obvious if these markers need to be wrapped in quotes or not. Without them, it invalidates the JSON file that they're used in, but if they do use quotes, the replacement won't work as expected. This can be seen in #415 and #184. 

For example, as it currently is implemented, developers would need to have the following configurations:
```json
{
  "web_origins": @@WEB_ORIGINS@@
}
```
This is _invalid_ JSON and a bit of a wonky thing to force onto the developer. With this change, they can now use the array replacements with or without wrapped quotes:

```json
{
   "grant_types": @@GRANT_TYPES@@,
   "web_origins": "@@WEB_ORIGINS@@"
}
 
```

The tricky part here is that this needs to work both for JSON and YAML input files. This fix is primarily for JSON configurations to maintain the validity of the file. However, YAML is a bit less strict about having the @@ array markers wrapped in quotes, however that is still supported, albeit not with a desired outcome. Examples of this can be seen in the test YAML test cases below.

A big bulk of this PR is adding tests to confirm and enforce the behavior that exists currently.

## 🎯 Testing

Separated out `keywordArrayReplace` and `keywordStringReplace` into their own functions so that they could have their own unit tests applied. Also added higher-level unit tests to the `keywordReplace` function to confirm expected results for both YAML and JSON inputs.

✅This change has unit test coverage

