### PR TITLE
Replacing dead link in log output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ if (require.main === module) {
       }
 
       if (typeof msg === 'string' && msg.includes('Payload validation error')) {
-        log.info('Please see https://github.com/auth0/auth0-deploy-cli#troubleshooting for common issues');
+        log.info('Please refer to the Auth0 Management API docs for expected payloads: https://auth0.com/docs/api/management/v2');
       }
       process.exit(1);
     });


### PR DESCRIPTION
## ✏️ Changes

As pointed out in #396, the link https://github.com/auth0/auth0-deploy-cli#troubleshooting doesn't resolve to an existing hash. A [deploy CLI troubleshooting page](https://auth0.com/docs/troubleshoot/integration-extensibility-issues/troubleshoot-the-deploy-cli-tool) _does_ exist, but it lacks actionable content.  This log outputs when there is an Auth0 API payload validation error, so instead, I'm suggesting we point to the Management API docs for more actionable troubleshooting. I'm not wedded to this link, but in my opinion it does seem more appropriate.



## 🔗 References

- #396 

## 🎯 Testing

No testing changes necessary.
