### PR TITLE
Adding ability to strip certain fields from create payload

### DIFF
--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -24,7 +24,8 @@ export default class APIHandler {
   client: Auth0APIClient; // TODO: apply stronger types to Auth0 API client
   identifiers: string[];
   objectFields: string[];
-  stripUpdateFields: string[];
+  stripUpdateFields: string[]; //Fields to strip from payload when updating
+  stripCreateFields: string[]; //Fields to strip from payload when creating
   name?: string; // TODO: understand if any handlers actually leverage `name` property
   functions: {
     getAll: string;
@@ -41,6 +42,7 @@ export default class APIHandler {
     objectFields?: APIHandler['objectFields'];
     identifiers?: APIHandler['identifiers'];
     stripUpdateFields?: APIHandler['stripUpdateFields'];
+    stripCreateFields?: APIHandler['stripCreateFields'];
     functions: {
       getAll?: string;
       update?: string;
@@ -56,6 +58,7 @@ export default class APIHandler {
     this.identifiers = options.identifiers || ['id', 'name'];
     this.objectFields = options.objectFields || [];
     this.stripUpdateFields = [...(options.stripUpdateFields || []), this.id];
+    this.stripCreateFields = options.stripCreateFields || [];
 
     this.functions = {
       getAll: 'getAll',
@@ -232,8 +235,9 @@ export default class APIHandler {
       .addEachTask({
         data: create || [],
         generator: (createItem) => {
+          const strippedPayload = stripFields(createItem, this.stripCreateFields);
           const createFunction = this.getClientFN(this.functions.create);
-          return createFunction(createItem)
+          return createFunction(strippedPayload)
             .then((data) => {
               this.didCreate(data);
               this.created += 1;

--- a/test/tools/auth0/handlers/default.tests.ts
+++ b/test/tools/auth0/handlers/default.tests.ts
@@ -1,0 +1,71 @@
+const { expect } = require('chai');
+import { PromisePoolExecutor } from 'promise-pool-executor';
+import mockHandler from '../../../../src/tools/auth0/handlers/default';
+import constants from '../../../../src/tools/constants';
+import { Assets, Auth0APIClient } from '../../../../src/types';
+
+const mockAssetType = 'mock-resource-type';
+
+//@ts-ignore
+const mockApiClient = {
+  [`${mockAssetType}`]: {
+    //@ts-ignore
+    delete: async ({ _id }, data) => {
+      return data;
+    },
+    //@ts-ignore
+    create: async ({ _id }, data) => {
+      return data;
+    },
+    //@ts-ignore
+    update: async ({ _id }, data) => {
+      return data;
+    },
+  },
+  pool: new PromisePoolExecutor({
+    concurrencyLimit: 100,
+    frequencyLimit: 3,
+    frequencyWindow: 1000, // 1 sec
+  }),
+} as Auth0APIClient;
+
+describe('#default handler', () => {
+  it('should strip designated fields from payload when creating', async () => {
+    let didCreateFunctionGetCalled = false;
+
+    const handler = new mockHandler({
+      client: mockApiClient,
+      stripCreateFields: ['stripThisFromCreate', 'stripObjectFromCreate.nestedProperty'],
+      type: mockAssetType,
+      functions: {
+        //@ts-ignore
+        create: async (payload) => {
+          didCreateFunctionGetCalled = true;
+          expect(payload).to.deep.equal({
+            id: 'some-id',
+            stripObjectFromCreate: {},
+            shouldNotSTripFromCreate: 'this property should be untouched',
+          });
+          return payload;
+        },
+      },
+    });
+
+    await handler.processChanges({} as Assets, {
+      del: [],
+      update: [],
+      conflicts: [],
+      create: [
+        {
+          id: 'some-id',
+          stripThisFromCreate: 'strip this from the create payload',
+          stripObjectFromCreate: {
+            nestedProperty: 'also strip this from the create payload',
+          },
+          shouldNotSTripFromCreate: 'this property should be untouched',
+        },
+      ],
+    });
+    expect(didCreateFunctionGetCalled).to.equal(true);
+  });
+});


### PR DESCRIPTION
## ✏️ Changes

Much like the `stripUpdateFields` class constructor property, which removes certain properties from entering the update payload, this PR is adding the same for create payloads through the `stripCreateFields` property. This is needed for certain asset types that have strict endpoints that will not allow certain fields from being created, only updated. One example of this is the log streams' `status` field, which prohibits setting a status on creation, only update.

## 🎯 Testing

Added test cases for the default API handler.