### PR TITLE
Fix: Removing colliding 'e' alias for `env`

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -64,7 +64,6 @@ function getParams() {
         type: 'string'
       },
       env: {
-        alias: 'e',
         describe: 'Override the mappings in config with environment variables.',
         boolean: true,
         default: false

--- a/src/args.ts
+++ b/src/args.ts
@@ -28,7 +28,6 @@ function getParams() {
         type: 'string'
       },
       env: {
-        alias: 'e',
         describe: 'Override the mappings in config with environment variables.',
         boolean: true,
         default: true


### PR DESCRIPTION
## ✏️ Changes

As pointed out in #450, there is a colliding "e" argument alias for the export command. This could result in a collision and/or unexpected behavior for both the `export_ids` and `env` configuration parameters. This was introduced in a [recent commit](https://github.com/auth0/auth0-deploy-cli/pull/432/commits/2a739642ebb8d287e2e7c30339375bf9597adee5#diff-f15b8e97bcfc645f8a5c25ac00512ae33cc1fb1e338fc9c079a1822e560a59dcR67) to address the missing `env` argument.

I've gone ahead and removed the "e" env alias for both import and export to reduce ambiguity. Further, the documentation of that feature only reference using it with the full `--env` flag name. While this is technically a breaking change, this alias is so new and undocumented that I do not believe it will introduce any further regressions in practice.

## 🔗 References

- #450 

## 🎯 Testing

Did a few local fixes locally to ensure this fixed the issue; more comprehensive automated tests for the command-line components of this software would be nice though.
