### PR TITLE
DXCDT-71: Auth0 API handler default class Typescript migration

### DIFF
--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -7,9 +7,8 @@ import handlers from './handlers';
 import {
   isDirectory, isFile, stripIdentifiers, toConfigFn
 } from '../../utils';
-import { Assets } from '..'
+import { Assets, Auth0APIClient, Config } from '../../types'
 
-type Config = { [key: string]: any }// TODO: replace with a more canonical representation of the Config type 
 type ManagementAPIClient = unknown// TODO: replace with a more canonical representation of the ManagementAPIClient type 
 type KeywordMappings = { [key: string]: (string | number)[] | string | number }
 
@@ -21,7 +20,7 @@ export default class DirectoryContext {
   mgmtClient: ManagementAPIClient;
   assets: Assets
 
-  constructor(config, mgmtClient) {
+  constructor(config: Config, mgmtClient: Auth0APIClient) {
     this.filePath = config.AUTH0_INPUT_FILE;
     this.config = config;
     this.mappings = config.AUTH0_KEYWORD_REPLACE_MAPPINGS;
@@ -40,7 +39,7 @@ export default class DirectoryContext {
     };
   }
 
-  loadFile(f:string, folder:string) {
+  loadFile(f: string, folder: string) {
     const basePath = path.join(this.filePath, folder);
     let toLoad = path.join(basePath, f);
     if (!isFile(toLoad)) {
@@ -50,7 +49,7 @@ export default class DirectoryContext {
     return loadFileAndReplaceKeywords(toLoad, this.mappings);
   }
 
-  async load() {
+  async load(): Promise<void> {
     if (isDirectory(this.filePath)) {
       /* If this is a directory, look for each file in the directory */
       log.info(`Processing directory ${this.filePath}`);
@@ -68,7 +67,7 @@ export default class DirectoryContext {
     throw new Error(`Not sure what to do with, ${this.filePath} as it is not a directory...`);
   }
 
-  async dump() {
+  async dump(): Promise<void> {
     const auth0 = new Auth0(this.mgmtClient, this.assets, toConfigFn(this.config));
     log.info('Loading Auth0 Tenant Data');
     await auth0.loadAll();

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -5,6 +5,7 @@ import DirectoryContext from './directory';
 
 import { isDirectory } from '../utils';
 import log from '../logger';
+import { Config } from '../types'
 
 const { version: packageVersion } = require('../../package.json')
 
@@ -19,50 +20,6 @@ const nonPrimitiveProps = [
   'EXCLUDED_PROPS',
   'INCLUDED_PROPS'
 ];
-
-type Config = {
-  AUTH0_DOMAIN: string
-  AUTH0_CLIENT_ID: string
-  AUTH0_CLIENT_SECRET: string
-  AUTH0_INPUT_FILE: string
-  AUTH0_ACCESS_TOKEN?: string
-  AUTH0_AUDIENCE?: string
-  AUTH0_API_MAX_RETRIES?: number
-}// TODO
-
-type Asset = { [key: string]: any }
-
-export type Assets = {
-  actions: Asset[],
-  attackProtection: Asset,
-  clients: Asset[],
-  clientGrants: Asset[],
-  connections: Asset[],
-  databases: Asset[],
-  emailProvider: Asset,
-  emailTemplates: Asset[],
-  guardianFactorProviders: Asset[],
-  guardianFactors: Asset[],
-  guardianFactorTemplates: Asset[],
-  guardianPhoneFactorMessageTypes: Asset[],
-  guardianPhoneFactorSelectedProvider: Asset,
-  guardianPolicies: Asset[],
-  hooks: Asset[],
-  migrations: Asset[]
-  organizations: Asset[],
-  pages: Asset[],
-  resourceServers: Asset[],
-  roles: Asset[],
-  rules: Asset[],
-  rulesConfigs: Asset[],
-  tenant: Asset,
-  triggers: Asset[],
-  //non-resource types
-  exclude: {
-    [key: string]: string[]
-  },
-  clientsOrig: Asset[],
-}
 
 export const setupContext = async (config: Config): Promise<DirectoryContext | YAMLContext> => {
   // Validate config

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../../utils';
 import handlers from './handlers';
 import cleanAssets from '../../readonly';
-import { Assets } from '..'
+import { Assets } from '../../types'
 
 
 type Config = { [key: string]: any }// TODO: replace with a more canonical representation of the Config type 

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -5,6 +5,8 @@ import {
   stripFields, dumpJSON, duplicateItems
 } from '../../utils';
 import { calculateChanges } from '../../calculateChanges';
+import { Asset, Assets, Auth0APIClient, Config } from '../../../types'
+
 
 export function order(value) {
   return function decorator(t, n, descriptor) {
@@ -13,33 +15,47 @@ export function order(value) {
   };
 }
 
-export default class DefaultHandler {
-  constructor(options) {
+export default class APIHandler {
+  config: any
+  id: string
+  type: string
+  updated: number
+  created: number
+  deleted: number
+  existing: Asset | Asset[] | null
+  client: Auth0APIClient // TODO: apply stronger types to Auth0 API client
+  identifiers: string[]
+  objectFields: string[]
+  stripUpdateFields: string[]
+  name?:string // TODO: understand if any handlers actually leverage `name` property
+
+  constructor(options: {
+    id?: APIHandler['id'],
+    config: Config,
+    type: APIHandler['type'],
+    client: Auth0APIClient,
+    objectFields?: APIHandler['objectFields']
+    identifiers?: APIHandler['identifiers']
+    stripUpdateFields?: APIHandler['stripUpdateFields']
+  }) {
     this.config = options.config;
     this.type = options.type;
     this.id = options.id || 'id';
     this.client = options.client;
     this.existing = null;
-    this.identifiers = options.identifiers || [ 'id', 'name' ];
+    this.identifiers = options.identifiers || ['id', 'name'];
     this.objectFields = options.objectFields || [];
     this.stripUpdateFields = [
       ...options.stripUpdateFields || [],
       this.id
     ];
-    this.functions = {
-      getAll: 'getAll',
-      create: 'create',
-      update: 'update',
-      delete: 'delete',
-      ...options.functions || {}
-    };
 
     this.updated = 0;
     this.created = 0;
     this.deleted = 0;
   }
 
-  getClientFN(fn) {
+  getClientFN(fn: 'getAll' | 'create' | 'update' | 'delete') {
     if (typeof fn === 'string') {
       const client = this.client[this.type];
       return client[fn].bind(client);
@@ -47,35 +63,35 @@ export default class DefaultHandler {
     return fn;
   }
 
-  didDelete(item) {
+  didDelete(item: Asset): void {
     log.info(`Deleted [${this.type}]: ${this.objString(item)}`);
   }
 
-  didCreate(item) {
+  didCreate(item: Asset): void {
     log.info(`Created [${this.type}]: ${this.objString(item)}`);
   }
 
-  didUpdate(item) {
+  didUpdate(item: Asset): void {
     log.info(`Updated [${this.type}]: ${this.objString(item)}`);
   }
 
-  objString(item) {
+  objString(item: Asset): string {
     return dumpJSON(item);
   }
 
-  async getType() {
+  async getType(): Promise<Asset> {
     // Each type to impl how to get the existing as its not consistent across the mgnt api.
     throw new Error(`Must implement getType for type ${this.type}`);
   }
 
-  async load() {
+  async load(): Promise<{ [key: string]: Asset }> {
     // Load Asset from Tenant
     log.info(`Retrieving ${this.type} data from Auth0`);
     this.existing = await this.getType();
     return { [this.type]: this.existing };
   }
 
-  async calcChanges(assets) {
+  async calcChanges(assets: Assets) {
     const typeAssets = assets[this.type];
 
     // Do nothing if not set
@@ -87,12 +103,13 @@ export default class DefaultHandler {
     return calculateChanges({
       handler: this,
       assets: typeAssets,
+      //@ts-ignore TODO: investigate what happens when `existing` is null
       existing,
       identifiers: this.identifiers
     });
   }
 
-  async validate(assets) {
+  async validate(assets: Assets): Promise<void> {
     // Ensure no duplication in id and name
     const typeAssets = assets[this.type];
 
@@ -143,7 +160,7 @@ export default class DefaultHandler {
         await this.client.pool.addEachTask({
           data: del || [],
           generator: (delItem) => {
-            const delFunction = this.getClientFN(this.functions.delete);
+            const delFunction = this.getClientFN('delete');
             return delFunction({ [this.id]: delItem[this.id] })
               .then(() => {
                 this.didDelete(delItem);
@@ -161,7 +178,7 @@ export default class DefaultHandler {
     await this.client.pool.addEachTask({
       data: conflicts || [],
       generator: (updateItem) => {
-        const updateFN = this.getClientFN(this.functions.update);
+        const updateFN = this.getClientFN('update');
         const params = { [this.id]: updateItem[this.id] };
         const payload = stripFields({ ...updateItem }, this.stripUpdateFields);
         return updateFN(params, payload)
@@ -176,7 +193,7 @@ export default class DefaultHandler {
     await this.client.pool.addEachTask({
       data: create || [],
       generator: (createItem) => {
-        const createFunction = this.getClientFN(this.functions.create);
+        const createFunction = this.getClientFN('create');
         return createFunction(createItem)
           .then((data) => {
             this.didCreate(data);
@@ -192,7 +209,7 @@ export default class DefaultHandler {
     await this.client.pool.addEachTask({
       data: update || [],
       generator: (updateItem) => {
-        const updateFN = this.getClientFN(this.functions.update);
+        const updateFN = this.getClientFN('update');
         const params = { [this.id]: updateItem[this.id] };
         const payload = stripFields({ ...updateItem }, this.stripUpdateFields);
         return updateFN(params, payload)

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -22,12 +22,18 @@ export default class APIHandler {
   updated: number
   created: number
   deleted: number
-  existing: Asset | Asset[] | null
+  existing: null | Asset | Asset[]
   client: Auth0APIClient // TODO: apply stronger types to Auth0 API client
   identifiers: string[]
   objectFields: string[]
   stripUpdateFields: string[]
-  name?:string // TODO: understand if any handlers actually leverage `name` property
+  name?: string // TODO: understand if any handlers actually leverage `name` property
+  functions: {
+    getAll: 'getAll',
+    update: 'update'
+    create: 'create',
+    delete: 'delete'
+  }// TODO: delete this enum object in favor of tighter typing
 
   constructor(options: {
     id?: APIHandler['id'],
@@ -37,6 +43,9 @@ export default class APIHandler {
     objectFields?: APIHandler['objectFields']
     identifiers?: APIHandler['identifiers']
     stripUpdateFields?: APIHandler['stripUpdateFields']
+    functions?: {
+      [key: string]: string
+    }//TODO: understand if any resource types pass in any additional functions
   }) {
     this.config = options.config;
     this.type = options.type;
@@ -50,12 +59,20 @@ export default class APIHandler {
       this.id
     ];
 
+    this.functions = {
+      getAll: 'getAll',
+      create: 'create',
+      delete: 'delete',
+      update: 'update',
+      ...options.functions || {}
+    }
+
     this.updated = 0;
     this.created = 0;
     this.deleted = 0;
   }
 
-  getClientFN(fn: 'getAll' | 'create' | 'update' | 'delete') {
+  getClientFN(fn: 'getAll' | 'create' | 'update' | 'delete' | Function): Function {
     if (typeof fn === 'string') {
       const client = this.client[this.type];
       return client[fn].bind(client);

--- a/src/tools/calculateChanges.ts
+++ b/src/tools/calculateChanges.ts
@@ -1,4 +1,6 @@
 import log from './logger';
+import APIHandler from '../tools/auth0/handlers/default'
+import { Asset } from '../types'
 
 /**
  * @template T
@@ -12,7 +14,7 @@ import log from './logger';
 export function processChangedObjectFields({
     handler, desiredAssetState, currentAssetState, allowDelete = false
 }: {
-    handler: Handler,
+    handler: APIHandler,
     desiredAssetState: Asset,
     currentAssetState: Asset,
     allowDelete?: boolean
@@ -79,22 +81,8 @@ export function processChangedObjectFields({
     return desiredAssetStateWithChanges;
 }
 
-// Temporary type for Asset until more canonical types are created
-type Asset = {
-    [key: string]: { [key: string]: string } | string//Temporarily accounting for different types of assets with arbitrary properties
-}
-
-// Temporary type for Auth0 API handler until more canonical types are created
-type Handler = {
-    id: string
-    name?: string
-    objectFields: string[]
-    objString: (arg0: Asset) => string
-}
-
-
 export function calculateChanges({ handler, assets, existing, identifiers = ['id', 'name'], allowDelete }: {
-    handler: Handler,
+    handler: APIHandler,
     assets: Asset[],
     existing: Asset[],
     identifiers: string[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,62 @@
+export type Auth0APIClient = {
+    [key: string]: {
+        getAll: any,
+        create: any,
+        update: any,
+        delete: any,
+    }
+    pool: any
+}// TODO: replace with a more accurate representation of the Auth0APIClient type 
+
+export type Config = {
+    AUTH0_DOMAIN: string
+    AUTH0_CLIENT_ID: string
+    AUTH0_CLIENT_SECRET: string
+    AUTH0_INPUT_FILE: string
+    AUTH0_ACCESS_TOKEN?: string
+    AUTH0_AUDIENCE?: string
+    AUTH0_API_MAX_RETRIES?: number
+    AUTH0_KEYWORD_REPLACE_MAPPINGS?: any
+    AUTH0_EXCLUDED_RULES?: any
+    AUTH0_EXCLUDED_CLIENTS?: any
+    AUTH0_EXCLUDED_DATABASES?: any
+    AUTH0_EXCLUDED_CONNECTIONS?: any
+    AUTH0_EXCLUDED_RESOURCE_SERVERS?: any
+    AUTH0_EXCLUDED_DEFAULTS?: any
+    AUTH0_EXPORT_IDENTIFIERS?: boolean
+    AUTH0_CONNECTIONS_DIRECTORY?: string
+}// TODO: replace with a more accurate representation of the Config type 
+
+export type Asset = { [key: string]: any }
+
+export type Assets = {
+    actions: Asset[],
+    attackProtection: Asset,
+    clients: Asset[],
+    clientGrants: Asset[],
+    connections: Asset[],
+    databases: Asset[],
+    emailProvider: Asset,
+    emailTemplates: Asset[],
+    guardianFactorProviders: Asset[],
+    guardianFactors: Asset[],
+    guardianFactorTemplates: Asset[],
+    guardianPhoneFactorMessageTypes: Asset[],
+    guardianPhoneFactorSelectedProvider: Asset,
+    guardianPolicies: Asset[],
+    hooks: Asset[],
+    migrations: Asset[]
+    organizations: Asset[],
+    pages: Asset[],
+    resourceServers: Asset[],
+    roles: Asset[],
+    rules: Asset[],
+    rulesConfigs: Asset[],
+    tenant: Asset,
+    triggers: Asset[],
+    //non-resource types
+    exclude: {
+        [key: string]: string[]
+    },
+    clientsOrig: Asset[],
+}

--- a/test/tools/auth0/handlers/rulesConfigs.tests.ts
+++ b/test/tools/auth0/handlers/rulesConfigs.tests.ts
@@ -1,5 +1,5 @@
-const { expect } = require('chai');
-const rulesConfigs = require('../../../../src/tools/auth0/handlers/rulesConfigs');
+import { expect } from 'chai';
+import rulesConfigs from '../../../../src/tools/auth0/handlers/rulesConfigs'
 
 const pool = {
   addEachTask: (data) => {
@@ -15,7 +15,7 @@ describe('#rulesConfigs handler', () => {
     it('should set rulesConfig', async () => {
       const auth0 = {
         rulesConfigs: {
-          set: (params, data) => {
+          update: (params, data) => {
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.key).to.equal('someKey');
@@ -26,7 +26,7 @@ describe('#rulesConfigs handler', () => {
         pool
       };
 
-      const handler = new rulesConfigs.default({ client: auth0 });
+      const handler = new rulesConfigs({ client: auth0 });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { rulesConfigs: [ { key: 'someKey', value: 'some_value' } ] } ]);
@@ -43,7 +43,7 @@ describe('#rulesConfigs handler', () => {
       rulesConfigs: { getAll: () => rulesConfigData }
     };
 
-    const handler = new rulesConfigs.default({ client: auth0 });
+    const handler = new rulesConfigs({ client: auth0 });
     const data = await handler.getType();
     expect(data).to.deep.equal(rulesConfigData);
   });


### PR DESCRIPTION
## ✏️ Changes

The API handlers a key abstraction in this codebase responsible for applying configuration diffs by reading and writing data from Auth0's management API. Unlike some of the other Typescript migration PRs, this one only encompasses changes necessary to type the base class. I suspect that the actual API handlers that extend off this base class will require quite a few changes so best to separate.

I'll point out a few comments below but one point I'd like to mention is the addition of the `types.ts` file. I'm usually averse from arbitrarily separating code out by the file extension this way, but the more I go through this migration, the more I realize that there are several key types that are shared widely across the codebase and they don't necessarily fit into any one existing directory or file. IMO, this is usually a litmus test for unorganized code, but applying such a reorganization is out of the scope of this PR, thus, relying on a general `types.ts` file appears to be the best solution here.

## 🎯 Testing

No functional changes to the code, and tests pass. However, there was one test: `test/tools/auth0/handlers/rulesConfigs.tests.ts` that suddenly wasn't passing. I'm not sure the exact reason why this code prevents it from passing, but the change to get it passing was fairly straightforward and made me wonder if the test ever worked in the first place.