### PR TITLE
Adding `AssetType` for tighter enforcement of object keys

### DIFF
--- a/src/context/directory/handlers/index.ts
+++ b/src/context/directory/handlers/index.ts
@@ -25,13 +25,14 @@ import attackProtection from './attackProtection';
 import branding from './branding';
 
 import DirectoryContext from '..'
+import { AssetTypes } from '../../../types'
 
 export type DirectoryHandler<T> = {
   dump: (context: DirectoryContext) => void,
   parse: (context: DirectoryContext) => T,
 }
 
-export default {
+const directoryHandlers: { [key in AssetTypes]: DirectoryHandler<{ [key: string]: unknown }> } = {
   rules,
   rulesConfigs,
   hooks,
@@ -57,4 +58,6 @@ export default {
   triggers,
   attackProtection,
   branding
-};
+}
+
+export default directoryHandlers;

--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -22,7 +22,8 @@ function parseCode(context: YAMLContext, code: string) {
 
 async function parse(context: YAMLContext): Promise<ParsedActions> {
   // Load the script file for each action
-  if (!context.assets.actions) return { actions: [] };
+  //@ts-ignore TODO: understand if empty array is intentionally being returned
+  if (!context.assets.actions) return [];
   const actions = {
     actions: [
       ...context.assets.actions.map((action) => ({

--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -9,7 +9,7 @@ import YAMLContext from '..'
 
 type ParsedActions = {
   actions: unknown[] | undefined
-} | []
+}
 
 type Secret = { name: string, value: string }
 
@@ -22,7 +22,7 @@ function parseCode(context: YAMLContext, code: string) {
 
 async function parse(context: YAMLContext): Promise<ParsedActions> {
   // Load the script file for each action
-  if (!context.assets.actions) return [];
+  if (!context.assets.actions) return { actions: [] };
   const actions = {
     actions: [
       ...context.assets.actions.map((action) => ({

--- a/src/context/yaml/handlers/index.ts
+++ b/src/context/yaml/handlers/index.ts
@@ -24,14 +24,15 @@ import triggers from './triggers';
 import attackProtection from './attackProtection';
 import branding from './branding';
 
-import YAMLContext  from '..'
+import YAMLContext from '..'
+import { AssetTypes } from '../../../types'
 
 export type YAMLHandler<T> = {
   dump: (context: YAMLContext) => Promise<T | {}>,//May return empty object to signal 
   parse: (context: YAMLContext) => Promise<T>,
 }
 
-export default {
+const yamlHandlers: { [key in AssetTypes]: YAMLHandler<{ [key: string]: unknown }> } = {
   rules,
   hooks,
   rulesConfigs,
@@ -57,4 +58,6 @@ export default {
   triggers,
   attackProtection,
   branding
-};
+}
+
+export default yamlHandlers;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,5 @@ export type Assets = {
     },
     clientsOrig: Asset[],
 }
+
+export type AssetTypes = 'rules' | 'rulesConfigs' | 'hooks' | 'pages' | 'databases' | 'clientGrants' | 'resourceServers' | 'clients' | 'connections' | 'tenant' | 'emailProvider' | 'emailTemplates' | 'guardianFactors' | 'guardianFactorProviders' | 'guardianFactorTemplates' | 'migrations' | 'guardianPhoneFactorMessageTypes' | 'guardianPhoneFactorSelectedProvider' | 'guardianPolicies' | 'roles' | 'actions' | 'organizations' | 'triggers' | 'attackProtection' | 'branding'


### PR DESCRIPTION
## ✏️ Changes

While implementing resource exclusions, the usages of objects with very specific keys correlating to asset types are the backbone of all the handlers. It became apparent that being able to enforce keys in an object with Typescript is crucial for the implementation. 

By leveraging this type, there will be less risk of accidentally not making crucial changes when adding or modifying new Management API features. In practice, this list would grow as features are added.

The type itself is a bit verbose but ensures a safe contract between various components in the system:

```ts
export type AssetTypes = 'rules' | 'rulesConfigs' | 'hooks' | 'pages' | 'databases' | 'clientGrants' | 'resourceServers' | 'clients' | 'connections' | 'tenant' | 'emailProvider' | 'emailTemplates' | 'guardianFactors' | 'guardianFactorProviders' | 'guardianFactorTemplates' | 'migrations' | 'guardianPhoneFactorMessageTypes' | 'guardianPhoneFactorSelectedProvider' | 'guardianPolicies' | 'roles' | 'actions' | 'organizations' | 'triggers' | 'attackProtection' | 'branding'
```

## 🎯 Testing

No functional changes so no additional tests.