### PR TITLE
Fixing test script to re-included accidentally removed tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "lint": "eslint --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "pretest": "rimraf ./.nyc_output",
-    "test": "ts-mocha -p tsconfig.json --recursive 'test/**/*.test.*'",
+    "test": "ts-mocha -p tsconfig.json --recursive 'test/**/*.test*'",
     "build": "rimraf ./lib && npx tsc",
     "dev": "npx tsc --watch",
     "prepare": "npm run build",


### PR DESCRIPTION
## ✏️ Changes

As [@toddbaert](https://github.com/toddbaert) [noticed in his #438 PR](https://github.com/auth0/auth0-deploy-cli/pull/438/files#r825032594), we accidentally disabled a large swath of tests by incorrectly setting the target pattern. This issue was introduced in a PR #433, but incorrectly assumed that _all_ tests were renamed to `foo.test.js` instead, there were several remaining tests that looked like `foo.tests.js`. This inconsistency is likely a mistake leftover from another time, but it's relatively harmless to keep. This PR fixes this error and ensures that all tests run. We can fix the other inconsistencies at a later point in time.

## 🔗 References

> Include at least one link to an explanation + requirements for this change, and more if at all possible. Typically this is a Jira/GitHub Issue, but could also be links to Zendesk tickets, RFCs, rollout plan or Slack conversations (for Slack conversations, make sure you provide a summary of the conversation under “Changes”).

## 🎯 Testing

Manually ran the tests and can confirm that all 495 unit tests run now; previously only ~200 would run.