### PR TITLE
Fixing logging output format

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,7 @@ const logger = createLogger({
   format: combine(
     colorize(),
     timestamp(),
-    format.printf((info) => `[${info.timestamp}] ${info.level}: ${info.message}`)
+    format.printf((info) => `${info.timestamp} - ${info.level}: ${info.message}`)
   ),
   transports: [new transports.Console()],
   exitOnError: false,


### PR DESCRIPTION
## ✏️ Changes

After merging #497 , I realized that the logging output was slightly different than it was previously. I don't think this would have impacted any consumers, but I'd prefer to keep the change as seamless as possible. 

Previous output (notice brackets and no hyphen):

```
[2022-04-08T14:01:56.421Z] info: Export Successful
```

Corrected output:

```
2022-04-08T14:01:56.421Z - info: Export Successful
```