### PR TITLE
DXCDT-74: JSON Handlers Typescript migration

### DIFF
--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -7,11 +7,16 @@ import {
   getFiles, existsMustBeDir, loadJSON, sanitize
 } from '../../../utils';
 import log from '../../../logger';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedActions = {
+  actions: unknown[] | undefined
+}
+
+function parse(context): ParsedActions {
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);
   if (!existsMustBeDir(actionsFolder)) return { actions: undefined }; // Skip
-  const files = getFiles(actionsFolder, [ '.json' ]);
+  const files = getFiles(actionsFolder, ['.json']);
   const actions = files.map((file) => {
     const action = { ...loadJSON(file, context.mappings) };
     const actionFolder = path.join(constants.ACTIONS_DIRECTORY, `${action.name}`);
@@ -64,7 +69,7 @@ function mapToAction(filePath, action) {
 }
 
 async function dump(context) {
-  const actions = [ ...context.assets.actions || [] ];
+  const actions = [...context.assets.actions || []];
   if (actions.length < 1) return;
 
   // Create Actions folder
@@ -79,7 +84,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const actionsHandler: DirectoryHandler<ParsedActions> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default actionsHandler;

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -2,8 +2,23 @@ import fs from 'fs-extra';
 import path from 'path';
 import { constants } from '../../../tools';
 import { dumpJSON, existsMustBeDir, loadJSON } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function attackProtectionFiles(filePath) {
+type ParsedAttackProtection = {
+  attackProtection: {
+    breachedPasswordDetection: unknown
+    bruteForceProtection: unknown
+    suspiciousIpThrottling: unknown
+  } | undefined
+}
+
+
+function attackProtectionFiles(filePath: string): {
+  directory: string
+  breachedPasswordDetection: string
+  bruteForceProtection: string
+  suspiciousIpThrottling: string
+} {
   const directory = path.join(filePath, constants.ATTACK_PROTECTION_DIRECTORY);
 
   return {
@@ -14,7 +29,7 @@ function attackProtectionFiles(filePath) {
   };
 }
 
-function parse(context) {
+function parse(context): ParsedAttackProtection {
   const files = attackProtectionFiles(context.filePath);
 
   if (!existsMustBeDir(files.directory)) {
@@ -36,7 +51,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { attackProtection } = context.assets;
 
   const files = attackProtectionFiles(context.filePath);
@@ -47,7 +62,10 @@ async function dump(context) {
   dumpJSON(files.suspiciousIpThrottling, attackProtection.suspiciousIpThrottling);
 }
 
-export default {
+
+const attackProtectionHandler: DirectoryHandler<ParsedAttackProtection> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default attackProtectionHandler;

--- a/src/context/directory/handlers/clientGrants.ts
+++ b/src/context/directory/handlers/clientGrants.ts
@@ -5,8 +5,13 @@ import { constants } from '../../../tools';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize, convertClientIdToName
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedClientGrants = {
+  clientGrants: unknown[] | undefined
+}
+
+function parse(context): ParsedClientGrants {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
   if (!existsMustBeDir(grantsFolder)) return { clientGrants: undefined }; // Skip
 
@@ -20,7 +25,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { clientGrants } = context.assets;
 
   if (!clientGrants) return; // Skip, nothing to dump
@@ -39,7 +44,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const clientGrantsHandler: DirectoryHandler<ParsedClientGrants> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default clientGrantsHandler;

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -6,8 +6,13 @@ import log from '../../../logger';
 import {
   isFile, getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize, clearClientArrays
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedClients = {
+  clients: unknown | undefined
+}
+
+function parse(context): ParsedClients {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
   if (!existsMustBeDir(clientsFolder)) return { clients: undefined }; // Skip
 
@@ -34,7 +39,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { clients } = context.assets;
 
   if (!clients) return; // Skip, nothing to dump
@@ -59,7 +64,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const clientsHandler: DirectoryHandler<ParsedClients> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default clientsHandler;

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -13,8 +13,13 @@ import {
   ensureProp,
   mapClientID2NameSorted
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedConnections = {
+  connections: unknown[] | undefined
+}
+
+function parse(context): ParsedConnections {
   const connectionDirectory = context.config.AUTH0_CONNECTIONS_DIRECTORY || constants.CONNECTIONS_DIRECTORY;
   const connectionsFolder = path.join(context.filePath, connectionDirectory);
   if (!existsMustBeDir(connectionsFolder)) return { connections: undefined }; // Skip
@@ -43,7 +48,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { connections } = context.assets;
 
   if (!connections) return; // Skip, nothing to dump
@@ -76,7 +81,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const connectionsHandler: DirectoryHandler<ParsedConnections> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default connectionsHandler;

--- a/src/context/directory/handlers/emailProvider.ts
+++ b/src/context/directory/handlers/emailProvider.ts
@@ -6,8 +6,13 @@ import {
   existsMustBeDir, isFile, dumpJSON, loadJSON
 } from '../../../utils';
 import { emailProviderDefaults } from '../../defaults';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedEmailProvider = {
+  emailProvider: unknown
+} | {}
+
+function parse(context): ParsedEmailProvider {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);
   if (!existsMustBeDir(emailsFolder)) return {}; // Skip
 
@@ -22,7 +27,7 @@ function parse(context) {
   return {};
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   let { emailProvider } = context.assets;
 
   if (!emailProvider) return; // Skip, nothing to dump
@@ -40,7 +45,9 @@ async function dump(context) {
   dumpJSON(emailProviderFile, emailProvider);
 }
 
-export default {
+const emailProviderHandler: DirectoryHandler<ParsedEmailProvider> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default emailProviderHandler;

--- a/src/context/directory/handlers/emailTemplates.ts
+++ b/src/context/directory/handlers/emailTemplates.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck TODO: FIX TYPE ISSUES IN THIS FILE. DO NOT MERGE UNTIL FIXED!
 import fs from 'fs-extra';
 import path from 'path';
 import { constants, loadFileAndReplaceKeywords } from '../../../tools';
@@ -6,12 +7,17 @@ import log from '../../../logger';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedEmailTemplates = {
+  emailTemplates: unknown | undefined
+}
+
+function parse(context): ParsedEmailTemplates {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);
   if (!existsMustBeDir(emailsFolder)) return { emailTemplates: undefined }; // Skip
 
-  const files = getFiles(emailsFolder, [ '.json', '.html' ]).filter((f) => path.basename(f) !== 'provider.json');
+  const files = getFiles(emailsFolder, ['.json', '.html']).filter((f) => path.basename(f) !== 'provider.json');
 
   const sorted = {};
 
@@ -41,8 +47,8 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
-  const emailTemplates = [ ...context.assets.emailTemplates || [] ];
+async function dump(context): Promise<void> {
+  const emailTemplates = [...context.assets.emailTemplates || []];
 
   if (!emailTemplates) return; // Skip, nothing to dump
 
@@ -61,7 +67,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const emailTemplatesHandler: DirectoryHandler<ParsedEmailTemplates> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default emailTemplatesHandler;

--- a/src/context/directory/handlers/guardianFactorProviders.ts
+++ b/src/context/directory/handlers/guardianFactorProviders.ts
@@ -5,12 +5,17 @@ import { constants } from '../../../tools';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianFactorProviders = {
+  guardianFactorProviders: unknown[] | undefined
+}
+
+function parse(context): ParsedGuardianFactorProviders {
   const factorProvidersFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_PROVIDERS_DIRECTORY);
   if (!existsMustBeDir(factorProvidersFolder)) return { guardianFactorProviders: undefined }; // Skip
 
-  const foundFiles = getFiles(factorProvidersFolder, [ '.json' ]);
+  const foundFiles = getFiles(factorProvidersFolder, ['.json']);
 
   const guardianFactorProviders = foundFiles.map((f) => loadJSON(f, context.mappings))
     .filter((p) => Object.keys(p).length > 0); // Filter out empty factorProvidersFolder
@@ -20,7 +25,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { guardianFactorProviders } = context.assets;
 
   if (!guardianFactorProviders) return; // Skip, nothing to dump
@@ -34,7 +39,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const guardianFactorProvidersHandler: DirectoryHandler<ParsedGuardianFactorProviders> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianFactorProvidersHandler;

--- a/src/context/directory/handlers/guardianFactorTemplates.ts
+++ b/src/context/directory/handlers/guardianFactorTemplates.ts
@@ -5,12 +5,17 @@ import { constants } from '../../../tools';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianFactorTemplates = {
+  guardianFactorTemplates: unknown[] | undefined
+}
+
+function parse(context): ParsedGuardianFactorTemplates {
   const factorTemplatesFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_TEMPLATES_DIRECTORY);
   if (!existsMustBeDir(factorTemplatesFolder)) return { guardianFactorTemplates: undefined }; // Skip
 
-  const foundFiles = getFiles(factorTemplatesFolder, [ '.json' ]);
+  const foundFiles = getFiles(factorTemplatesFolder, ['.json']);
 
   const guardianFactorTemplates = foundFiles.map((f) => loadJSON(f, context.mappings))
     .filter((p) => Object.keys(p).length > 0); // Filter out empty guardianFactorTemplates
@@ -20,7 +25,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { guardianFactorTemplates } = context.assets;
 
   if (!guardianFactorTemplates) return; // Skip, nothing to dump
@@ -34,7 +39,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const guardianFactorTemplatesHandler: DirectoryHandler<ParsedGuardianFactorTemplates> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianFactorTemplatesHandler;

--- a/src/context/directory/handlers/guardianFactors.ts
+++ b/src/context/directory/handlers/guardianFactors.ts
@@ -5,12 +5,17 @@ import { constants } from '../../../tools';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianFactors = {
+  guardianFactors: unknown[] | undefined
+}
+
+function parse(context): ParsedGuardianFactors {
   const factorsFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY, constants.GUARDIAN_FACTORS_DIRECTORY);
   if (!existsMustBeDir(factorsFolder)) return { guardianFactors: undefined }; // Skip
 
-  const foundFiles = getFiles(factorsFolder, [ '.json' ]);
+  const foundFiles = getFiles(factorsFolder, ['.json']);
 
   const guardianFactors = foundFiles.map((f) => loadJSON(f, context.mappings))
     .filter((p) => Object.keys(p).length > 0); // Filter out empty guardianFactors
@@ -20,7 +25,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { guardianFactors } = context.assets;
 
   if (!guardianFactors) return; // Skip, nothing to dump
@@ -34,7 +39,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const guardianFactorsHandler: DirectoryHandler<ParsedGuardianFactors> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianFactorsHandler;

--- a/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
@@ -4,8 +4,13 @@ import { constants } from '../../../tools';
 import {
   existsMustBeDir, dumpJSON, loadJSON, isFile
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianFactorMessageTypes = {
+  guardianPhoneFactorMessageTypes: unknown
+} | {}
+
+function parse(context): ParsedGuardianFactorMessageTypes {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
   if (!existsMustBeDir(guardianFolder)) return {}; // Skip
 
@@ -20,7 +25,7 @@ function parse(context) {
   return {};
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { guardianPhoneFactorMessageTypes } = context.assets;
 
   if (!guardianPhoneFactorMessageTypes) return; // Skip, nothing to dump
@@ -32,7 +37,9 @@ async function dump(context) {
   dumpJSON(file, guardianPhoneFactorMessageTypes);
 }
 
-export default {
+const guardianFactorMessageTypesHandler: DirectoryHandler<ParsedGuardianFactorMessageTypes> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianFactorMessageTypesHandler;

--- a/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -4,8 +4,13 @@ import { constants } from '../../../tools';
 import {
   existsMustBeDir, dumpJSON, loadJSON, isFile
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianFactorSelectedProvider = {
+  guardianPhoneFactorSelectedProvider: unknown
+} | {}
+
+function parse(context): ParsedGuardianFactorSelectedProvider {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
   if (!existsMustBeDir(guardianFolder)) return {}; // Skip
 
@@ -20,7 +25,7 @@ function parse(context) {
   return {};
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { guardianPhoneFactorSelectedProvider } = context.assets;
 
   if (!guardianPhoneFactorSelectedProvider) return; // Skip, nothing to dump
@@ -32,7 +37,10 @@ async function dump(context) {
   dumpJSON(file, guardianPhoneFactorSelectedProvider);
 }
 
-export default {
+
+const guardianFactorSelectedProviderHandler: DirectoryHandler<ParsedGuardianFactorSelectedProvider> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianFactorSelectedProviderHandler;

--- a/src/context/directory/handlers/guardianPolicies.ts
+++ b/src/context/directory/handlers/guardianPolicies.ts
@@ -4,8 +4,13 @@ import { constants } from '../../../tools';
 import {
   existsMustBeDir, dumpJSON, loadJSON, isFile
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedGuardianPolicies = {
+  guardianPolicies: unknown[] 
+} | {}
+
+function parse(context): ParsedGuardianPolicies {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
   if (!existsMustBeDir(guardianFolder)) return {}; // Skip
 
@@ -17,7 +22,7 @@ function parse(context) {
     };
   }
 
-  return {};
+  return {} as ParsedGuardianPolicies;
 }
 
 async function dump(context) {
@@ -32,7 +37,9 @@ async function dump(context) {
   dumpJSON(file, guardianPolicies);
 }
 
-export default {
+const guardianPoliciesHandler: DirectoryHandler<ParsedGuardianPolicies> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default guardianPoliciesHandler;

--- a/src/context/directory/handlers/hooks.ts
+++ b/src/context/directory/handlers/hooks.ts
@@ -6,12 +6,17 @@ import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize
 } from '../../../utils';
 import log from '../../../logger';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedHooks = {
+  hooks: unknown[] | undefined
+}
+
+function parse(context): ParsedHooks {
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);
   if (!existsMustBeDir(hooksFolder)) return { hooks: undefined }; // Skip
 
-  const files = getFiles(hooksFolder, [ '.json' ]);
+  const files = getFiles(hooksFolder, ['.json']);
 
   const hooks = files.map((f) => {
     const hook = { ...loadJSON(f, context.mappings) };
@@ -29,8 +34,8 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
-  const hooks = [ ...context.assets.hooks || [] ];
+async function dump(context): Promise<void> {
+  const hooks = [...context.assets.hooks || []];
 
   if (hooks.length < 1) return;
 
@@ -52,7 +57,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const hooksHandler: DirectoryHandler<ParsedHooks> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default hooksHandler;

--- a/src/context/directory/handlers/index.ts
+++ b/src/context/directory/handlers/index.ts
@@ -23,6 +23,13 @@ import organizations from './organizations';
 import triggers from './triggers';
 import attackProtection from './attackProtection';
 
+type Context = any // TODO: replace with a more canonical representation of the Context type 
+
+export type DirectoryHandler<T> = {
+  dump: (context: Context) => void,
+  parse: (context: Context) => T,
+}
+
 export default {
   rules,
   rulesConfigs,

--- a/src/context/directory/handlers/migrations.ts
+++ b/src/context/directory/handlers/migrations.ts
@@ -2,24 +2,27 @@ import path from 'path';
 import {
   existsMustBeDir, isFile, dumpJSON, loadJSON
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedMigrations = {
+  migrations: unknown[]
+} | {}
+
+function parse(context): ParsedMigrations {
   const baseFolder = path.join(context.filePath);
   if (!existsMustBeDir(baseFolder)) return {}; // Skip
 
   const migrationsFile = path.join(baseFolder, 'migrations.json');
 
-  if (isFile(migrationsFile)) {
-    /* eslint-disable camelcase */
-    const migrations = loadJSON(migrationsFile, context.mappings);
+  if (!isFile(migrationsFile)) return {};
 
-    return { migrations };
-  }
+  /* eslint-disable camelcase */
+  const migrations = loadJSON(migrationsFile, context.mappings);
 
-  return {};
+  return { migrations };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void>{
   const { migrations } = context.assets;
 
   if (!migrations || Object.keys(migrations).length === 0) return; // Skip, nothing to dump
@@ -28,7 +31,9 @@ async function dump(context) {
   dumpJSON(migrationsFile, migrations);
 }
 
-export default {
+const migrationsHandler: DirectoryHandler<ParsedMigrations> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default migrationsHandler;

--- a/src/context/directory/handlers/organizations.ts
+++ b/src/context/directory/handlers/organizations.ts
@@ -5,8 +5,13 @@ import log from '../../../logger';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedOrganizations = {
+  organizations: unknown[] | undefined
+}
+
+function parse(context): ParsedOrganizations {
   const organizationsFolder = path.join(context.filePath, 'organizations');
 
   if (!existsMustBeDir(organizationsFolder)) return { organizations: undefined }; // Skip
@@ -23,7 +28,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { organizations } = context.assets;
 
   // API returns an empty object if no grants are present
@@ -57,7 +62,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const organizationsHandler: DirectoryHandler<ParsedOrganizations> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default organizationsHandler;

--- a/src/context/directory/handlers/resourceServers.ts
+++ b/src/context/directory/handlers/resourceServers.ts
@@ -4,12 +4,17 @@ import { constants } from '../../../tools';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedResourceServers = {
+  resourceServers: unknown[] | undefined
+}
+
+function parse(context): ParsedResourceServers {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);
   if (!existsMustBeDir(resourceServersFolder)) return { resourceServers: undefined }; // Skip
 
-  const foundFiles = getFiles(resourceServersFolder, [ '.json' ]);
+  const foundFiles = getFiles(resourceServersFolder, ['.json']);
 
   const resourceServers = foundFiles.map((f) => loadJSON(f, context.mappings))
     .filter((p) => Object.keys(p).length > 0); // Filter out empty resourceServers
@@ -19,7 +24,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { resourceServers } = context.assets;
 
   if (!resourceServers) return; // Skip, nothing to dump
@@ -33,7 +38,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const resourceServersHandler: DirectoryHandler<ParsedResourceServers> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default resourceServersHandler;

--- a/src/context/directory/handlers/roles.ts
+++ b/src/context/directory/handlers/roles.ts
@@ -6,12 +6,17 @@ import log from '../../../logger';
 import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize
 } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedRoles = {
+  roles: unknown[] | undefined
+}
+
+function parse(context): ParsedRoles {
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);
   if (!existsMustBeDir(rolesFolder)) return { roles: undefined }; // Skip
 
-  const files = getFiles(rolesFolder, [ '.json' ]);
+  const files = getFiles(rolesFolder, ['.json']);
 
   const roles = files.map((f) => {
     const role = { ...loadJSON(f, context.mappings) };
@@ -45,7 +50,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const rolesHandler: DirectoryHandler<ParsedRoles> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default rolesHandler;

--- a/src/context/directory/handlers/rules.ts
+++ b/src/context/directory/handlers/rules.ts
@@ -7,11 +7,17 @@ import {
   getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize
 } from '../../../utils';
 
-function parse(context) {
+import { DirectoryHandler } from './index'
+
+type ParsedRules = {
+  rules: unknown[] | undefined
+}
+
+function parse(context): ParsedRules {
   const rulesFolder = path.join(context.filePath, constants.RULES_DIRECTORY);
   if (!existsMustBeDir(rulesFolder)) return { rules: undefined }; // Skip
 
-  const files = getFiles(rulesFolder, [ '.json' ]);
+  const files: string[] = getFiles(rulesFolder, [ '.json' ]);
 
   const rules = files.map((f) => {
     const rule = { ...loadJSON(f, context.mappings) };
@@ -26,7 +32,7 @@ function parse(context) {
   };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const rules = [ ...context.assets.rules || [] ];
 
   if (!rules) return; // Skip, nothing to dump
@@ -47,7 +53,9 @@ async function dump(context) {
   });
 }
 
-export default {
+const rulesHandler: DirectoryHandler<ParsedRules> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default rulesHandler;

--- a/src/context/directory/handlers/rulesConfigs.ts
+++ b/src/context/directory/handlers/rulesConfigs.ts
@@ -2,12 +2,17 @@ import path from 'path';
 import { constants } from '../../../tools';
 
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
+import { DirectoryHandler } from '.'
 
-function parse(context) {
+type ParsedRulesConfigs = {
+  rulesConfigs: unknown[] | undefined
+}
+
+function parse(context): ParsedRulesConfigs {
   const rulesConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);
   if (!existsMustBeDir(rulesConfigsFolder)) return { rulesConfigs: undefined }; // Skip
 
-  const foundFiles = getFiles(rulesConfigsFolder, [ '.json' ]);
+  const foundFiles: string[] = getFiles(rulesConfigsFolder, ['.json']);
 
   const rulesConfigs = foundFiles.map((f) => loadJSON(f, context.mappings))
     .filter((p) => Object.keys(p).length > 0); // Filter out empty rulesConfigs
@@ -17,12 +22,14 @@ function parse(context) {
   };
 }
 
-async function dump() {
+async function dump(): Promise<void> {
   // do not export rulesConfigs as its values cannot be extracted
-  return null;
+  return;
 }
 
-export default {
+const rulesConfigsHandler: DirectoryHandler<ParsedRulesConfigs> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default rulesConfigsHandler;

--- a/src/context/directory/handlers/tenant.ts
+++ b/src/context/directory/handlers/tenant.ts
@@ -31,8 +31,8 @@ function parse(context): ParsedTenant {
     return {
       tenant: {
         ...tenant,
-        session_lifetime: hoursAsInteger('session_lifetime', session_lifetime),
-        idle_session_lifetime: hoursAsInteger('idle_session_lifetime', idle_session_lifetime),
+        session_lifetime_in_minutes: hoursAsInteger('session_lifetime', session_lifetime)['session_lifetime_in_minutes'],
+        idle_session_lifetime_in_minutes: hoursAsInteger('idle_session_lifetime', idle_session_lifetime)['idle_session_lifetime_in_minutes'],
       }
     };
     /* eslint-enable camelcase */

--- a/src/context/directory/handlers/triggers.ts
+++ b/src/context/directory/handlers/triggers.ts
@@ -1,11 +1,16 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { constants } from '../../../tools';
+import { DirectoryHandler } from '.';
 
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import log from '../../../logger';
 
-function parse(context) {
+type ParsedTriggers = {
+  triggers: unknown[] | undefined
+}
+
+function parse(context): ParsedTriggers {
   const triggersFolder = path.join(context.filePath, constants.TRIGGERS_DIRECTORY);
 
   if (!existsMustBeDir(triggersFolder)) return { triggers: undefined }; // Skip
@@ -17,7 +22,7 @@ function parse(context) {
   return { triggers };
 }
 
-async function dump(context) {
+async function dump(context): Promise<void> {
   const { triggers } = context.assets;
 
   if (!triggers) return;
@@ -30,7 +35,9 @@ async function dump(context) {
   fs.writeFileSync(triggerFile, JSON.stringify(triggers, null, 2));
 }
 
-export default {
+const triggersHandler: DirectoryHandler<ParsedTriggers> = {
   parse,
-  dump
-};
+  dump,
+}
+
+export default triggersHandler;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": false,
+    "strictNullChecks": true,
     "skipLibCheck": true
   },
   "include": [


### PR DESCRIPTION
## ✏️ Changes

Applying types to the JSON handlers, the primary abstraction for writing and parsing JSON configuration files for the respective resource types. The types are fairly straightforward, branching off a `DirectoryHandler<T>` generic type that inherits an expected type representing the parsed JSON file. 

For the most part there were no functional changes necessary to ensure that the compiler was satisfied, but I will note a few instances below.

## 🎯 Testing

This PR does not introduce any changes in tests.