### PR TITLE
DXCDT-66: Add excluded properties into connections update payload

### DIFF
--- a/src/tools/auth0/handlers/connections.js
+++ b/src/tools/auth0/handlers/connections.js
@@ -1,7 +1,7 @@
 import dotProp from 'dot-prop';
+import _ from 'lodash';
 import DefaultHandler, { order } from './default';
 import { filterExcluded, convertClientNameToId, getEnabledClients } from '../../utils';
-import _ from 'lodash'
 
 export const schema = {
   type: 'array',
@@ -15,7 +15,7 @@ export const schema = {
       realms: { type: 'array', items: { type: 'string' } },
       metadata: { type: 'object' }
     },
-    required: ['name', 'strategy']
+    required: [ 'name', 'strategy' ]
   }
 };
 
@@ -37,7 +37,7 @@ export const addExcludedConnectionPropertiesToChanges = ({
   const excludedOptions = excludedFields.filter(
     // Only include fields that pertain to options
     (excludedField) => excludedField.startsWith('options')
-  )
+  );
 
   const newProposedUpdates = proposedChanges.update.map((proposedConnection) => {
     const currConnection = existingConnectionsMap[proposedConnection.id];
@@ -70,7 +70,7 @@ export default class ConnectionsHandler extends DefaultHandler {
     super({
       ...config,
       type: 'connections',
-      stripUpdateFields: ['strategy', 'name']
+      stripUpdateFields: [ 'strategy', 'name' ]
     });
   }
 

--- a/src/tools/auth0/handlers/connections.js
+++ b/src/tools/auth0/handlers/connections.js
@@ -1,3 +1,4 @@
+import dotProp from 'dot-prop';
 import DefaultHandler, { order } from './default';
 import { filterExcluded, convertClientNameToId, getEnabledClients } from '../../utils';
 
@@ -15,6 +16,50 @@ export const schema = {
     },
     required: [ 'name', 'strategy' ]
   }
+};
+
+// addExcludedConnectionPropertiesToChanges superimposes excluded properties on the `options` object. The Auth0 API
+// will overwrite the options property when updating connections, so it is necessary to add excluded properties back in to prevent those excluded properties from being deleted.
+// This use case is common because organizations may not want to expose sensitive connection details, but want to preserve them in the tenant.
+// exported only for unit testing purposes
+export const addExcludedConnectionPropertiesToChanges = ({
+  proposedChanges,
+  existingConnections,
+  config
+}) => {
+  if (proposedChanges.update.length === 0) return proposedChanges;
+
+  const excludedFields = config()?.EXCLUDED_PROPS?.connections || [];
+  if (excludedFields.length === 0) return proposedChanges;
+
+  const newProposedUpdates = proposedChanges.update.map((proposedConnection) => {
+    const currConnection = existingConnections.find(({ id }) => id === proposedConnection.id);
+
+    if (currConnection === undefined) return proposedConnection;
+
+    // Only include fields that pertain to options
+    const currentExcludedPropertyValues = excludedFields.filter((excludedField) => excludedField.indexOf('options') === 0).reduce((agg, excludedField) => {
+      if (!dotProp.has(currConnection, excludedField)) return agg;
+
+      const currentExcludedFieldValue = dotProp.get(currConnection, excludedField);
+
+      dotProp.set(agg, excludedField, currentExcludedFieldValue);
+      return agg;
+    }, {});
+
+    return {
+      ...proposedConnection,
+      options: {
+        ...proposedConnection.options,
+        ...currentExcludedPropertyValues.options
+      }
+    };
+  });
+
+  return {
+    ...proposedChanges,
+    update: newProposedUpdates
+  };
 };
 
 export default class ConnectionsHandler extends DefaultHandler {
@@ -74,7 +119,11 @@ export default class ConnectionsHandler extends DefaultHandler {
         enabled_clients: getEnabledClients(assets, connection, existingConnections, clients)
       }
     ));
-    return super.calcChanges({ ...assets, connections: formatted });
+    const proposedChanges = await super.calcChanges({ ...assets, connections: formatted });
+
+    const proposedChangesWithExcludedProperties = addExcludedConnectionPropertiesToChanges({ proposedChanges, existingConnections, config: this.config });
+
+    return proposedChangesWithExcludedProperties;
   }
 
   // Run after clients are updated so we can convert all the enabled_clients names to id's

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -12,7 +12,7 @@ const pool = {
 };
 
 describe('#connections handler', () => {
-  const config = function (key) {
+  const config = function(key) {
     return config.data && config.data[key];
   };
 
@@ -35,7 +35,7 @@ describe('#connections handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ connections: data }]);
+        await stageFn.apply(handler, [ { connections: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -51,7 +51,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
   });
 
@@ -59,7 +59,7 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
@@ -78,7 +78,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [{ name: 'someConnection' }] }]);
+      await stageFn.apply(handler, [ { connections: [ { name: 'someConnection' } ] } ]);
     });
 
     it('should get connections', async () => {
@@ -87,7 +87,7 @@ describe('#connections handler', () => {
       const auth0 = {
         connections: {
           getAll: () => [
-            { strategy: 'github', name: 'github', enabled_clients: [clientId] },
+            { strategy: 'github', name: 'github', enabled_clients: [ clientId ] },
             { strategy: 'auth0', name: 'db-should-be-ignored', enabled_clients: [] }
           ]
         },
@@ -101,33 +101,33 @@ describe('#connections handler', () => {
 
       const handler = new connections.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([{ strategy: 'github', name: 'github', enabled_clients: [clientId] }]);
+      expect(data).to.deep.equal([ { strategy: 'github', name: 'github', enabled_clients: [ clientId ] } ]);
     });
 
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ name: 'someConnection', id: 'con1', strategy: 'custom' }]
+          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
         },
         clients: {
-          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -138,23 +138,23 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -168,12 +168,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -206,7 +206,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -219,7 +219,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -231,16 +231,16 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -254,12 +254,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -292,7 +292,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -305,7 +305,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -317,7 +317,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -325,26 +325,26 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['client1-id', 'excluded-one-id'],
+              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{
-            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: ['excluded-one-id']
-          }]
+          getAll: () => [ {
+            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: [ 'excluded-one-id' ]
+          } ]
         },
         clients: {
           getAll: () => [
@@ -362,34 +362,34 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: ['client1', 'excluded-one', 'excluded-two'],
+          enabled_clients: [ 'client1', 'excluded-one', 'excluded-two' ],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data, exclude: { clients: ['excluded-one', 'excluded-two'] } }]);
+      await stageFn.apply(handler, [ { connections: data, exclude: { clients: [ 'excluded-one', 'excluded-two' ] } } ]);
     });
 
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -406,7 +406,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should delete all connections', async () => {
@@ -415,14 +415,14 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -433,7 +433,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [] }]);
+      await stageFn.apply(handler, [ { connections: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -441,17 +441,17 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -468,7 +468,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should not remove connections if run by extension', async () => {
@@ -479,12 +479,12 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -495,7 +495,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [] }]);
+      await stageFn.apply(handler, [ { connections: [] } ]);
     });
 
     it('should not remove/create/update excluded connections', async () => {
@@ -513,7 +513,7 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
@@ -533,12 +533,12 @@ describe('#connections handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const assets = {
         exclude: {
-          connections: ['existing1', 'existing2', 'existing3']
+          connections: [ 'existing1', 'existing2', 'existing3' ]
         },
-        connections: [{ name: 'existing3', strategy: 'custom' }]
+        connections: [ { name: 'existing3', strategy: 'custom' } ]
       };
 
-      await stageFn.apply(handler, [assets]);
+      await stageFn.apply(handler, [ assets ]);
     });
   });
 });
@@ -637,7 +637,7 @@ describe('#addExcludedConnectionPropertiesToChanges', () => {
       config: () => ({
         EXCLUDED_PROPS: {
           connections: [
-            'options',
+            'options'
           ]
         }
       }),
@@ -670,7 +670,7 @@ describe('#addExcludedConnectionPropertiesToChanges', () => {
         EXCLUDED_PROPS: {
           connections: [
             'some-unrelated-property-1',
-            'options.some-unrelated-property-2',
+            'options.some-unrelated-property-2'
           ],
           tenant: [
             'some-unrelated-property-3'

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 const { expect } = require('chai');
 const connections = require('../../../../src/tools/auth0/handlers/connections');
 
@@ -11,7 +12,7 @@ const pool = {
 };
 
 describe('#connections handler', () => {
-  const config = function(key) {
+  const config = function (key) {
     return config.data && config.data[key];
   };
 
@@ -34,7 +35,7 @@ describe('#connections handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [ { connections: data } ]);
+        await stageFn.apply(handler, [{ connections: data }]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -50,7 +51,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
   });
 
@@ -58,7 +59,7 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
@@ -77,7 +78,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [ { name: 'someConnection' } ] } ]);
+      await stageFn.apply(handler, [{ connections: [{ name: 'someConnection' }] }]);
     });
 
     it('should get connections', async () => {
@@ -86,7 +87,7 @@ describe('#connections handler', () => {
       const auth0 = {
         connections: {
           getAll: () => [
-            { strategy: 'github', name: 'github', enabled_clients: [ clientId ] },
+            { strategy: 'github', name: 'github', enabled_clients: [clientId] },
             { strategy: 'auth0', name: 'db-should-be-ignored', enabled_clients: [] }
           ]
         },
@@ -100,33 +101,33 @@ describe('#connections handler', () => {
 
       const handler = new connections.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([ { strategy: 'github', name: 'github', enabled_clients: [ clientId ] } ]);
+      expect(data).to.deep.equal([{ strategy: 'github', name: 'github', enabled_clients: [clientId] }]);
     });
 
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
+          getAll: () => [{ name: 'someConnection', id: 'con1', strategy: 'custom' }]
         },
         clients: {
-          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
+          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
         },
         pool
       };
@@ -137,23 +138,23 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -167,12 +168,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -205,7 +206,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -218,7 +219,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -230,16 +231,16 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -253,12 +254,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -291,7 +292,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -304,7 +305,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -316,7 +317,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -324,26 +325,26 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
+              enabled_clients: ['client1-id', 'excluded-one-id'],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ {
-            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: [ 'excluded-one-id' ]
-          } ]
+          getAll: () => [{
+            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: ['excluded-one-id']
+          }]
         },
         clients: {
           getAll: () => [
@@ -361,34 +362,34 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: [ 'client1', 'excluded-one', 'excluded-two' ],
+          enabled_clients: ['client1', 'excluded-one', 'excluded-two'],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data, exclude: { clients: [ 'excluded-one', 'excluded-two' ] } } ]);
+      await stageFn.apply(handler, [{ connections: data, exclude: { clients: ['excluded-one', 'excluded-two'] } }]);
     });
 
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -405,7 +406,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should delete all connections', async () => {
@@ -414,14 +415,14 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -432,7 +433,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [] } ]);
+      await stageFn.apply(handler, [{ connections: [] }]);
       expect(removed).to.equal(true);
     });
 
@@ -440,17 +441,17 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -467,7 +468,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should not remove connections if run by extension', async () => {
@@ -478,12 +479,12 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -494,7 +495,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [] } ]);
+      await stageFn.apply(handler, [{ connections: [] }]);
     });
 
     it('should not remove/create/update excluded connections', async () => {
@@ -512,7 +513,7 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
@@ -532,12 +533,144 @@ describe('#connections handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const assets = {
         exclude: {
-          connections: [ 'existing1', 'existing2', 'existing3' ]
+          connections: ['existing1', 'existing2', 'existing3']
         },
-        connections: [ { name: 'existing3', strategy: 'custom' } ]
+        connections: [{ name: 'existing3', strategy: 'custom' }]
       };
 
-      await stageFn.apply(handler, [ assets ]);
+      await stageFn.apply(handler, [assets]);
     });
+  });
+});
+
+describe('#addExcludedConnectionPropertiesToChanges', () => {
+  const { addExcludedConnectionPropertiesToChanges } = connections;
+
+  const mockConnsWithoutExcludedProps = [
+    {
+      id: 'con_1',
+      name: 'connection-1',
+      options: {
+        domain: 'login.auth0.net'
+      },
+      enabled_clients: [
+        'client_1',
+        'client_2'
+      ],
+      shouldHaveExcludedProps: true// Not a real connection property, just helps testing
+    },
+    {
+      id: 'con_2',
+      name: 'connection-2',
+      options: {
+        domain: 'enterprise-login.auth0.net'
+      },
+      enabled_clients: [
+        'client_1'
+      ],
+      shouldHaveExcludedProps: false// Not a real connection property, just helps testing
+    },
+    {
+      id: 'con_3',
+      name: 'connection-3',
+      options: {
+        domain: 'login.azure-prod-us.net'
+      },
+      enabled_clients: [
+        'client_1',
+        'client_3'
+      ],
+      shouldHaveExcludedProps: true// Not a real connection property, just helps testing
+    }
+  ];
+
+  const mockConnsWithExcludedProps = mockConnsWithoutExcludedProps.map((conn) => {
+    if (!conn.shouldHaveExcludedProps) return conn;
+    return {
+      ...conn,
+      options: {
+        ...conn.options,
+        client_id: `${conn.id}-client-id`,
+        client_secret: `${conn.id}-client-secret`
+      }
+    };
+  });
+
+  const proposedChanges = {
+    del: [],
+    update: mockConnsWithoutExcludedProps,
+    create: []
+  };
+
+  const existingConnections = mockConnsWithExcludedProps;
+
+  const config = () => ({
+    EXCLUDED_PROPS: {
+      tenant: [
+        'some-unrelated-excluded-property'
+      ],
+      connections: [
+        'options.client_id',
+        'options.client_secret'
+      ]
+    }
+  });
+
+  it('should add excluded properties into connections update payload', () => {
+    const updatedProposedChanges = addExcludedConnectionPropertiesToChanges({
+      config,
+      existingConnections,
+      proposedChanges
+    });
+    expect(updatedProposedChanges.update).to.lengthOf(proposedChanges.update.length);
+    // Loop through proposed changes and expect to see connections that should have excluded properties to have them
+    updatedProposedChanges.update.forEach((change, i) => {
+      if (!change.shouldHaveExcludedProps) {
+        return expect(change).to.deep.equal(mockConnsWithoutExcludedProps[i]);
+      }
+      expect(change).to.deep.equal(mockConnsWithExcludedProps[i]);
+    });
+  });
+
+  it('should not modify update payload if no excluded properties exist', () => {
+    const updatedProposedChangesNoConfig = addExcludedConnectionPropertiesToChanges({
+      config: () => ({}),
+      existingConnections,
+      proposedChanges
+    });
+
+    expect(updatedProposedChangesNoConfig).to.deep.equal(proposedChanges);// Expect no change
+  });
+
+  it('should not modify update payload if only unrelated excluded properties exist', () => {
+    const updatedProposedChangesUnrelatedConfig = addExcludedConnectionPropertiesToChanges({
+      config: () => ({
+        EXCLUDED_PROPS: {
+          connections: [
+            'some-unrelated-property-1',
+            'some-unrelated-property-2'
+          ]
+        }
+      }),
+      existingConnections,
+      proposedChanges
+    });
+    expect(updatedProposedChangesUnrelatedConfig).to.deep.equal(proposedChanges);// Expect no change
+  });
+
+  it('should not modify update payload if no updates are proposed', () => {
+    const updatedProposedChangesUnrelatedConfig = addExcludedConnectionPropertiesToChanges({
+      config,
+      existingConnections,
+      proposedChanges: {
+        ...proposedChanges,
+        update: []// Override to have no proposed updates
+      }
+    });
+    expect(updatedProposedChangesUnrelatedConfig).to.deep.equal({
+      create: [],
+      del: [],
+      update: []
+    });// Expect no change
   });
 });

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -12,7 +12,7 @@ const pool = {
 };
 
 describe('#connections handler', () => {
-  const config = function(key) {
+  const config = function (key) {
     return config.data && config.data[key];
   };
 
@@ -35,7 +35,7 @@ describe('#connections handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [ { connections: data } ]);
+        await stageFn.apply(handler, [{ connections: data }]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -51,7 +51,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
   });
 
@@ -59,7 +59,7 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
@@ -78,7 +78,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [ { name: 'someConnection' } ] } ]);
+      await stageFn.apply(handler, [{ connections: [{ name: 'someConnection' }] }]);
     });
 
     it('should get connections', async () => {
@@ -87,7 +87,7 @@ describe('#connections handler', () => {
       const auth0 = {
         connections: {
           getAll: () => [
-            { strategy: 'github', name: 'github', enabled_clients: [ clientId ] },
+            { strategy: 'github', name: 'github', enabled_clients: [clientId] },
             { strategy: 'auth0', name: 'db-should-be-ignored', enabled_clients: [] }
           ]
         },
@@ -101,33 +101,33 @@ describe('#connections handler', () => {
 
       const handler = new connections.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([ { strategy: 'github', name: 'github', enabled_clients: [ clientId ] } ]);
+      expect(data).to.deep.equal([{ strategy: 'github', name: 'github', enabled_clients: [clientId] }]);
     });
 
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
+          getAll: () => [{ name: 'someConnection', id: 'con1', strategy: 'custom' }]
         },
         clients: {
-          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
+          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
         },
         pool
       };
@@ -138,23 +138,23 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -168,12 +168,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -206,7 +206,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -219,7 +219,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -231,16 +231,16 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -254,12 +254,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -292,7 +292,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -305,7 +305,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: [ 'client1' ],
+          enabled_clients: ['client1'],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -317,7 +317,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -325,26 +325,26 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function(params, data) {
+          update: function (params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
+              enabled_clients: ['client1-id', 'excluded-one-id'],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ {
-            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: [ 'excluded-one-id' ]
-          } ]
+          getAll: () => [{
+            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: ['excluded-one-id']
+          }]
         },
         clients: {
           getAll: () => [
@@ -362,34 +362,34 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: [ 'client1', 'excluded-one', 'excluded-two' ],
+          enabled_clients: ['client1', 'excluded-one', 'excluded-two'],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data, exclude: { clients: [ 'excluded-one', 'excluded-two' ] } } ]);
+      await stageFn.apply(handler, [{ connections: data, exclude: { clients: ['excluded-one', 'excluded-two'] } }]);
     });
 
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -406,7 +406,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should delete all connections', async () => {
@@ -415,14 +415,14 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -433,7 +433,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [] } ]);
+      await stageFn.apply(handler, [{ connections: [] }]);
       expect(removed).to.equal(true);
     });
 
@@ -441,17 +441,17 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: function(data) {
+          create: function (data) {
             (() => expect(this).to.not.be.undefined)();
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -468,7 +468,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [ { connections: data } ]);
+      await stageFn.apply(handler, [{ connections: data }]);
     });
 
     it('should not remove connections if run by extension', async () => {
@@ -479,12 +479,12 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
         },
         clients: {
           getAll: () => []
@@ -495,7 +495,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { connections: [] } ]);
+      await stageFn.apply(handler, [{ connections: [] }]);
     });
 
     it('should not remove/create/update excluded connections', async () => {
@@ -513,7 +513,7 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function(params) {
+          delete: function (params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
@@ -533,12 +533,12 @@ describe('#connections handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const assets = {
         exclude: {
-          connections: [ 'existing1', 'existing2', 'existing3' ]
+          connections: ['existing1', 'existing2', 'existing3']
         },
-        connections: [ { name: 'existing3', strategy: 'custom' } ]
+        connections: [{ name: 'existing3', strategy: 'custom' }]
       };
 
-      await stageFn.apply(handler, [ assets ]);
+      await stageFn.apply(handler, [assets]);
     });
   });
 });
@@ -632,6 +632,28 @@ describe('#addExcludedConnectionPropertiesToChanges', () => {
     });
   });
 
+  it('should add entire excluded options object into connections update payload', () => {
+    const updatedProposedChanges = addExcludedConnectionPropertiesToChanges({
+      config: () => ({
+        EXCLUDED_PROPS: {
+          connections: [
+            'options',
+          ]
+        }
+      }),
+      existingConnections,
+      proposedChanges
+    });
+    expect(updatedProposedChanges.update).to.lengthOf(proposedChanges.update.length);
+    // Loop through proposed changes and expect to see connections that should have excluded properties to have them
+    updatedProposedChanges.update.forEach((change, i) => {
+      if (!change.shouldHaveExcludedProps) {
+        return expect(change).to.deep.equal(mockConnsWithoutExcludedProps[i]);
+      }
+      expect(change).to.deep.equal(mockConnsWithExcludedProps[i]);
+    });
+  });
+
   it('should not modify update payload if no excluded properties exist', () => {
     const updatedProposedChangesNoConfig = addExcludedConnectionPropertiesToChanges({
       config: () => ({}),
@@ -648,7 +670,10 @@ describe('#addExcludedConnectionPropertiesToChanges', () => {
         EXCLUDED_PROPS: {
           connections: [
             'some-unrelated-property-1',
-            'some-unrelated-property-2'
+            'options.some-unrelated-property-2',
+          ],
+          tenant: [
+            'some-unrelated-property-3'
           ]
         }
       }),

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -12,7 +12,7 @@ const pool = {
 };
 
 describe('#connections handler', () => {
-  const config = function (key) {
+  const config = function(key) {
     return config.data && config.data[key];
   };
 
@@ -35,7 +35,7 @@ describe('#connections handler', () => {
       ];
 
       try {
-        await stageFn.apply(handler, [{ connections: data }]);
+        await stageFn.apply(handler, [ { connections: data } ]);
       } catch (err) {
         expect(err).to.be.an('object');
         expect(err.message).to.include('Names must be unique');
@@ -51,7 +51,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
   });
 
@@ -59,7 +59,7 @@ describe('#connections handler', () => {
     it('should create connection', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
@@ -78,7 +78,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [{ name: 'someConnection' }] }]);
+      await stageFn.apply(handler, [ { connections: [ { name: 'someConnection' } ] } ]);
     });
 
     it('should get connections', async () => {
@@ -87,7 +87,7 @@ describe('#connections handler', () => {
       const auth0 = {
         connections: {
           getAll: () => [
-            { strategy: 'github', name: 'github', enabled_clients: [clientId] },
+            { strategy: 'github', name: 'github', enabled_clients: [ clientId ] },
             { strategy: 'auth0', name: 'db-should-be-ignored', enabled_clients: [] }
           ]
         },
@@ -101,33 +101,33 @@ describe('#connections handler', () => {
 
       const handler = new connections.default({ client: auth0, config });
       const data = await handler.getType();
-      expect(data).to.deep.equal([{ strategy: 'github', name: 'github', enabled_clients: [clientId] }]);
+      expect(data).to.deep.equal([ { strategy: 'github', name: 'github', enabled_clients: [ clientId ] } ]);
     });
 
     it('should update connection', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{ name: 'someConnection', id: 'con1', strategy: 'custom' }]
+          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
         },
         clients: {
-          getAll: () => [{ name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' }]
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -138,23 +138,23 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -168,12 +168,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -206,7 +206,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -219,7 +219,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -231,16 +231,16 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should keep client ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               name: 'someConnection-2',
               strategy: 'custom',
               options: {
@@ -254,12 +254,12 @@ describe('#connections handler', () => {
             });
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec'],
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
               options: {
                 passwordPolicy: 'testPolicy',
                 idpinitiated: {
@@ -292,7 +292,7 @@ describe('#connections handler', () => {
         {
           name: 'someSamlConnection',
           strategy: 'samlp',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -305,7 +305,7 @@ describe('#connections handler', () => {
         {
           name: 'someConnection-2',
           strategy: 'custom',
-          enabled_clients: ['client1'],
+          enabled_clients: [ 'client1' ],
           options: {
             passwordPolicy: 'testPolicy',
             idpinitiated: {
@@ -317,7 +317,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -325,26 +325,26 @@ describe('#connections handler', () => {
     it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
           },
-          update: function (params, data) {
+          update: function(params, data) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: ['client1-id', 'excluded-one-id'],
+              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [{
-            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: ['excluded-one-id']
-          }]
+          getAll: () => [ {
+            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: [ 'excluded-one-id' ]
+          } ]
         },
         clients: {
           getAll: () => [
@@ -362,34 +362,34 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          enabled_clients: ['client1', 'excluded-one', 'excluded-two'],
+          enabled_clients: [ 'client1', 'excluded-one', 'excluded-two' ],
           options: {
             passwordPolicy: 'testPolicy'
           }
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data, exclude: { clients: ['excluded-one', 'excluded-two'] } }]);
+      await stageFn.apply(handler, [ { connections: data, exclude: { clients: [ 'excluded-one', 'excluded-two' ] } } ]);
     });
 
     it('should delete connection and create another one instead', async () => {
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             expect(data).to.be.an('object');
             expect(data.name).to.equal('someConnection');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
 
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -406,7 +406,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should delete all connections', async () => {
@@ -415,14 +415,14 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve([]),
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             removed = true;
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -433,7 +433,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [] }]);
+      await stageFn.apply(handler, [ { connections: [] } ]);
       expect(removed).to.equal(true);
     });
 
@@ -441,17 +441,17 @@ describe('#connections handler', () => {
       config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
-          create: function (data) {
+          create: function(data) {
             (() => expect(this).to.not.be.undefined)();
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -468,7 +468,7 @@ describe('#connections handler', () => {
         }
       ];
 
-      await stageFn.apply(handler, [{ connections: data }]);
+      await stageFn.apply(handler, [ { connections: data } ]);
     });
 
     it('should not remove connections if run by extension', async () => {
@@ -479,12 +479,12 @@ describe('#connections handler', () => {
         connections: {
           create: () => Promise.resolve(),
           update: () => Promise.resolve([]),
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          getAll: () => [{ id: 'con1', name: 'existingConnection', strategy: 'custom' }]
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
         },
         clients: {
           getAll: () => []
@@ -495,7 +495,7 @@ describe('#connections handler', () => {
       const handler = new connections.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [{ connections: [] }]);
+      await stageFn.apply(handler, [ { connections: [] } ]);
     });
 
     it('should not remove/create/update excluded connections', async () => {
@@ -513,7 +513,7 @@ describe('#connections handler', () => {
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
           },
-          delete: function (params) {
+          delete: function(params) {
             (() => expect(this).to.not.be.undefined)();
             expect(params).to.be.an('undefined');
             return Promise.resolve([]);
@@ -533,12 +533,12 @@ describe('#connections handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const assets = {
         exclude: {
-          connections: ['existing1', 'existing2', 'existing3']
+          connections: [ 'existing1', 'existing2', 'existing3' ]
         },
-        connections: [{ name: 'existing3', strategy: 'custom' }]
+        connections: [ { name: 'existing3', strategy: 'custom' } ]
       };
 
-      await stageFn.apply(handler, [assets]);
+      await stageFn.apply(handler, [ assets ]);
     });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

### Problem
Developers [reporting of issues](https://github.com/auth0/auth0-deploy-cli/issues/420) where properties excluded through the `EXCLUDED_PROPS` configuration values were properly excluding them on export, but on subsequent imports were effectively being deleted. This occurs because of a small quirk with the [PATCH connections endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id):

>Note: if you use the options parameter, the whole options object will be overridden, so ensure that all parameters are present

Depending on the connection type, the result of this API call with critical excluded properties absent results in an error or success. In both cases, it precludes the ability to manage connections with excluded values. Fortunately as far as our team can tell, this _only_ affects connections. 

The solution here is to pluck the values of excluded properties from existing connections and add into the PATCH payload so that the excluded values are preserved in the tenant. The hope here is that the blast radius will be quite small and given the amount of test cases applied, should be fairly safe to introduce; we don't believe it's wise to apply a wider solution at this time.

## 🔗 References

- Relevant Github issue: #420 

## 🎯 Testing

Added the following test cases to the newly introduced `addExcludedConnectionPropertiesToChanges` function:

- Adding excluded properties when absent in the proposed changes
- Adding entire `options` property when excluded
- No change to payload if no config exists
- No change to payload if no relevant excluded properties exist
- No change to payload if no proposed updates exist
