### PR TITLE
Fix: Deploying rules configs fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ if (require.main === module) {
     .then(() => process.exit(0))
     .catch((error: { type?: string; stage?: Stage; message?: string; stack?: string }) => {
       const command = params._[0];
-      console.log({ error });
       if (error.type || error.stage) {
         log.error(
           `Problem running command ${command} during stage ${error.stage} when processing type ${error.type}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ if (require.main === module) {
     .then(() => process.exit(0))
     .catch((error: { type?: string; stage?: Stage; message?: string; stack?: string }) => {
       const command = params._[0];
+      console.log({ error });
       if (error.type || error.stage) {
         log.error(
           `Problem running command ${command} during stage ${error.stage} when processing type ${error.type}`

--- a/test/tools/auth0/handlers/rulesConfigs.tests.ts
+++ b/test/tools/auth0/handlers/rulesConfigs.tests.ts
@@ -15,7 +15,7 @@ describe('#rulesConfigs handler', () => {
     it('should set rulesConfig', async () => {
       const auth0 = {
         rulesConfigs: {
-          update: (params, data) => {
+          set: (params, data) => {
             expect(params).to.be.an('object');
             expect(data).to.be.an('object');
             expect(params.key).to.equal('someKey');


### PR DESCRIPTION
## ✏️ Changes

As reported in #479, in the most recent 7.7.0 release, a regression was introduced where deploy would fail at the process changes step for rules configs. The exact error:

```shell
2022-04-06T17:55:26.771Z - error: Problem running command deploy during stage processChanges when processing type rulesConfigs
2022-04-06T17:55:26.772Z - error: Cannot read property 'bind' of undefined
```

This is indicative of a "missing" method for the rules config asset type in the Node SDK.

The Deploy CLI relies upon a dynamically generated mapping between the assets managed and the Node Auth0 library. In general, each asset type has a correlating manager in that library including the `update`, `delete`, 'create` and `getAll` methods. However, for a select few asset types, the method names are different (ex: rules configs uses `set` instead of `update`). This requires the option to override these mappings on a per-asset basis. In this specific case, the override that the rules configs asset type uses to declare this override can be seen [here](https://github.com/auth0/auth0-deploy-cli/blob/master/src/tools/auth0/handlers/rulesConfigs.ts#L24).

During the Typescript migration, it wasn't clear why this dynamic scheme was being used. I had mistakenly interpreted as an unnecessary abstraction and decided to deleted in favor of more hardcoded function names. In fact, during this refactor, I had incurred a suddenly-failing rules configs test, a warning I should have heeded in hindsight. 

## 🔗 References

Original Github issue: #479 

## 🎯 Testing

This was actually caught in `test/tools/auth0/handlers/rulesConfigs.tests.ts` a while ago, but I had mistakenly modified it so it started passing again. The change made in the PR is a reversion back to the correct original state.