### PR TITLE
Allow ## string replacements to exist inside @@ array replacement mappings

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -30,9 +30,8 @@ export function keywordStringReplace(input: string, mappings: KeywordMappings): 
 export function keywordReplace(input: string, mappings: KeywordMappings): string {
   // Replace keywords with mappings within input.
   if (mappings && Object.keys(mappings).length > 0) {
-    input = keywordStringReplace(input, mappings);
-
     input = keywordArrayReplace(input, mappings);
+    input = keywordStringReplace(input, mappings);
   }
   return input;
 }

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -288,23 +288,6 @@ describe('#keywordReplacement', () => {
         bar: 'OTHER_REPLACEMENT',
       });
     });
-
-    // DO NOT MERGE
-    it('TEST! -- see if this works for objects', () => {
-      const inputWrappedInQuotes = '{ "foo": "@@ARRAY_REPLACEMENT@@", "bar": "OTHER_REPLACEMENT"}';
-
-      const objectInput = { someObject: 'this is an object' };
-
-      const output = utils.keywordArrayReplace(inputWrappedInQuotes, {
-        ARRAY_REPLACEMENT: objectInput,
-        OTHER_REPLACEMENT: 'baz',
-      });
-      const parsedOutput = JSON.parse(output);
-      expect(parsedOutput).to.deep.equal({
-        foo: objectInput,
-        bar: 'OTHER_REPLACEMENT',
-      });
-    });
   });
 });
 

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -181,7 +181,7 @@ describe('#keywordReplacement', () => {
 
     expect(() => JSON.parse(output)).to.not.throw();
 
-    const outputNoWhitespace = JSON.stringify(JSON.parse(output)); //Ensuring conversion can occur back and forth, remove whitespace for test consistency
+    const outputNoWhitespace = JSON.stringify(JSON.parse(output)); // Ensuring conversion can occur back and forth, remove whitespace for test consistency
     const expected = JSON.stringify({
       arrayReplace: ['string-replace-value', 'other-array-replace-value'],
       stringReplace: 'string-replace-value',
@@ -201,25 +201,23 @@ describe('#keywordReplacement', () => {
       },
     };
     const inputJSON = `{ 
-        "objectReplace": "@@OBJECT_REPLACEMENT@@", 
-        "stringReplace": "##STRING_REPLACEMENT##", 
-        "noReplace": "NO_REPLACEMENT" 
+      "stringReplace": "##STRING_REPLACEMENT##", 
+      "noReplace": "NO_REPLACEMENT",
+      "objectReplace": "@@OBJECT_REPLACEMENT@@"
       }`;
     const output = utils.keywordReplace(inputJSON, mapping);
 
     expect(() => JSON.parse(output)).to.not.throw();
 
-    const outputNoWhitespace = JSON.stringify(JSON.parse(output)); //Ensuring conversion can occur back and forth, remove whitespace for test consistency
+    const outputNoWhitespace = JSON.stringify(JSON.parse(output)); // Ensuring conversion can occur back and forth, remove whitespace for test consistency
     const expected = JSON.stringify({
+      stringReplace: 'string-replace-value',
+      noReplace: 'NO_REPLACEMENT',
       objectReplace: {
         propertyShouldStringReplace: 'string-replace-value',
         propertyShouldNotStringReplace: 'this should not be replaced',
       },
-      stringReplace: 'string-replace-value',
-      noReplace: 'NO_REPLACEMENT',
     });
-
-    console.log({outputNoWhitespace})
 
     expect(outputNoWhitespace).to.equal(expected);
   });
@@ -291,7 +289,7 @@ describe('#keywordReplacement', () => {
       });
     });
 
-    //DO NOT MERGE
+    // DO NOT MERGE
     it('TEST! -- see if this works for objects', () => {
       const inputWrappedInQuotes = '{ "foo": "@@ARRAY_REPLACEMENT@@", "bar": "OTHER_REPLACEMENT"}';
 


### PR DESCRIPTION
## ✏️ Changes

Per the request in #487 , this change enables the ability to include nested ## string keyword replacements inside an @@ array replacement. Example:

**Config.json**
```json
{
  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
    "MAILTRAP_PASSWORD": "your-mailtrip-password",
    "EMAIL_CREDENTIALS": {
      "smtp_pass": "##MAILTRAP_PASSWORD##"
    }
  }
}
```
**mock-email-config.json:**
```json
{
  "email-prop-1": "foo",
  "email-mailtrap-pass": "##MAILTRAP_PASSWORD##",
  "email-credentials": "@@EMAIL_CREDENTIALS@@"
}
```
**Output**:
```json
{
  "email-prop-1": "foo",
  "email-mailtrap-pass": "your-mailtrip-password",
  "email-credentials": {
    "smtp_pass": "your-mailtrip-password"
  }
}
```

Fortunately, this request was fairly straightforward, but non-trivial edge cases and hypothetical usages may exist which may not be supported. I mention this because I see this as the furthest we should be willing to go to stay within the spirit of the original feature offering and not trying to address all complex use cases that offer diminishing returns on work.

## 🔗 References

Original Github issue: #487 

## 🎯 Testing

Added a couple of tests cases addressing the new use cases including the OP's object replacement use case.
