### PR TITLE
Allow fuller deletion support when `AUTH0_ALLOW_DELETE` is enabled

### DIFF
--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -137,6 +137,7 @@ export default class APIHandler {
 
     const existing = await this.getType();
 
+    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
     // Figure out what needs to be updated vs created
     return calculateChanges({
       handler: this,
@@ -144,6 +145,7 @@ export default class APIHandler {
       //@ts-ignore TODO: investigate what happens when `existing` is null
       existing,
       identifiers: this.identifiers,
+      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
   }
 

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -9,7 +9,7 @@ import {
 } from '../../utils';
 import log from '../../../logger';
 import { calculateChanges } from '../../calculateChanges';
-import { Asset, Assets, AssetTypes, Auth0APIClient, CalculatedChanges } from '../../../types';
+import { Asset, Assets, Auth0APIClient, CalculatedChanges } from '../../../types';
 import { ConfigFunction } from '../../../configFactory';
 
 export function order(value) {
@@ -113,24 +113,10 @@ export default class APIHandler {
 
   async load(): Promise<{ [key: string]: Asset | Asset[] | null }> {
     // Load Asset from Tenant
-    const data = await (async () => {
-      try {
-        const data = await this.getType();
-        log.info(`Retrieving ${this.type} data from Auth0`);
-        return data;
-      } catch (err) {
-        if (err.statusCode === 403 && err.message.includes('Insufficient scope')) {
-          const requiredScopes = err.message
-            ?.split('Insufficient scope, expected any of: ')
-            ?.slice(1);
-          log.warn(`Cannot retrieve ${this.type} due to missing scopes: ${requiredScopes}`);
-          return undefined;
-        }
-        throw err;
-      }
-    })();
+    log.info(`Retrieving ${this.type} data from Auth0`);
 
-    //@ts-ignore
+    const data = await this.getType();
+
     this.existing = obfuscateSensitiveValues(data, this.sensitiveFieldsToObfuscate);
 
     return { [this.type]: this.existing };
@@ -149,14 +135,14 @@ export default class APIHandler {
       };
     }
 
-    const existing = await this.load();
+    const existing = await this.getType();
 
     // Figure out what needs to be updated vs created
     return calculateChanges({
       handler: this,
       assets: typeAssets,
       //@ts-ignore TODO: investigate what happens when `existing` is null
-      existing: existing[this.type],
+      existing,
       identifiers: this.identifiers,
     });
   }

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -9,7 +9,7 @@ import {
 } from '../../utils';
 import log from '../../../logger';
 import { calculateChanges } from '../../calculateChanges';
-import { Asset, Assets, Auth0APIClient, CalculatedChanges } from '../../../types';
+import { Asset, Assets, AssetTypes, Auth0APIClient, CalculatedChanges } from '../../../types';
 import { ConfigFunction } from '../../../configFactory';
 
 export function order(value) {
@@ -113,10 +113,24 @@ export default class APIHandler {
 
   async load(): Promise<{ [key: string]: Asset | Asset[] | null }> {
     // Load Asset from Tenant
-    log.info(`Retrieving ${this.type} data from Auth0`);
+    const data = await (async () => {
+      try {
+        const data = await this.getType();
+        log.info(`Retrieving ${this.type} data from Auth0`);
+        return data;
+      } catch (err) {
+        if (err.statusCode === 403 && err.message.includes('Insufficient scope')) {
+          const requiredScopes = err.message
+            ?.split('Insufficient scope, expected any of: ')
+            ?.slice(1);
+          log.warn(`Cannot retrieve ${this.type} due to missing scopes: ${requiredScopes}`);
+          return undefined;
+        }
+        throw err;
+      }
+    })();
 
-    const data = await this.getType();
-
+    //@ts-ignore
     this.existing = obfuscateSensitiveValues(data, this.sensitiveFieldsToObfuscate);
 
     return { [this.type]: this.existing };
@@ -135,17 +149,15 @@ export default class APIHandler {
       };
     }
 
-    const existing = await this.getType();
+    const existing = await this.load();
 
-    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
     // Figure out what needs to be updated vs created
     return calculateChanges({
       handler: this,
       assets: typeAssets,
       //@ts-ignore TODO: investigate what happens when `existing` is null
-      existing,
+      existing: existing[this.type],
       identifiers: this.identifiers,
-      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
   }
 

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -249,12 +249,14 @@ export default class OrganizationsHandler extends DefaultHandler {
         .filter((connection) => !!connection.connection_id);
     });
 
+    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
+
     const changes = calculateChanges({
       handler: this,
       assets: organizations,
       existing,
       identifiers: ['id', 'name'],
-      allowDelete: false, //TODO: actually pass in correct allowDelete value
+      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
 
     log.debug(

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -249,8 +249,6 @@ export default class OrganizationsHandler extends DefaultHandler {
         .filter((connection) => !!connection.connection_id);
     });
 
-    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
-
     const changes = calculateChanges({
       handler: this,
       assets: organizations,

--- a/src/tools/auth0/handlers/resourceServers.ts
+++ b/src/tools/auth0/handlers/resourceServers.ts
@@ -80,12 +80,14 @@ export default class ResourceServersHandler extends DefaultHandler {
     resourceServers = resourceServers.filter((r) => !excluded.includes(r.name));
     existing = existing.filter((r) => !excluded.includes(r.name));
 
+    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
+
     return calculateChanges({
       handler: this,
       assets: resourceServers,
       existing,
       identifiers: ['id', 'identifier'],
-      allowDelete: false, //TODO: actually pass in correct allowDelete value
+      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
   }
 

--- a/src/tools/auth0/handlers/resourceServers.ts
+++ b/src/tools/auth0/handlers/resourceServers.ts
@@ -80,8 +80,6 @@ export default class ResourceServersHandler extends DefaultHandler {
     resourceServers = resourceServers.filter((r) => !excluded.includes(r.name));
     existing = existing.filter((r) => !excluded.includes(r.name));
 
-    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
-
     return calculateChanges({
       handler: this,
       assets: resourceServers,

--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -185,12 +185,14 @@ export default class RolesHandler extends DefaultHandler {
     if (!roles) return;
     // Gets roles from destination tenant
     const existing = await this.getType();
+
+    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
     const changes = calculateChanges({
       handler: this,
       assets: roles,
       existing,
       identifiers: ['id', 'name'],
-      allowDelete: false, //TODO: actually pass in correct allowDelete value
+      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
     log.debug(
       `Start processChanges for roles [delete:${changes.del.length}] [update:${changes.update.length}], [create:${changes.create.length}]`

--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -186,7 +186,6 @@ export default class RolesHandler extends DefaultHandler {
     // Gets roles from destination tenant
     const existing = await this.getType();
 
-    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
     const changes = calculateChanges({
       handler: this,
       assets: roles,

--- a/src/tools/auth0/handlers/rules.ts
+++ b/src/tools/auth0/handlers/rules.ts
@@ -86,8 +86,6 @@ export default class RulesHandler extends DefaultHandler {
       existing = existing.filter((r) => !excludedRules.includes(r.name));
     }
 
-    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
-
     // Figure out what needs to be updated vs created
     const { del, update, create, conflicts } = calculateChanges({
       handler: this,

--- a/src/tools/auth0/handlers/rules.ts
+++ b/src/tools/auth0/handlers/rules.ts
@@ -86,13 +86,15 @@ export default class RulesHandler extends DefaultHandler {
       existing = existing.filter((r) => !excludedRules.includes(r.name));
     }
 
+    console.log({ allowDelete: this.config('AUTH0_ALLOW_DELETE') });
+
     // Figure out what needs to be updated vs created
     const { del, update, create, conflicts } = calculateChanges({
       handler: this,
       assets: rules,
       existing,
       identifiers: ['id', 'name'],
-      allowDelete: false, //TODO: actually pass in correct allowDelete value
+      allowDelete: !!this.config('AUTH0_ALLOW_DELETE'),
     });
     // Figure out the rules that need to be re-ordered
     const futureRules = [...create, ...update];

--- a/src/tools/calculateChanges.ts
+++ b/src/tools/calculateChanges.ts
@@ -8,19 +8,19 @@ import { Asset, CalculatedChanges } from '../types';
  * @param {T} desiredAssetState
  * @param {T} currentAssetState
  * @param {string[]} [objectFields=[]]
- * @param {boolean} [allowDelete=false]
+ * @param {boolean} [allowDelete]
  * @returns T
  */
 export function processChangedObjectFields({
   handler,
   desiredAssetState,
   currentAssetState,
-  allowDelete = false,
+  allowDelete,
 }: {
   handler: APIHandler;
   desiredAssetState: Asset;
   currentAssetState: Asset;
-  allowDelete?: boolean;
+  allowDelete: boolean;
 }) {
   const desiredAssetStateWithChanges = { ...desiredAssetState };
 


### PR DESCRIPTION
## ✏️ Changes

The typescript migration revealed a few locations where deletes were being prevented unintentionally simply by omission. During the migration, I had set the `allowDelete` values to false to prevent any functional changes. This PR loops back and introduces fuller support across the board for deletion when `AUTH0_ALLOW_DELETE` is set to true. 

Affects the following:

- Organizations
- Resource Servers
- Rules
- Roles
- Client `client_metadata` field (fixes #418)

## 🔗 References

Related Github issue for Client `client_metadata` field: #418 

## 🎯 Testing

Existing integration and unit tests already cover this usage and is confirmed with manual testing. Because no end-to-end tests, there are not additional tests to write.
