### PR TITLE
DXCDT-48: Directory branding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `auth0-deploy-cli` tool supports the importing and exporting of Auth0 Tenant
 Supported Auth0 Management API resources
 
 - [x] [Actions](https://auth0.com/docs/api/management/v2/#!/Actions/get_actions)
-- [ ] [Branding](https://auth0.com/docs/api/management/v2/#!/Branding/get_branding)
+- [x] [Branding](https://auth0.com/docs/api/management/v2/#!/Branding/get_branding)
 - [x] [Clients (Applications)](https://auth0.com/docs/api/management/v2#!/Clients/get_clients)
 - [x] [Client Grants](https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants)
 - [x] [Connections](https://auth0.com/docs/api/management/v2#!/Connections/get_connections)

--- a/src/context/directory/handlers/branding.ts
+++ b/src/context/directory/handlers/branding.ts
@@ -51,12 +51,13 @@ async function dump(context: DirectoryContext) {
   if (!!templates) dumpBrandingTemplates(context);
 }
 
-const dumpBrandingTemplates = ({
-  filePath,
-  assets: {
+const dumpBrandingTemplates = ({ filePath, assets }: DirectoryContext): void => {
+  if (!assets || !assets.branding) return;
+
+  const {
     branding: { templates = [] },
-  },
-}: DirectoryContext): void => {
+  } = assets;
+
   const brandingTemplatesFolder = path.join(
     filePath,
     constants.BRANDING_DIRECTORY,
@@ -86,19 +87,24 @@ const dumpBrandingTemplates = ({
   });
 };
 
-const dumpBranding = ({
-  filePath,
-  assets: {
-    branding: { templates: _templates, ...branding },
-  },
-}: DirectoryContext): void => {
+const dumpBranding = ({ filePath, assets }: DirectoryContext): void => {
+  if (!assets || !assets.branding) return;
+
+  const { branding } = assets;
+
+  const brandingWithoutTemplates = (() => {
+    const newBranding = { ...branding };
+    delete newBranding.templates;
+    return newBranding;
+  })();
+
   const brandingDirectory = path.join(filePath, constants.BRANDING_DIRECTORY);
 
   fs.ensureDirSync(brandingDirectory);
 
   const brandingFilePath = path.join(brandingDirectory, 'branding.json');
 
-  dumpJSON(brandingFilePath, branding);
+  dumpJSON(brandingFilePath, brandingWithoutTemplates);
 };
 
 const brandingHandler: DirectoryHandler<ParsedBranding> = {

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -11,13 +11,12 @@ type ParsedBranding = {
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
   // Load the HTML file for each page
-
   const { branding } = context.assets;
 
-  if (!branding || !branding.templates) return { branding };
+  if (!branding && !branding['templates']) return { branding };
 
   const templates = branding.templates.map((templateDefinition) => {
-    const markupFile = path.join(templateDefinition.body);
+    const markupFile = path.join(context.basePath, templateDefinition.body);
     return {
       template: templateDefinition.template,
       body: loadFileAndReplaceKeywords(markupFile, context.mappings),
@@ -33,7 +32,7 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedBranding> {
-  const { branding } = context.assets || { branding: undefined };
+  const { branding } = context.assets.branding;
   branding.templates = branding.templates || [];
 
   // create templates folder

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -5,28 +5,40 @@ import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
 
+type BrandingTemplate = {
+  template: string;
+  body: string;
+};
+
 type ParsedBranding = {
-  branding: unknown;
+  branding: {
+    templates?: BrandingTemplate[];
+    [key: string]: unknown;
+  };
 };
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
   // Load the HTML file for each page
-  const { branding } = context.assets;
+  const {
+    branding: { templates, ...branding },
+  } = context.assets;
 
   if (!branding && !branding['templates']) return { branding };
 
-  const templates = branding.templates.map((templateDefinition) => {
-    const markupFile = path.join(context.basePath, templateDefinition.body);
-    return {
-      template: templateDefinition.template,
-      body: loadFileAndReplaceKeywords(markupFile, context.mappings),
-    };
-  });
+  const parsedTemplates: BrandingTemplate[] = templates.map(
+    (templateDefinition: BrandingTemplate): BrandingTemplate => {
+      const markupFile = path.join(context.basePath, templateDefinition.body);
+      return {
+        template: templateDefinition.template,
+        body: loadFileAndReplaceKeywords(markupFile, context.mappings),
+      };
+    }
+  );
 
   return {
     branding: {
       ...branding,
-      templates,
+      templates: parsedTemplates,
     },
   };
 }

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -19,6 +19,9 @@ type ParsedBranding = {
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
   // Load the HTML file for each page
+  //@ts-ignore
+  if (!context.assets.branding) return { branding: undefined };
+
   const {
     branding: { templates, ...branding },
   } = context.assets;
@@ -44,7 +47,8 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedBranding> {
-  const { branding } = context.assets.branding;
+  const { branding } = context.assets;
+
   branding.templates = branding.templates || [];
 
   // create templates folder

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -19,8 +19,12 @@ type ParsedBranding = {
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
   // Load the HTML file for each page
-  //@ts-ignore
-  if (!context.assets.branding) return { branding: undefined };
+  if (!context.assets.branding)
+    return {
+      branding: {
+        templates: [],
+      },
+    };
 
   const {
     branding: { templates, ...branding },

--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -1,7 +1,7 @@
 import DefaultHandler from './default';
 import constants from '../../constants';
 import log from '../../../logger';
-import { Assets, Asset } from '../../../types';
+import { Asset } from '../../../types';
 
 export const schema = {
   type: 'object',

--- a/test/context/directory/branding.test.js
+++ b/test/context/directory/branding.test.js
@@ -21,7 +21,7 @@ const brandingSettings = JSON.stringify({
 });
 
 describe('#directory context branding', () => {
-  it('should process templates', async () => {
+  it('should process branding settings, including templates', async () => {
     const dir = path.join(testDataDir, 'directory', 'branding-process');
     cleanThenMkdir(dir);
     const brandingDir = path.join(dir, constants.BRANDING_DIRECTORY);
@@ -50,7 +50,7 @@ describe('#directory context branding', () => {
     ]);
   });
 
-  it('should dump templates', async () => {
+  it('should dump branding settings, including templates', async () => {
     const repoDir = path.join(testDataDir, 'directory', 'branding-dump');
     cleanThenMkdir(repoDir);
     const context = new Context({ AUTH0_INPUT_FILE: repoDir }, mockMgmtClient());

--- a/test/context/yaml/branding.test.js
+++ b/test/context/yaml/branding.test.js
@@ -15,13 +15,14 @@ describe('#YAML context branding templates', () => {
     cleanThenMkdir(dir);
 
     const htmlFile = path.join(dir, 'universalLogin.html');
+
     fs.writeFileSync(htmlFile, html);
 
     const yaml = `
     branding:
       templates:
         - template: universal_login
-          body: ${htmlFile}
+          body: universalLogin.html
     `;
     const yamlFile = path.join(dir, 'config.yaml');
     fs.writeFileSync(yamlFile, yaml);

--- a/test/context/yaml/branding.test.js
+++ b/test/context/yaml/branding.test.js
@@ -10,7 +10,7 @@ const html = '<html>##foo##</html>';
 const htmlTransformed = '<html>bar</html>';
 
 describe('#YAML context branding templates', () => {
-  it('should process branding templates', async () => {
+  it('should process branding settings, including templates', async () => {
     const dir = path.join(testDataDir, 'yaml', 'branding-process');
     cleanThenMkdir(dir);
 
@@ -39,7 +39,7 @@ describe('#YAML context branding templates', () => {
     ]);
   });
 
-  it('should dump branding templates', async () => {
+  it('should dump branding settings, including templates', async () => {
     const dir = path.join(testDataDir, 'yaml', 'branding-dump');
     cleanThenMkdir(dir);
     const context = new Context(

--- a/test/utils.js
+++ b/test/utils.js
@@ -105,6 +105,7 @@ export function mockMgmtClient() {
       getBruteForceConfig: () => ({}),
       getSuspiciousIpThrottlingConfig: () => ({}),
     },
+    branding: { getSettings: () => ({}) },
   };
 }
 


### PR DESCRIPTION
## ✏️ Changes

Inspired by #447 , this PR adds support for managing branding settings with the directory configuration format (YAML already supported).

Example of resulting **branding.json**:
```json
{
  "colors": {
    "primary": "#F8F8F2",
    "page_background": "#222221"
  },
  "font": {
    "url": "https://mycompany.org/font/myfont.ttf"
  },
  "logo_url": "https://foo.com/assets/logo.png"
}

```

A good bit of this PR is massaging the tests to reflect this new support and also enabling a high level of fault tolerance with regards to dumping and processing the data in the case of undefined properties.

## 🔗 References

Original inspiration PR: #447 