### PR TITLE
Distinguishing between two loadFile functions

### DIFF
--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -21,7 +21,7 @@ function parse(context) {
         const htmlFileName = path.join(clientsFolder, client.custom_login_page);
 
         if (isFile(htmlFileName)) {
-          client.custom_login_page = loadFile(htmlFileName, context.mappings);
+          client.custom_login_page = loadFileAndReplaceKeywords(htmlFileName, context.mappings);
         }
       }
 

--- a/src/context/directory/handlers/connections.js
+++ b/src/context/directory/handlers/connections.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -30,7 +30,7 @@ function parse(context) {
         const htmlFileName = path.join(connectionsFolder, connection.options.email.body);
 
         if (isFile(htmlFileName)) {
-          connection.options.email.body = loadFile(htmlFileName, context.mappings);
+          connection.options.email.body = loadFileAndReplaceKeywords(htmlFileName, context.mappings);
         }
       }
 

--- a/src/context/directory/handlers/databases.js
+++ b/src/context/directory/handlers/databases.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -47,7 +47,7 @@ function getDatabase(folder, mappings) {
         // skip invalid keys in customScripts object
         log.warn('Skipping invalid database configuration: ' + name);
       } else {
-        database.options.customScripts[name] = loadFile(
+        database.options.customScripts[name] = loadFileAndReplaceKeywords(
           path.join(folder, script),
           mappings
         );

--- a/src/context/directory/handlers/emailTemplates.js
+++ b/src/context/directory/handlers/emailTemplates.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -31,7 +31,7 @@ function parse(context) {
     } else {
       emailTemplates.push({
         ...loadJSON(data.meta, context.mappings),
-        body: loadFile(data.html, context.mappings)
+        body: loadFileAndReplaceKeywords(data.html, context.mappings)
       });
     }
   });

--- a/src/context/directory/handlers/pages.js
+++ b/src/context/directory/handlers/pages.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { constants, loadFile } from '../../../tools';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import log from '../../../logger';
 import {
@@ -31,7 +31,7 @@ function parse(context) {
     } else {
       pages.push({
         ...loadJSON(data.meta, context.mappings),
-        html: loadFile(data.html, context.mappings)
+        html: loadFileAndReplaceKeywords(data.html, context.mappings)
       });
     }
   });

--- a/src/context/directory/index.js
+++ b/src/context/directory/index.js
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { loadFile, Auth0 } from '../../tools';
+import { loadFileAndReplaceKeywords, Auth0 } from '../../tools';
 
 import cleanAssets from '../../readonly';
 import log from '../../logger';
@@ -35,7 +35,7 @@ export default class {
       // try load not relative to yaml file
       toLoad = f;
     }
-    return loadFile(toLoad, this.mappings);
+    return loadFileAndReplaceKeywords(toLoad, this.mappings);
   }
 
   async load() {

--- a/src/context/yaml/index.js
+++ b/src/context/yaml/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
 import path from 'path';
-import { loadFile, keywordReplace, Auth0 } from '../../tools';
+import { loadFileAndReplaceKeywords, keywordReplace, Auth0 } from '../../tools';
 
 import log from '../../logger';
 import {
@@ -41,7 +41,7 @@ export default class {
       // try load not relative to yaml file
       toLoad = f;
     }
-    return loadFile(path.resolve(toLoad), this.mappings);
+    return loadFileAndReplaceKeywords(path.resolve(toLoad), this.mappings);
   }
 
   async load() {

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -1,13 +1,13 @@
 import constants from './constants';
 import deploy from './deploy';
 import Auth0 from './auth0';
-import { keywordReplace, loadFile } from './utils';
+import { keywordReplace, loadFileAndReplaceKeywords } from './utils';
 
 export default {
   constants,
   deploy,
   keywordReplace,
-  loadFile,
+  loadFileAndReplaceKeywords,
   Auth0
 };
 
@@ -15,6 +15,6 @@ export {
   constants,
   deploy,
   keywordReplace,
-  loadFile,
+  loadFileAndReplaceKeywords,
   Auth0
 };

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -53,7 +53,7 @@ export function convertClientNamesToIds(names, clients) {
   return [ ...unresolved, ...result ];
 }
 
-export function loadFile(file, mappings) {
+export function loadFileAndReplaceKeywords(file, mappings) {
   // Load file and replace keyword mappings
   const f = path.resolve(file);
   try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import sanitizeName from 'sanitize-filename';
 import dotProp from 'dot-prop';
-import { loadFile } from './tools';
+import { loadFileAndReplaceKeywords } from './tools';
 import log from './logger';
 
 export function isDirectory(f) {
@@ -34,7 +34,7 @@ export function getFiles(folder, exts) {
 
 export function loadJSON(file, mappings) {
   try {
-    const content = loadFile(file, mappings);
+    const content = loadFileAndReplaceKeywords(file, mappings);
     return JSON.parse(content);
   } catch (e) {
     throw new Error(`Error parsing JSON from metadata file: ${file}, because: ${e.message}`);

--- a/test/tools/utils.tests.js
+++ b/test/tools/utils.tests.js
@@ -38,13 +38,13 @@ const expectations = {
 describe('#utils', function() {
   it('should load file', () => {
     const file = path.resolve(__dirname, 'test.file.json');
-    const loaded = utils.loadFile(file, mappings);
+    const loaded = utils.loadFileAndReplaceKeywords(file, mappings);
     expect(JSON.parse(loaded)).to.deep.equal(expectations);
   });
 
   it('should throw error if cannot load file', () => {
     expect(function() {
-      utils.loadFile('notexist.json', mappings);
+      utils.loadFileAndReplaceKeywords('notexist.json', mappings);
     }).to.throw(/Unable to load file.*/);
   });
 


### PR DESCRIPTION
## ✏️ Changes

There are currently two `loadFile` functions, one is a utility function used to load and replace keywords. The other is a method on the resource handler class that allows extendable functionality to how configuration files are loaded, ultimately calling the former.

Both functions do similar things and one calls the other, but it is confusing when developing to distinguish between the two. This PR attempts to reduce the confusion by naming the base level utility function to `loadFileAndReplaceKeywords`. This will make reasoning about the keyword replacement code a bit more reasonable. 