### PR TITLE
Standardize empty vs null resources (1 of 2)

### DIFF
--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -61,16 +61,16 @@ function mapToAction(filePath, action) {
     code: mapActionCode(filePath, action),
     runtime: action.runtime,
     status: action.status,
-    dependencies: action.dependencies || [],
+    dependencies: action.dependencies,
     secrets: mapSecrets(action.secrets),
     supported_triggers: action.supported_triggers,
     deployed: action.deployed || action.all_changes_deployed,
   };
 }
 
-async function dump(context: DirectoryContext) {
-  const actions = [...(context.assets.actions || [])];
-  if (actions.length < 1) return;
+async function dump(context: DirectoryContext): Promise<void> {
+  const { actions } = context.assets;
+  if (!actions || actions.length < 1) return;
 
   // Create Actions folder
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);

--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -7,14 +7,15 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 import log from '../../../logger';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedActions = {
-  actions: unknown[] | undefined;
+  actions: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedActions {
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);
-  if (!existsMustBeDir(actionsFolder)) return { actions: undefined }; // Skip
+  if (!existsMustBeDir(actionsFolder)) return { actions: null }; // Skip
   const files = getFiles(actionsFolder, ['.json']);
   const actions = files.map((file) => {
     const action = { ...loadJSON(file, context.mappings) };

--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -70,7 +70,7 @@ function mapToAction(filePath, action) {
 
 async function dump(context: DirectoryContext): Promise<void> {
   const { actions } = context.assets;
-  if (!actions || actions.length < 1) return;
+  if (!actions) return;
 
   // Create Actions folder
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -55,7 +55,7 @@ function parse(context: DirectoryContext): ParsedAttackProtection {
 async function dump(context: DirectoryContext): Promise<void> {
   const { attackProtection } = context.assets;
 
-  if (attackProtection === null) return;
+  if (!attackProtection) return;
 
   const files = attackProtectionFiles(context.filePath);
   fs.ensureDirSync(files.directory);

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -4,15 +4,14 @@ import { constants } from '../../../tools';
 import { dumpJSON, existsMustBeDir, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedAttackProtection = {
-  attackProtection:
-    | {
-        breachedPasswordDetection: unknown;
-        bruteForceProtection: unknown;
-        suspiciousIpThrottling: unknown;
-      }
-    | undefined;
+  attackProtection: {
+    breachedPasswordDetection: Asset;
+    bruteForceProtection: Asset;
+    suspiciousIpThrottling: Asset;
+  } | null;
 };
 
 function attackProtectionFiles(filePath: string): {
@@ -36,7 +35,7 @@ function parse(context: DirectoryContext): ParsedAttackProtection {
 
   if (!existsMustBeDir(files.directory)) {
     return {
-      attackProtection: undefined,
+      attackProtection: null,
     };
   }
 
@@ -55,6 +54,8 @@ function parse(context: DirectoryContext): ParsedAttackProtection {
 
 async function dump(context: DirectoryContext): Promise<void> {
   const { attackProtection } = context.assets;
+
+  if (attackProtection === null) return;
 
   const files = attackProtectionFiles(context.filePath);
   fs.ensureDirSync(files.directory);

--- a/src/context/directory/handlers/branding.ts
+++ b/src/context/directory/handlers/branding.ts
@@ -22,7 +22,7 @@ function parse(context: DirectoryContext): ParsedBranding {
     constants.BRANDING_TEMPLATES_DIRECTORY
   );
 
-  if (!existsMustBeDir(brandingTemplatesFolder)) return { branding: context.assets.branding };
+  if (!existsMustBeDir(brandingTemplatesFolder)) return { branding: null };
 
   const templatesDefinitionFiles = getFiles(brandingTemplatesFolder, ['.json']);
   const templates = templatesDefinitionFiles.map((templateDefinitionFile) => {
@@ -45,15 +45,15 @@ function parse(context: DirectoryContext): ParsedBranding {
 async function dump(context: DirectoryContext) {
   const { branding } = context.assets;
 
-  if (branding === null) return;
+  if (!branding) return;
 
   dumpBranding(context);
 
-  if (branding.templates !== null) dumpBrandingTemplates(context);
+  if (!!branding.templates) dumpBrandingTemplates(context);
 }
 
 const dumpBrandingTemplates = ({ filePath, assets }: DirectoryContext): void => {
-  if (assets.branding === null || assets.branding.templates === null) return;
+  if (!assets.branding || !assets.branding.templates) return;
 
   const {
     branding: { templates = [] },

--- a/src/context/directory/handlers/branding.ts
+++ b/src/context/directory/handlers/branding.ts
@@ -4,15 +4,16 @@ import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 import { dumpJSON, existsMustBeDir, getFiles, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedBranding = {
-  branding: unknown | undefined;
+  branding: Asset | null;
 };
 
 function parse(context: DirectoryContext): ParsedBranding {
   const brandingDirectory = path.join(context.filePath, constants.BRANDING_DIRECTORY);
 
-  if (!existsMustBeDir(brandingDirectory)) return { branding: undefined };
+  if (!existsMustBeDir(brandingDirectory)) return { branding: null };
 
   const branding = loadJSON(path.join(brandingDirectory, 'branding.json'), context.mappings);
 
@@ -42,17 +43,17 @@ function parse(context: DirectoryContext): ParsedBranding {
 }
 
 async function dump(context: DirectoryContext) {
-  const {
-    branding: { templates = [], ...branding },
-  } = context.assets;
+  const { branding } = context.assets;
 
-  if (!!branding) dumpBranding(context);
+  if (branding === null) return;
 
-  if (!!templates) dumpBrandingTemplates(context);
+  dumpBranding(context);
+
+  if (branding.templates !== null) dumpBrandingTemplates(context);
 }
 
 const dumpBrandingTemplates = ({ filePath, assets }: DirectoryContext): void => {
-  if (!assets || !assets.branding) return;
+  if (assets.branding === null || assets.branding.templates === null) return;
 
   const {
     branding: { templates = [] },

--- a/src/context/directory/handlers/clientGrants.ts
+++ b/src/context/directory/handlers/clientGrants.ts
@@ -12,14 +12,15 @@ import {
 } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedClientGrants = {
-  clientGrants: unknown[] | undefined;
+  clientGrants: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedClientGrants {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
-  if (!existsMustBeDir(grantsFolder)) return { clientGrants: undefined }; // Skip
+  if (!existsMustBeDir(grantsFolder)) return { clientGrants: null }; // Skip
 
   const foundFiles = getFiles(grantsFolder, ['.json']);
 
@@ -43,7 +44,8 @@ async function dump(context: DirectoryContext): Promise<void> {
   // Convert client_id to the client name for readability
   clientGrants.forEach((grant) => {
     const dumpGrant = { ...grant };
-    dumpGrant.client_id = convertClientIdToName(dumpGrant.client_id, context.assets.clientsOrig);
+    if (context.assets.clientsOrig)
+      dumpGrant.client_id = convertClientIdToName(dumpGrant.client_id, context.assets.clientsOrig);
 
     const name = sanitize(`${dumpGrant.client_id} (${dumpGrant.audience})`);
     const grantFile = path.join(grantsFolder, `${name}.json`);

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -12,16 +12,17 @@ import {
   sanitize,
   clearClientArrays,
 } from '../../../utils';
+import { Asset } from '../../../types';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 
 type ParsedClients = {
-  clients: unknown | undefined;
+  clients: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedClients {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
-  if (!existsMustBeDir(clientsFolder)) return { clients: undefined }; // Skip
+  if (!existsMustBeDir(clientsFolder)) return { clients: null }; // Skip
 
   const foundFiles = getFiles(clientsFolder, ['.json']);
 

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -15,16 +15,17 @@ import {
 } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedConnections = {
-  connections: unknown[] | undefined;
+  connections: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedConnections {
   const connectionDirectory =
     context.config.AUTH0_CONNECTIONS_DIRECTORY || constants.CONNECTIONS_DIRECTORY;
   const connectionsFolder = path.join(context.filePath, connectionDirectory);
-  if (!existsMustBeDir(connectionsFolder)) return { connections: undefined }; // Skip
+  if (!existsMustBeDir(connectionsFolder)) return { connections: null }; // Skip
 
   const foundFiles = getFiles(connectionsFolder, ['.json']);
 
@@ -54,7 +55,7 @@ function parse(context: DirectoryContext): ParsedConnections {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const { connections } = context.assets;
+  const { connections, clientsOrig } = context.assets;
 
   if (!connections) return; // Skip, nothing to dump
 
@@ -66,10 +67,7 @@ async function dump(context: DirectoryContext): Promise<void> {
     const dumpedConnection = {
       ...connection,
       ...(connection.enabled_clients && {
-        enabled_clients: mapClientID2NameSorted(
-          connection.enabled_clients,
-          context.assets.clientsOrig
-        ),
+        enabled_clients: mapClientID2NameSorted(connection.enabled_clients, clientsOrig || []),
       }),
     };
 

--- a/src/context/directory/handlers/databases.ts
+++ b/src/context/directory/handlers/databases.ts
@@ -14,9 +14,10 @@ import {
 
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedDatabases = {
-  databases: unknown[] | undefined;
+  databases: Asset[] | null;
 };
 
 type DatabaseMetadata = {
@@ -80,7 +81,7 @@ function getDatabase(folder: string, mappings): {} {
 
 function parse(context: DirectoryContext): ParsedDatabases {
   const databaseFolder = path.join(context.filePath, constants.DATABASE_CONNECTIONS_DIRECTORY);
-  if (!existsMustBeDir(databaseFolder)) return { databases: undefined }; // Skip
+  if (!existsMustBeDir(databaseFolder)) return { databases: null }; // Skip
 
   const folders = fs
     .readdirSync(databaseFolder)
@@ -118,7 +119,7 @@ async function dump(context: DirectoryContext): Promise<void> {
       ...(database.enabled_clients && {
         enabled_clients: mapClientID2NameSorted(
           database.enabled_clients,
-          context.assets.clientsOrig
+          context.assets.clientsOrig || []
         ),
       }),
       options: {

--- a/src/context/directory/handlers/emailProvider.ts
+++ b/src/context/directory/handlers/emailProvider.ts
@@ -28,7 +28,7 @@ function parse(context: DirectoryContext): ParsedEmailProvider {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  if (context.assets.emailProvider === null) return; // Skip, nothing to dump
+  if (!context.assets.emailProvider) return; // Skip, nothing to dump
 
   const emailProvider: typeof context.assets.emailProvider = (() => {
     const excludedDefaults = context.assets.exclude?.defaults || [];

--- a/src/context/directory/handlers/emailTemplates.ts
+++ b/src/context/directory/handlers/emailTemplates.ts
@@ -6,14 +6,15 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedEmailTemplates = {
-  emailTemplates: unknown | undefined;
+  emailTemplates: Asset | null;
 };
 
 function parse(context: DirectoryContext): ParsedEmailTemplates {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);
-  if (!existsMustBeDir(emailsFolder)) return { emailTemplates: undefined }; // Skip
+  if (!existsMustBeDir(emailsFolder)) return { emailTemplates: null }; // Skip
 
   const files = getFiles(emailsFolder, ['.json', '.html']).filter(
     (f) => path.basename(f) !== 'provider.json'

--- a/src/context/directory/handlers/emailTemplates.ts
+++ b/src/context/directory/handlers/emailTemplates.ts
@@ -9,7 +9,7 @@ import DirectoryContext from '..';
 import { Asset } from '../../../types';
 
 type ParsedEmailTemplates = {
-  emailTemplates: Asset | null;
+  emailTemplates: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedEmailTemplates {
@@ -52,7 +52,7 @@ function parse(context: DirectoryContext): ParsedEmailTemplates {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const emailTemplates = [...(context.assets.emailTemplates || [])];
+  const emailTemplates = context.assets.emailTemplates;
 
   if (!emailTemplates) return; // Skip, nothing to dump
 

--- a/src/context/directory/handlers/guardianFactorProviders.ts
+++ b/src/context/directory/handlers/guardianFactorProviders.ts
@@ -5,9 +5,10 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactorProviders = {
-  guardianFactorProviders: unknown[] | undefined;
+  guardianFactorProviders: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedGuardianFactorProviders {
@@ -16,7 +17,7 @@ function parse(context: DirectoryContext): ParsedGuardianFactorProviders {
     constants.GUARDIAN_DIRECTORY,
     constants.GUARDIAN_PROVIDERS_DIRECTORY
   );
-  if (!existsMustBeDir(factorProvidersFolder)) return { guardianFactorProviders: undefined }; // Skip
+  if (!existsMustBeDir(factorProvidersFolder)) return { guardianFactorProviders: null }; // Skip
 
   const foundFiles = getFiles(factorProvidersFolder, ['.json']);
 

--- a/src/context/directory/handlers/guardianFactorTemplates.ts
+++ b/src/context/directory/handlers/guardianFactorTemplates.ts
@@ -5,9 +5,10 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactorTemplates = {
-  guardianFactorTemplates: unknown[] | undefined;
+  guardianFactorTemplates: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedGuardianFactorTemplates {
@@ -16,7 +17,7 @@ function parse(context: DirectoryContext): ParsedGuardianFactorTemplates {
     constants.GUARDIAN_DIRECTORY,
     constants.GUARDIAN_TEMPLATES_DIRECTORY
   );
-  if (!existsMustBeDir(factorTemplatesFolder)) return { guardianFactorTemplates: undefined }; // Skip
+  if (!existsMustBeDir(factorTemplatesFolder)) return { guardianFactorTemplates: null }; // Skip
 
   const foundFiles = getFiles(factorTemplatesFolder, ['.json']);
 

--- a/src/context/directory/handlers/guardianFactors.ts
+++ b/src/context/directory/handlers/guardianFactors.ts
@@ -5,9 +5,10 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactors = {
-  guardianFactors: unknown[] | undefined;
+  guardianFactors: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedGuardianFactors {
@@ -16,7 +17,7 @@ function parse(context: DirectoryContext): ParsedGuardianFactors {
     constants.GUARDIAN_DIRECTORY,
     constants.GUARDIAN_FACTORS_DIRECTORY
   );
-  if (!existsMustBeDir(factorsFolder)) return { guardianFactors: undefined }; // Skip
+  if (!existsMustBeDir(factorsFolder)) return { guardianFactors: null }; // Skip
 
   const foundFiles = getFiles(factorsFolder, ['.json']);
 

--- a/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
@@ -4,26 +4,25 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedGuardianFactorMessageTypes =
-  | {
-      guardianPhoneFactorMessageTypes: unknown;
-    }
-  | {};
+type ParsedGuardianFactorMessageTypes = {
+  guardianPhoneFactorMessageTypes: Asset | null;
+};
 
 function parse(context: DirectoryContext): ParsedGuardianFactorMessageTypes {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
-  if (!existsMustBeDir(guardianFolder)) return {}; // Skip
+  if (!existsMustBeDir(guardianFolder)) return { guardianPhoneFactorMessageTypes: null }; // Skip
 
   const file = path.join(guardianFolder, 'phoneFactorMessageTypes.json');
 
-  if (isFile(file)) {
-    return {
-      guardianPhoneFactorMessageTypes: loadJSON(file, context.mappings),
-    };
+  if (!isFile(file)) {
+    return { guardianPhoneFactorMessageTypes: null };
   }
 
-  return {};
+  return {
+    guardianPhoneFactorMessageTypes: loadJSON(file, context.mappings),
+  };
 }
 
 async function dump(context: DirectoryContext): Promise<void> {

--- a/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -4,26 +4,25 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedGuardianFactorSelectedProvider =
-  | {
-      guardianPhoneFactorSelectedProvider: unknown;
-    }
-  | {};
+type ParsedGuardianFactorSelectedProvider = {
+  guardianPhoneFactorSelectedProvider: Asset | null;
+};
 
 function parse(context: DirectoryContext): ParsedGuardianFactorSelectedProvider {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
-  if (!existsMustBeDir(guardianFolder)) return {}; // Skip
+  if (!existsMustBeDir(guardianFolder)) return { guardianPhoneFactorSelectedProvider: null }; // Skip
 
   const file = path.join(guardianFolder, 'phoneFactorSelectedProvider.json');
 
-  if (isFile(file)) {
-    return {
-      guardianPhoneFactorSelectedProvider: loadJSON(file, context.mappings),
-    };
+  if (!isFile(file)) {
+    return { guardianPhoneFactorSelectedProvider: null };
   }
 
-  return {};
+  return {
+    guardianPhoneFactorSelectedProvider: loadJSON(file, context.mappings),
+  };
 }
 
 async function dump(context: DirectoryContext): Promise<void> {

--- a/src/context/directory/handlers/guardianPolicies.ts
+++ b/src/context/directory/handlers/guardianPolicies.ts
@@ -4,26 +4,25 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedGuardianPolicies =
-  | {
-      guardianPolicies: unknown[];
-    }
-  | {};
+type ParsedGuardianPolicies = {
+  guardianPolicies: Asset[] | null;
+};
 
 function parse(context: DirectoryContext): ParsedGuardianPolicies {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);
-  if (!existsMustBeDir(guardianFolder)) return {}; // Skip
+  if (!existsMustBeDir(guardianFolder)) return { guardianPolicies: null }; // Skip
 
   const file = path.join(guardianFolder, 'policies.json');
 
-  if (isFile(file)) {
-    return {
-      guardianPolicies: loadJSON(file, context.mappings),
-    };
+  if (!isFile(file)) {
+    return { guardianPolicies: null };
   }
 
-  return {} as ParsedGuardianPolicies;
+  return {
+    guardianPolicies: loadJSON(file, context.mappings),
+  };
 }
 
 async function dump(context: DirectoryContext) {

--- a/src/context/directory/handlers/hooks.ts
+++ b/src/context/directory/handlers/hooks.ts
@@ -35,9 +35,9 @@ function parse(context: DirectoryContext): ParsedHooks {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const hooks = [...(context.assets.hooks || [])];
+  const hooks = context.assets.hooks;
 
-  if (hooks.length < 1) return;
+  if (!hooks || hooks.length < 1) return;
 
   // Create Hooks folder
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);

--- a/src/context/directory/handlers/hooks.ts
+++ b/src/context/directory/handlers/hooks.ts
@@ -6,14 +6,15 @@ import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../.
 import log from '../../../logger';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedHooks = {
-  hooks: unknown[] | undefined;
+  hooks: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedHooks {
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);
-  if (!existsMustBeDir(hooksFolder)) return { hooks: undefined }; // Skip
+  if (!existsMustBeDir(hooksFolder)) return { hooks: null }; // Skip
 
   const files = getFiles(hooksFolder, ['.json']);
 

--- a/src/context/directory/handlers/hooks.ts
+++ b/src/context/directory/handlers/hooks.ts
@@ -37,7 +37,7 @@ function parse(context: DirectoryContext): ParsedHooks {
 async function dump(context: DirectoryContext): Promise<void> {
   const hooks = context.assets.hooks;
 
-  if (!hooks || hooks.length < 1) return;
+  if (!hooks) return;
 
   // Create Hooks folder
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);

--- a/src/context/directory/handlers/index.ts
+++ b/src/context/directory/handlers/index.ts
@@ -26,14 +26,16 @@ import branding from './branding';
 import logStreams from './logStreams';
 
 import DirectoryContext from '..';
-import { AssetTypes } from '../../../types';
+import { AssetTypes, Asset } from '../../../types';
 
 export type DirectoryHandler<T> = {
   dump: (context: DirectoryContext) => void;
   parse: (context: DirectoryContext) => T;
 };
 
-const directoryHandlers: { [key in AssetTypes]: DirectoryHandler<{ [key: string]: unknown }> } = {
+const directoryHandlers: {
+  [key in AssetTypes]: DirectoryHandler<{ [key: string]: Asset | Asset[] | null }>;
+} = {
   rules,
   rulesConfigs,
   hooks,

--- a/src/context/directory/handlers/logStreams.ts
+++ b/src/context/directory/handlers/logStreams.ts
@@ -7,12 +7,12 @@ import DirectoryContext from '..';
 import { Asset } from '../../../types';
 
 type ParsedLogStreams = {
-  logStreams: Asset[] | undefined;
+  logStreams: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedLogStreams {
   const logStreamsDirectory = path.join(context.filePath, constants.LOG_STREAMS_DIRECTORY);
-  if (!existsMustBeDir(logStreamsDirectory)) return { logStreams: undefined }; // Skip
+  if (!existsMustBeDir(logStreamsDirectory)) return { logStreams: null }; // Skip
 
   const foundFiles = getFiles(logStreamsDirectory, ['.json']);
 

--- a/src/context/directory/handlers/logStreams.ts
+++ b/src/context/directory/handlers/logStreams.ts
@@ -26,7 +26,7 @@ function parse(context: DirectoryContext): ParsedLogStreams {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const logStreams = context.assets.logStreams || [];
+  const logStreams = context.assets.logStreams;
 
   if (!logStreams) return; // Skip, nothing to dump
 

--- a/src/context/directory/handlers/migrations.ts
+++ b/src/context/directory/handlers/migrations.ts
@@ -2,20 +2,19 @@ import path from 'path';
 import { existsMustBeDir, isFile, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedMigrations =
-  | {
-      migrations: unknown[];
-    }
-  | {};
+type ParsedMigrations = {
+  migrations: Asset[] | null;
+};
 
 function parse(context: DirectoryContext): ParsedMigrations {
   const baseFolder = path.join(context.filePath);
-  if (!existsMustBeDir(baseFolder)) return {}; // Skip
+  if (!existsMustBeDir(baseFolder)) return { migrations: null }; // Skip
 
   const migrationsFile = path.join(baseFolder, 'migrations.json');
 
-  if (!isFile(migrationsFile)) return {};
+  if (!isFile(migrationsFile)) return { migrations: null };
 
   /* eslint-disable camelcase */
   const migrations = loadJSON(migrationsFile, context.mappings);

--- a/src/context/directory/handlers/organizations.ts
+++ b/src/context/directory/handlers/organizations.ts
@@ -5,15 +5,16 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedOrganizations = {
-  organizations: unknown[] | undefined;
+  organizations: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedOrganizations {
   const organizationsFolder = path.join(context.filePath, 'organizations');
 
-  if (!existsMustBeDir(organizationsFolder)) return { organizations: undefined }; // Skip
+  if (!existsMustBeDir(organizationsFolder)) return { organizations: null }; // Skip
 
   const files = getFiles(organizationsFolder, ['.json']);
 

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -6,14 +6,15 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedPages = {
-  pages: unknown[] | undefined;
+  pages: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedPages {
   const pagesFolder = path.join(context.filePath, constants.PAGES_DIRECTORY);
-  if (!existsMustBeDir(pagesFolder)) return { pages: undefined }; // Skip
+  if (!existsMustBeDir(pagesFolder)) return { pages: null }; // Skip
 
   const files: string[] = getFiles(pagesFolder, ['.json', '.html']);
 
@@ -30,7 +31,7 @@ function parse(context: DirectoryContext): ParsedPages {
     return acc;
   }, {});
 
-  const pages = Object.values(sorted).flatMap(({ meta, html }): unknown[] => {
+  const pages = Object.values(sorted).flatMap(({ meta, html }): Asset[] => {
     if (!meta) {
       log.warn(`Skipping pages file ${html} as missing the corresponding '.json' file`);
       return [];

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -52,7 +52,7 @@ function parse(context: DirectoryContext): ParsedPages {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const pages = [...(context.assets.pages || [])];
+  const pages = context.assets.pages;
 
   if (!pages) return; // Skip, nothing to dump
 

--- a/src/context/directory/handlers/resourceServers.ts
+++ b/src/context/directory/handlers/resourceServers.ts
@@ -4,14 +4,15 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedResourceServers = {
-  resourceServers: unknown[] | undefined;
+  resourceServers: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedResourceServers {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);
-  if (!existsMustBeDir(resourceServersFolder)) return { resourceServers: undefined }; // Skip
+  if (!existsMustBeDir(resourceServersFolder)) return { resourceServers: null }; // Skip
 
   const foundFiles = getFiles(resourceServersFolder, ['.json']);
 

--- a/src/context/directory/handlers/roles.ts
+++ b/src/context/directory/handlers/roles.ts
@@ -6,14 +6,15 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedRoles = {
-  roles: unknown[] | undefined;
+  roles: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedRoles {
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);
-  if (!existsMustBeDir(rolesFolder)) return { roles: undefined }; // Skip
+  if (!existsMustBeDir(rolesFolder)) return { roles: null }; // Skip
 
   const files = getFiles(rolesFolder, ['.json']);
 

--- a/src/context/directory/handlers/rules.ts
+++ b/src/context/directory/handlers/rules.ts
@@ -33,7 +33,7 @@ function parse(context: DirectoryContext): ParsedRules {
 }
 
 async function dump(context: DirectoryContext): Promise<void> {
-  const rules = [...(context.assets.rules || [])];
+  const { rules } = context.assets;
 
   if (!rules) return; // Skip, nothing to dump
 

--- a/src/context/directory/handlers/rules.ts
+++ b/src/context/directory/handlers/rules.ts
@@ -7,14 +7,15 @@ import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../.
 
 import { DirectoryHandler } from './index';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedRules = {
-  rules: unknown[] | undefined;
+  rules: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedRules {
   const rulesFolder = path.join(context.filePath, constants.RULES_DIRECTORY);
-  if (!existsMustBeDir(rulesFolder)) return { rules: undefined }; // Skip
+  if (!existsMustBeDir(rulesFolder)) return { rules: null }; // Skip
 
   const files: string[] = getFiles(rulesFolder, ['.json']);
 

--- a/src/context/directory/handlers/rulesConfigs.ts
+++ b/src/context/directory/handlers/rulesConfigs.ts
@@ -4,14 +4,15 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedRulesConfigs = {
-  rulesConfigs: unknown[] | undefined;
+  rulesConfigs: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedRulesConfigs {
   const rulesConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);
-  if (!existsMustBeDir(rulesConfigsFolder)) return { rulesConfigs: undefined }; // Skip
+  if (!existsMustBeDir(rulesConfigsFolder)) return { rulesConfigs: null }; // Skip
 
   const foundFiles: string[] = getFiles(rulesConfigsFolder, ['.json']);
 

--- a/src/context/directory/handlers/tenant.ts
+++ b/src/context/directory/handlers/tenant.ts
@@ -3,48 +3,50 @@ import { existsMustBeDir, isFile, dumpJSON, loadJSON, clearTenantFlags } from '.
 import { sessionDurationsToMinutes } from '../../../sessionDurationsToMinutes';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedTenant =
-  | {
-      tenant: {
+type ParsedTenant = {
+  tenant:
+    | ({
         session_lifetime: number;
         idle_session_lifetime: number;
-        [key: string]: unknown;
-      };
-    }
-  | {};
+      } & {
+        [key: string]: Asset;
+      })
+    | null;
+};
 
 function parse(context: DirectoryContext): ParsedTenant {
   const baseFolder = path.join(context.filePath);
-  if (!existsMustBeDir(baseFolder)) return {}; // Skip
+  if (!existsMustBeDir(baseFolder)) return { tenant: null }; // Skip
 
   const tenantFile = path.join(baseFolder, 'tenant.json');
 
-  if (isFile(tenantFile)) {
-    /* eslint-disable camelcase */
-    const {
-      session_lifetime,
-      idle_session_lifetime,
-      ...tenant
-    }: {
-      session_lifetime?: number;
-      idle_session_lifetime?: number;
-      [key: string]: any;
-    } = loadJSON(tenantFile, context.mappings);
-
-    clearTenantFlags(tenant);
-
-    const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
-
-    return {
-      tenant: {
-        ...tenant,
-        ...sessionDurations,
-      },
-    };
+  if (!isFile(tenantFile)) {
+    return { tenant: null };
   }
+  /* eslint-disable camelcase */
+  const {
+    session_lifetime,
+    idle_session_lifetime,
+    ...tenant
+  }: {
+    session_lifetime?: number;
+    idle_session_lifetime?: number;
+    [key: string]: any;
+  } = loadJSON(tenantFile, context.mappings);
 
-  return {};
+  clearTenantFlags(tenant);
+
+  const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
+
+  return {
+    //@ts-ignore
+    tenant: {
+      ...tenant,
+      ...sessionDurations,
+    },
+  };
 }
 
 async function dump(context: DirectoryContext): Promise<void> {

--- a/src/context/directory/handlers/triggers.ts
+++ b/src/context/directory/handlers/triggers.ts
@@ -6,15 +6,16 @@ import DirectoryContext from '..';
 
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import log from '../../../logger';
+import { Asset } from '../../../types';
 
 type ParsedTriggers = {
-  triggers: unknown[] | undefined;
+  triggers: Asset[] | null;
 };
 
 function parse(context: DirectoryContext): ParsedTriggers {
   const triggersFolder = path.join(context.filePath, constants.TRIGGERS_DIRECTORY);
 
-  if (!existsMustBeDir(triggersFolder)) return { triggers: undefined }; // Skip
+  if (!existsMustBeDir(triggersFolder)) return { triggers: null }; // Skip
 
   const files = getFiles(triggersFolder, ['.json']);
 

--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -64,8 +64,9 @@ function mapActionCode(basePath: string, action: { code: string; name: string })
 
 async function dump(context: YAMLContext): Promise<ParsedActions> {
   const { actions } = context.assets;
-  //@ts-ignore TODO: need to investigate why returning void here when other handlers do not
-  if (!actions) return; // Nothing to do
+
+  if (!actions) return { actions: null };
+
   return {
     actions: actions.map((action) => ({
       name: action.name,

--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -6,9 +6,10 @@ import { sanitize } from '../../../utils';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedActions = {
-  actions: unknown[] | undefined;
+  actions: Asset[] | null;
 };
 
 type Secret = { name: string; value: string };
@@ -22,17 +23,18 @@ function parseCode(context: YAMLContext, code: string) {
 
 async function parse(context: YAMLContext): Promise<ParsedActions> {
   // Load the script file for each action
-  //@ts-ignore TODO: understand if empty array is intentionally being returned
-  if (!context.assets.actions) return [];
-  const actions = {
+  const { actions } = context.assets;
+
+  if (!actions) return { actions: null };
+
+  return {
     actions: [
-      ...context.assets.actions.map((action) => ({
+      ...actions.map((action) => ({
         ...action,
         code: parseCode(context, action.code),
       })),
     ],
   };
-  return actions;
 }
 
 function mapSecrets(secrets: { name: string; value: string }[]): Secret[] {

--- a/src/context/yaml/handlers/attackProtection.ts
+++ b/src/context/yaml/handlers/attackProtection.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedAttackProtection = {
-  attackProtection: unknown;
+  attackProtection: Asset;
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedAttackProtection> {

--- a/src/context/yaml/handlers/attackProtection.ts
+++ b/src/context/yaml/handlers/attackProtection.ts
@@ -3,12 +3,16 @@ import YAMLContext from '..';
 import { Asset } from '../../../types';
 
 type ParsedAttackProtection = {
-  attackProtection: Asset;
+  attackProtection: Asset | null;
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedAttackProtection> {
+  const { attackProtection } = context.assets;
+
+  if (!attackProtection) return { attackProtection: null };
+
   return {
-    attackProtection: context.assets.attackProtection || {},
+    attackProtection,
   };
 }
 

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -28,13 +28,13 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
       },
     };
 
-  if (context.assets.branding === null) return { branding: null };
+  if (!context.assets.branding) return { branding: null };
 
   const {
     branding: { templates, ...branding },
   } = context.assets;
 
-  if (templates === null || templates === undefined) {
+  if (!templates) {
     return { branding: { ...branding } };
   }
 
@@ -59,7 +59,7 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
 async function dump(context: YAMLContext): Promise<ParsedBranding> {
   const { branding } = context.assets;
 
-  if (branding === null) return { branding: null };
+  if (!branding) return { branding: null };
 
   let templates = branding.templates || [];
 

--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -20,7 +20,6 @@ async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
 async function dump(context: YAMLContext): Promise<ParsedClientGrants> {
   const { clientGrants, clients } = context.assets;
 
-  // Nothing to do
   if (!clientGrants) return { clientGrants: null };
 
   // Convert client_id to the client name for readability

--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -1,9 +1,10 @@
 import { convertClientIdToName } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedClientGrants = {
-  clientGrants: unknown[];
+  clientGrants: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
@@ -14,7 +15,7 @@ async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedClientGrants | {}> {
-  const { clientGrants } = context.assets;
+  const { clientGrants, clients } = context.assets;
 
   // Nothing to do
   if (!clientGrants) return {};
@@ -23,7 +24,7 @@ async function dump(context: YAMLContext): Promise<ParsedClientGrants | {}> {
   return {
     clientGrants: clientGrants.map((grant) => {
       const dumpGrant = { ...grant };
-      dumpGrant.client_id = convertClientIdToName(dumpGrant.client_id, context.assets.clients);
+      dumpGrant.client_id = convertClientIdToName(dumpGrant.client_id, clients || []);
       return dumpGrant;
     }),
   };

--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -8,17 +8,20 @@ type ParsedClientGrants = {
 };
 
 async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
-  // nothing to do, set default empty
+  const { clientGrants } = context.assets;
+
+  if (!clientGrants) return { clientGrants: null };
+
   return {
-    clientGrants: context.assets.clientGrants,
+    clientGrants,
   };
 }
 
-async function dump(context: YAMLContext): Promise<ParsedClientGrants | {}> {
+async function dump(context: YAMLContext): Promise<ParsedClientGrants> {
   const { clientGrants, clients } = context.assets;
 
   // Nothing to do
-  if (!clientGrants) return {};
+  if (!clientGrants) return { clientGrants: null };
 
   // Convert client_id to the client name for readability
   return {

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -17,8 +17,8 @@ async function parse(context: YAMLContext): Promise<ParsedClients> {
   const { clients } = context.assets;
   const clientsFolder = path.join(context.basePath, constants.CLIENTS_DIRECTORY);
 
-  if (!clients || !clients.length) {
-    return { clients: context.assets.clients };
+  if (!clients) {
+    return { clients: null };
   }
 
   return {
@@ -43,7 +43,7 @@ async function dump(context: YAMLContext): Promise<ParsedClients> {
   const clientsFolder = path.join(context.basePath, constants.CLIENTS_DIRECTORY);
 
   const { clients } = context.assets;
-  if (clients === null) return { clients: null };
+  if (!clients) return { clients: null };
 
   return {
     clients: [

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -5,9 +5,10 @@ import log from '../../../logger';
 import { isFile, sanitize, clearClientArrays } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedClients = {
-  clients: unknown[];
+  clients: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedClients> {
@@ -41,9 +42,12 @@ async function dump(context: YAMLContext): Promise<ParsedClients> {
   // Save custom_login_page to a separate html file
   const clientsFolder = path.join(context.basePath, constants.CLIENTS_DIRECTORY);
 
+  const { clients } = context.assets;
+  if (clients === null) return { clients: null };
+
   return {
     clients: [
-      ...context.assets.clients.map((client) => {
+      ...clients.map((client) => {
         if (client.custom_login_page) {
           const clientName = sanitize(client.name);
           const html = client.custom_login_page;

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -12,9 +12,10 @@ import {
 } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedConnections = {
-  connections: unknown[];
+  connections: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedConnections> {
@@ -62,7 +63,7 @@ const getFormattedOptions = (connection, clients) => {
 };
 
 async function dump(context: YAMLContext): Promise<ParsedConnections | {}> {
-  const { connections } = context.assets;
+  const { connections, clients } = context.assets;
 
   // Nothing to do
   if (!connections) return {};
@@ -72,12 +73,9 @@ async function dump(context: YAMLContext): Promise<ParsedConnections | {}> {
     connections: connections.map((connection) => {
       const dumpedConnection = {
         ...connection,
-        ...getFormattedOptions(connection, context.assets.clients),
+        ...getFormattedOptions(connection, clients),
         ...(connection.enabled_clients && {
-          enabled_clients: mapClientID2NameSorted(
-            connection.enabled_clients,
-            context.assets.clients
-          ),
+          enabled_clients: mapClientID2NameSorted(connection.enabled_clients, clients || []),
         }),
       };
 

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -63,10 +63,8 @@ const getFormattedOptions = (connection, clients) => {
 async function dump(context: YAMLContext): Promise<ParsedConnections> {
   const { connections, clients } = context.assets;
 
-  // Nothing to do
   if (!connections) return { connections: null };
 
-  // nothing to do, set default if empty
   return {
     connections: connections.map((connection) => {
       const dumpedConnection = {

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -19,13 +19,11 @@ type ParsedConnections = {
 };
 
 async function parse(context: YAMLContext): Promise<ParsedConnections> {
-  // Load the HTML file for email connections
-
   const { connections } = context.assets;
   const connectionsFolder = path.join(context.basePath, constants.CONNECTIONS_DIRECTORY);
 
-  if (!connections || !connections.length) {
-    return { connections: context.assets.connections };
+  if (!connections) {
+    return { connections: null };
   }
 
   return {
@@ -62,11 +60,11 @@ const getFormattedOptions = (connection, clients) => {
   }
 };
 
-async function dump(context: YAMLContext): Promise<ParsedConnections | {}> {
+async function dump(context: YAMLContext): Promise<ParsedConnections> {
   const { connections, clients } = context.assets;
 
   // Nothing to do
-  if (!connections) return {};
+  if (!connections) return { connections: null };
 
   // nothing to do, set default if empty
   return {

--- a/src/context/yaml/handlers/databases.ts
+++ b/src/context/yaml/handlers/databases.ts
@@ -39,9 +39,8 @@ async function parse(context: YAMLContext): Promise<ParsedDatabases> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedDatabases> {
-  const { databases } = context.assets;
+  const { databases, clients } = context.assets;
 
-  // Nothing to do
   if (!databases) return { databases: null };
 
   const sortCustomScripts = ([name1]: [string, Function], [name2]: [string, Function]): number => {
@@ -54,10 +53,7 @@ async function dump(context: YAMLContext): Promise<ParsedDatabases> {
       ...databases.map((database) => ({
         ...database,
         ...(database.enabled_clients && {
-          enabled_clients: mapClientID2NameSorted(
-            database.enabled_clients,
-            context.assets.clients || []
-          ),
+          enabled_clients: mapClientID2NameSorted(database.enabled_clients, clients || []),
         }),
         options: {
           ...database.options,

--- a/src/context/yaml/handlers/databases.ts
+++ b/src/context/yaml/handlers/databases.ts
@@ -4,9 +4,10 @@ import { mapClientID2NameSorted, sanitize } from '../../../utils';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedDatabases = {
-  databases: unknown[];
+  databases: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedDatabases | {}> {
@@ -51,7 +52,10 @@ async function dump(context: YAMLContext): Promise<ParsedDatabases | {}> {
       ...databases.map((database) => ({
         ...database,
         ...(database.enabled_clients && {
-          enabled_clients: mapClientID2NameSorted(database.enabled_clients, context.assets.clients),
+          enabled_clients: mapClientID2NameSorted(
+            database.enabled_clients,
+            context.assets.clients || []
+          ),
         }),
         options: {
           ...database.options,

--- a/src/context/yaml/handlers/databases.ts
+++ b/src/context/yaml/handlers/databases.ts
@@ -10,13 +10,15 @@ type ParsedDatabases = {
   databases: Asset[] | null;
 };
 
-async function parse(context: YAMLContext): Promise<ParsedDatabases | {}> {
+async function parse(context: YAMLContext): Promise<ParsedDatabases> {
   // Load the script file for custom db
-  if (!context.assets.databases) return {};
+  const { databases } = context.assets;
+
+  if (!databases) return { databases: null };
 
   return {
     databases: [
-      ...context.assets.databases.map((database) => ({
+      ...databases.map((database) => ({
         ...database,
         options: {
           ...database.options,
@@ -36,11 +38,11 @@ async function parse(context: YAMLContext): Promise<ParsedDatabases | {}> {
   };
 }
 
-async function dump(context: YAMLContext): Promise<ParsedDatabases | {}> {
+async function dump(context: YAMLContext): Promise<ParsedDatabases> {
   const { databases } = context.assets;
 
   // Nothing to do
-  if (!databases) return {};
+  if (!databases) return { databases: null };
 
   const sortCustomScripts = ([name1]: [string, Function], [name2]: [string, Function]): number => {
     if (name1 === name2) return 0;
@@ -83,7 +85,7 @@ async function dump(context: YAMLContext): Promise<ParsedDatabases | {}> {
     ],
   };
 }
-const databasesHandler: YAMLHandler<ParsedDatabases | {}> = {
+const databasesHandler: YAMLHandler<ParsedDatabases> = {
   parse,
   dump,
 };

--- a/src/context/yaml/handlers/emailProvider.ts
+++ b/src/context/yaml/handlers/emailProvider.ts
@@ -18,16 +18,20 @@ async function parse(context: YAMLContext): Promise<ParsedEmailProvider> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedEmailProvider> {
-  let { emailProvider } = context.assets;
+  if (!context.assets.emailProvider) return { emailProvider: null };
 
-  const excludedDefaults = context.assets.exclude?.defaults || [];
-  if (emailProvider && !excludedDefaults.includes('emailProvider')) {
-    // Add placeholder for credentials as they cannot be exported
-    emailProvider = emailProviderDefaults(emailProvider);
-  }
+  const emailProvider = (() => {
+    const { emailProvider } = context.assets;
+    const excludedDefaults = context.assets.exclude?.defaults || [];
+    if (emailProvider && !excludedDefaults.includes('emailProvider')) {
+      // Add placeholder for credentials as they cannot be exported
+      return emailProviderDefaults(emailProvider);
+    }
+    return emailProvider;
+  })();
 
   return {
-    emailProvider: emailProvider || {},
+    emailProvider,
   };
 }
 

--- a/src/context/yaml/handlers/emailProvider.ts
+++ b/src/context/yaml/handlers/emailProvider.ts
@@ -1,15 +1,19 @@
 import { emailProviderDefaults } from '../../defaults';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedEmailProvider = {
-  emailProvider: unknown;
+  emailProvider: Asset | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedEmailProvider> {
-  // nothing to do, set default if empty
+  const { emailProvider } = context.assets;
+
+  if (!emailProvider) return { emailProvider: null };
+
   return {
-    emailProvider: { ...(context.assets.emailProvider || {}) },
+    emailProvider,
   };
 }
 

--- a/src/context/yaml/handlers/emailTemplates.ts
+++ b/src/context/yaml/handlers/emailTemplates.ts
@@ -28,7 +28,7 @@ async function parse(context: YAMLContext): Promise<ParsedEmailTemplates> {
 async function dump(context: YAMLContext): Promise<ParsedEmailTemplates> {
   let emailTemplates = context.assets.emailTemplates;
 
-  if (!emailTemplates || emailTemplates.length < 1) {
+  if (!emailTemplates) {
     return { emailTemplates: null };
   }
 

--- a/src/context/yaml/handlers/emailTemplates.ts
+++ b/src/context/yaml/handlers/emailTemplates.ts
@@ -3,15 +3,18 @@ import path from 'path';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedEmailTemplates = {
-  emailTemplates: unknown[];
+  emailTemplates: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedEmailTemplates> {
   // Load the HTML file for each page
+  const { emailTemplates } = context.assets;
 
-  const emailTemplates = context.assets.emailTemplates || [];
+  if (!emailTemplates) return { emailTemplates: null };
+
   return {
     emailTemplates: [
       ...emailTemplates.map((et) => ({

--- a/src/context/yaml/handlers/emailTemplates.ts
+++ b/src/context/yaml/handlers/emailTemplates.ts
@@ -26,20 +26,22 @@ async function parse(context: YAMLContext): Promise<ParsedEmailTemplates> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedEmailTemplates> {
-  let emailTemplates = [...(context.assets.emailTemplates || [])];
+  let emailTemplates = context.assets.emailTemplates;
 
-  if (emailTemplates.length > 0) {
-    // Create Templates folder
-    const templatesFolder = path.join(context.basePath, 'emailTemplates');
-    fs.ensureDirSync(templatesFolder);
-    emailTemplates = emailTemplates.map((template) => {
-      // Dump template to file
-      const templateFile = path.join(templatesFolder, `${template.template}.html`);
-      log.info(`Writing ${templateFile}`);
-      fs.writeFileSync(templateFile, template.body);
-      return { ...template, body: `./emailTemplates/${template.template}.html` };
-    });
+  if (!emailTemplates || emailTemplates.length < 1) {
+    return { emailTemplates: null };
   }
+
+  // Create Templates folder
+  const templatesFolder = path.join(context.basePath, 'emailTemplates');
+  fs.ensureDirSync(templatesFolder);
+  emailTemplates = emailTemplates.map((template) => {
+    // Dump template to file
+    const templateFile = path.join(templatesFolder, `${template.template}.html`);
+    log.info(`Writing ${templateFile}`);
+    fs.writeFileSync(templateFile, template.body);
+    return { ...template, body: `./emailTemplates/${template.template}.html` };
+  });
 
   return { emailTemplates };
 }

--- a/src/context/yaml/handlers/guardianFactorProviders.ts
+++ b/src/context/yaml/handlers/guardianFactorProviders.ts
@@ -1,14 +1,18 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactorProviders = {
-  guardianFactorProviders: unknown[];
+  guardianFactorProviders: Asset[] | null;
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorProviders> {
-  // nothing to do, set default empty
+  const { guardianFactorProviders } = context.assets;
+
+  if (!guardianFactorProviders) return { guardianFactorProviders: null };
+
   return {
-    guardianFactorProviders: [...(context.assets.guardianFactorProviders || [])],
+    guardianFactorProviders,
   };
 }
 

--- a/src/context/yaml/handlers/guardianFactorTemplates.ts
+++ b/src/context/yaml/handlers/guardianFactorTemplates.ts
@@ -1,14 +1,18 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactorTemplates = {
-  guardianFactorTemplates: unknown[];
+  guardianFactorTemplates: Asset[] | null;
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorTemplates> {
-  // nothing to do, set default if empty
+  const { guardianFactorTemplates } = context.assets;
+
+  if (!guardianFactorTemplates) return { guardianFactorTemplates: null };
+
   return {
-    guardianFactorTemplates: [...(context.assets.guardianFactorTemplates || [])],
+    guardianFactorTemplates,
   };
 }
 

--- a/src/context/yaml/handlers/guardianFactors.ts
+++ b/src/context/yaml/handlers/guardianFactors.ts
@@ -1,14 +1,18 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedGuardianFactors = {
-  guardianFactors: unknown[];
+  guardianFactors: Asset[] | null;
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactors> {
-  // nothing to do, set default if empty
+  const { guardianFactors } = context.assets;
+
+  if (!guardianFactors) return { guardianFactors: null };
+
   return {
-    guardianFactors: [...(context.assets.guardianFactors || [])],
+    guardianFactors,
   };
 }
 

--- a/src/context/yaml/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/context/yaml/handlers/guardianPhoneFactorMessageTypes.ts
@@ -6,9 +6,12 @@ type ParsedGuardianFactorMessageTypes = {
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorMessageTypes> {
-  // nothing to do, set default if empty
+  const { guardianPhoneFactorMessageTypes } = context.assets;
+
+  if (!guardianPhoneFactorMessageTypes) return { guardianPhoneFactorMessageTypes: null };
+
   return {
-    guardianPhoneFactorMessageTypes: { ...(context.assets.guardianPhoneFactorMessageTypes || {}) },
+    guardianPhoneFactorMessageTypes,
   };
 }
 

--- a/src/context/yaml/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/context/yaml/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -8,11 +8,12 @@ type ParsedGuardianPhoneFactorSelectedProvider = {
 async function parseAndDump(
   context: YAMLContext
 ): Promise<ParsedGuardianPhoneFactorSelectedProvider> {
-  // nothing to do, set default empty
+  const { guardianPhoneFactorSelectedProvider } = context.assets;
+
+  if (!guardianPhoneFactorSelectedProvider) return { guardianPhoneFactorSelectedProvider: null };
+
   return {
-    guardianPhoneFactorSelectedProvider: {
-      ...(context.assets.guardianPhoneFactorSelectedProvider || {}),
-    },
+    guardianPhoneFactorSelectedProvider,
   };
 }
 

--- a/src/context/yaml/handlers/guardianPolicies.ts
+++ b/src/context/yaml/handlers/guardianPolicies.ts
@@ -6,9 +6,12 @@ type ParsedGuardianPolicies = {
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianPolicies> {
-  // nothing to do, set default if empty
+  const { guardianPolicies } = context.assets;
+
+  if (!guardianPolicies) return { guardianPolicies: null };
+
   return {
-    guardianPolicies: { ...(context.assets.guardianPolicies || {}) },
+    guardianPolicies,
   };
 }
 

--- a/src/context/yaml/handlers/hooks.ts
+++ b/src/context/yaml/handlers/hooks.ts
@@ -7,20 +7,19 @@ import log from '../../../logger';
 
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedHooks =
-  | {
-      hooks: unknown[];
-    }
-  | {};
+type ParsedHooks = {
+  hooks: Asset[] | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedHooks> {
-  // Load the script file for each hook
-  if (!context.assets.hooks) return {};
+  const { hooks } = context.assets;
+  if (!hooks) return { hooks: null };
 
   return {
     hooks: [
-      ...context.assets.hooks.map((hook) => {
+      ...hooks.map((hook) => {
         if (hook.script) {
           //@ts-ignore TODO: understand why two arguments are passed when context.loadFile only accepts one
           hook.script = context.loadFile(hook.script, constants.HOOKS_DIRECTORY);

--- a/src/context/yaml/handlers/hooks.ts
+++ b/src/context/yaml/handlers/hooks.ts
@@ -34,25 +34,27 @@ async function parse(context: YAMLContext): Promise<ParsedHooks> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedHooks> {
-  let hooks = [...(context.assets.hooks || [])];
+  let hooks = context.assets.hooks;
 
-  if (hooks.length > 0) {
-    // Create hooks folder
-    const hooksFolder = path.join(context.basePath, 'hooks');
-    fs.ensureDirSync(hooksFolder);
-
-    hooks = hooks.map((hook) => {
-      // Dump hook code to file
-      // For cases when hook does not have `meta['hook-name']`
-      hook.name = hook.name || hook.id;
-      const codeName = sanitize(`${hook.name}.js`);
-      const codeFile = path.join(hooksFolder, codeName);
-      log.info(`Writing ${codeFile}`);
-      fs.writeFileSync(codeFile, hook.script);
-
-      return { ...hook, script: `./hooks/${codeName}` };
-    });
+  if (!hooks || hooks.length < 1) {
+    return { hooks: null };
   }
+
+  // Create hooks folder
+  const hooksFolder = path.join(context.basePath, 'hooks');
+  fs.ensureDirSync(hooksFolder);
+
+  hooks = hooks.map((hook) => {
+    // Dump hook code to file
+    // For cases when hook does not have `meta['hook-name']`
+    hook.name = hook.name || hook.id;
+    const codeName = sanitize(`${hook.name}.js`);
+    const codeFile = path.join(hooksFolder, codeName);
+    log.info(`Writing ${codeFile}`);
+    fs.writeFileSync(codeFile, hook.script);
+
+    return { ...hook, script: `./hooks/${codeName}` };
+  });
 
   return { hooks };
 }

--- a/src/context/yaml/handlers/hooks.ts
+++ b/src/context/yaml/handlers/hooks.ts
@@ -36,7 +36,7 @@ async function parse(context: YAMLContext): Promise<ParsedHooks> {
 async function dump(context: YAMLContext): Promise<ParsedHooks> {
   let hooks = context.assets.hooks;
 
-  if (!hooks || hooks.length < 1) {
+  if (!hooks) {
     return { hooks: null };
   }
 

--- a/src/context/yaml/handlers/logStreams.ts
+++ b/src/context/yaml/handlers/logStreams.ts
@@ -7,8 +7,12 @@ type ParsedLogStreams = {
 };
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedLogStreams> {
+  const { logStreams } = context.assets;
+
+  if (!logStreams) return { logStreams: null };
+
   return {
-    logStreams: context.assets.logStreams || [],
+    logStreams,
   };
 }
 

--- a/src/context/yaml/handlers/migrations.ts
+++ b/src/context/yaml/handlers/migrations.ts
@@ -8,6 +8,9 @@ type ParsedMigrations = {
 
 async function parse(context: YAMLContext): Promise<ParsedMigrations> {
   const { migrations } = context.assets;
+
+  if (!migrations) return { migrations: null };
+
   return { migrations };
 }
 

--- a/src/context/yaml/handlers/migrations.ts
+++ b/src/context/yaml/handlers/migrations.ts
@@ -6,7 +6,7 @@ type ParsedMigrations = {
   migrations: Asset | null;
 };
 
-async function parse(context: YAMLContext): Promise<ParsedMigrations> {
+async function parseAndDump(context: YAMLContext): Promise<ParsedMigrations> {
   const { migrations } = context.assets;
 
   if (!migrations) return { migrations: null };
@@ -14,15 +14,9 @@ async function parse(context: YAMLContext): Promise<ParsedMigrations> {
   return { migrations };
 }
 
-async function dump(context: YAMLContext): Promise<ParsedMigrations> {
-  const { migrations } = context.assets;
-
-  return { migrations: migrations || {} };
-}
-
 const migrationsHandler: YAMLHandler<ParsedMigrations> = {
-  parse,
-  dump,
+  parse: parseAndDump,
+  dump: parseAndDump,
 };
 
 export default migrationsHandler;

--- a/src/context/yaml/handlers/migrations.ts
+++ b/src/context/yaml/handlers/migrations.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedMigrations = {
-  migrations: unknown[];
+  migrations: Asset | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedMigrations> {

--- a/src/context/yaml/handlers/organizations.ts
+++ b/src/context/yaml/handlers/organizations.ts
@@ -19,26 +19,26 @@ async function parse(context: YAMLContext): Promise<ParsedOrganizations> {
 async function dump(context: YAMLContext): Promise<ParsedOrganizations> {
   const { organizations } = context.assets;
 
+  if (!organizations) return { organizations: null };
+
   return {
-    organizations: [
-      ...(organizations || []).map((org) => {
-        if (org.connections.length > 0) {
-          org.connections = org.connections.map((c) => {
-            // connection is a computed field
-            const name = c.connection && c.connection.name;
-            delete c.connection_id;
-            delete c.connection;
+    organizations: organizations.map((org) => {
+      if (org.connections.length > 0) {
+        org.connections = org.connections.map((c) => {
+          // connection is a computed field
+          const name = c.connection && c.connection.name;
+          delete c.connection_id;
+          delete c.connection;
 
-            return {
-              name,
-              ...c,
-            };
-          });
-        }
+          return {
+            name,
+            ...c,
+          };
+        });
+      }
 
-        return org;
-      }),
-    ],
+      return org;
+    }),
   };
 }
 

--- a/src/context/yaml/handlers/organizations.ts
+++ b/src/context/yaml/handlers/organizations.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedOrganizations = {
-  organizations: unknown[];
+  organizations: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedOrganizations> {

--- a/src/context/yaml/handlers/organizations.ts
+++ b/src/context/yaml/handlers/organizations.ts
@@ -9,8 +9,10 @@ type ParsedOrganizations = {
 async function parse(context: YAMLContext): Promise<ParsedOrganizations> {
   const { organizations } = context.assets;
 
+  if (!organizations) return { organizations: null };
+
   return {
-    organizations: organizations,
+    organizations,
   };
 }
 

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -4,21 +4,21 @@ import fs from 'fs-extra';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedPages =
-  | {
-      pages: unknown[];
-    }
-  | {};
+type ParsedPages = {
+  pages: Asset[] | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedPages> {
   // Load the HTML file for each page
+  const { pages } = context.assets;
 
-  if (!context.assets.pages) return {};
+  if (!pages) return { pages: null };
 
   return {
     pages: [
-      ...context.assets.pages.map((page) => ({
+      ...pages.map((page) => ({
         ...page,
         html: page.html ? context.loadFile(page.html) : '',
       })),

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -27,28 +27,30 @@ async function parse(context: YAMLContext): Promise<ParsedPages> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedPages> {
-  let pages = [...(context.assets.pages || [])];
+  let pages = context.assets.pages;
 
-  if (pages.length > 0) {
-    // Create Pages folder
-    const pagesFolder = path.join(context.basePath, 'pages');
-    fs.ensureDirSync(pagesFolder);
-
-    pages = pages.map((page) => {
-      if (page.name === 'error_page' && page.html === undefined) {
-        return page;
-      }
-
-      // Dump html to file
-      const htmlFile = path.join(pagesFolder, `${page.name}.html`);
-      log.info(`Writing ${htmlFile}`);
-      fs.writeFileSync(htmlFile, page.html);
-      return {
-        ...page,
-        html: `./pages/${page.name}.html`,
-      };
-    });
+  if (!pages || pages.length < 1) {
+    return { pages: null };
   }
+
+  // Create Pages folder
+  const pagesFolder = path.join(context.basePath, 'pages');
+  fs.ensureDirSync(pagesFolder);
+
+  pages = pages.map((page) => {
+    if (page.name === 'error_page' && page.html === undefined) {
+      return page;
+    }
+
+    // Dump html to file
+    const htmlFile = path.join(pagesFolder, `${page.name}.html`);
+    log.info(`Writing ${htmlFile}`);
+    fs.writeFileSync(htmlFile, page.html);
+    return {
+      ...page,
+      html: `./pages/${page.name}.html`,
+    };
+  });
 
   return { pages };
 }

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -29,7 +29,7 @@ async function parse(context: YAMLContext): Promise<ParsedPages> {
 async function dump(context: YAMLContext): Promise<ParsedPages> {
   let pages = context.assets.pages;
 
-  if (!pages || pages.length < 1) {
+  if (!pages) {
     return { pages: null };
   }
 

--- a/src/context/yaml/handlers/resourceServers.ts
+++ b/src/context/yaml/handlers/resourceServers.ts
@@ -7,9 +7,13 @@ type ParsedResourceServers = {
 };
 
 async function parse(context: YAMLContext): Promise<ParsedResourceServers> {
-  // nothing to do, set default if empty
+  const { resourceServers } = context.assets;
+
+  if (!resourceServers) {
+    return { resourceServers: null };
+  }
   return {
-    resourceServers: context.assets.resourceServers,
+    resourceServers,
   };
 }
 

--- a/src/context/yaml/handlers/resourceServers.ts
+++ b/src/context/yaml/handlers/resourceServers.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedResourceServers = {
-  resourceServers: unknown[];
+  resourceServers: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedResourceServers> {

--- a/src/context/yaml/handlers/resourceServers.ts
+++ b/src/context/yaml/handlers/resourceServers.ts
@@ -6,7 +6,7 @@ type ParsedResourceServers = {
   resourceServers: Asset[] | null;
 };
 
-async function parse(context: YAMLContext): Promise<ParsedResourceServers> {
+async function dumpAndParse(context: YAMLContext): Promise<ParsedResourceServers> {
   const { resourceServers } = context.assets;
 
   if (!resourceServers) {
@@ -17,16 +17,9 @@ async function parse(context: YAMLContext): Promise<ParsedResourceServers> {
   };
 }
 
-async function dump(context: YAMLContext): Promise<ParsedResourceServers> {
-  // nothing to do, set default if empty
-  return {
-    resourceServers: [...(context.assets.resourceServers || [])],
-  };
-}
-
 const resourceServersHandler: YAMLHandler<ParsedResourceServers> = {
-  parse,
-  dump,
+  parse: dumpAndParse,
+  dump: dumpAndParse,
 };
 
 export default resourceServersHandler;

--- a/src/context/yaml/handlers/roles.ts
+++ b/src/context/yaml/handlers/roles.ts
@@ -7,7 +7,6 @@ type ParsedRoles = {
 };
 
 async function parse(context: YAMLContext): Promise<ParsedRoles> {
-  // nothing to do, set default empty
   const { roles } = context.assets;
 
   if (!roles) return { roles: null };
@@ -18,17 +17,18 @@ async function parse(context: YAMLContext): Promise<ParsedRoles> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedRoles> {
-  // remove empty descriptions
-  return {
-    roles: [
-      ...(context.assets.roles || []).map((role) => {
-        if (role.description === null) {
-          delete role.description;
-        }
+  const { roles } = context.assets;
 
-        return role;
-      }),
-    ],
+  if (!roles) return { roles: null };
+
+  return {
+    roles: roles.map((role) => {
+      if (role.description === null) {
+        delete role.description;
+      }
+
+      return role;
+    }),
   };
 }
 

--- a/src/context/yaml/handlers/roles.ts
+++ b/src/context/yaml/handlers/roles.ts
@@ -8,8 +8,12 @@ type ParsedRoles = {
 
 async function parse(context: YAMLContext): Promise<ParsedRoles> {
   // nothing to do, set default empty
+  const { roles } = context.assets;
+
+  if (!roles) return { roles: null };
+
   return {
-    roles: context.assets.roles,
+    roles,
   };
 }
 

--- a/src/context/yaml/handlers/roles.ts
+++ b/src/context/yaml/handlers/roles.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
 type ParsedRoles = {
-  roles: unknown[];
+  roles: Asset[] | null;
 };
 
 async function parse(context: YAMLContext): Promise<ParsedRoles> {

--- a/src/context/yaml/handlers/rules.ts
+++ b/src/context/yaml/handlers/rules.ts
@@ -28,22 +28,24 @@ async function parse(context: YAMLContext): Promise<ParsedRules> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedRules> {
-  let rules = [...(context.assets.rules || [])];
+  let { rules } = context.assets;
 
-  if (rules.length > 0) {
-    // Create Rules folder
-    const rulesFolder = path.join(context.basePath, 'rules');
-    fs.ensureDirSync(rulesFolder);
-
-    rules = rules.map((rule) => {
-      // Dump rule to file
-      const scriptName = sanitize(`${rule.name}.js`);
-      const scriptFile = path.join(rulesFolder, scriptName);
-      log.info(`Writing ${scriptFile}`);
-      fs.writeFileSync(scriptFile, rule.script);
-      return { ...rule, script: `./rules/${scriptName}` };
-    });
+  if (!rules || rules.length < 1) {
+    return { rules: null };
   }
+
+  // Create Rules folder
+  const rulesFolder = path.join(context.basePath, 'rules');
+  fs.ensureDirSync(rulesFolder);
+
+  rules = rules.map((rule) => {
+    // Dump rule to file
+    const scriptName = sanitize(`${rule.name}.js`);
+    const scriptFile = path.join(rulesFolder, scriptName);
+    log.info(`Writing ${scriptFile}`);
+    fs.writeFileSync(scriptFile, rule.script);
+    return { ...rule, script: `./rules/${scriptName}` };
+  });
 
   return { rules };
 }

--- a/src/context/yaml/handlers/rules.ts
+++ b/src/context/yaml/handlers/rules.ts
@@ -6,20 +6,20 @@ import log from '../../../logger';
 
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedRules =
-  | {
-      rules: unknown[];
-    }
-  | {};
+type ParsedRules = {
+  rules: Asset[] | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedRules> {
-  // Load the script file for each rule
-  if (!context.assets.rules) return {};
+  const { rules } = context.assets;
+
+  if (!rules) return { rules: null };
 
   return {
     rules: [
-      ...context.assets.rules.map((rule) => ({
+      ...rules.map((rule) => ({
         ...rule,
         script: context.loadFile(rule.script),
       })),

--- a/src/context/yaml/handlers/rules.ts
+++ b/src/context/yaml/handlers/rules.ts
@@ -30,7 +30,7 @@ async function parse(context: YAMLContext): Promise<ParsedRules> {
 async function dump(context: YAMLContext): Promise<ParsedRules> {
   let { rules } = context.assets;
 
-  if (!rules || rules.length < 1) {
+  if (!rules) {
     return { rules: null };
   }
 

--- a/src/context/yaml/handlers/rulesConfigs.ts
+++ b/src/context/yaml/handlers/rulesConfigs.ts
@@ -1,16 +1,19 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedRulesConfigs =
-  | {
-      rulesConfigs: unknown[];
-    }
-  | {};
+type ParsedRulesConfigs = {
+  rulesConfigs: Asset[] | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedRulesConfigs> {
   // nothing to do, set default if empty
+  const { rulesConfigs } = context.assets;
+
+  if (!rulesConfigs) return { rulesConfigs: null };
+
   return {
-    rulesConfigs: context.assets.rulesConfigs,
+    rulesConfigs,
   };
 }
 

--- a/src/context/yaml/handlers/rulesConfigs.ts
+++ b/src/context/yaml/handlers/rulesConfigs.ts
@@ -7,7 +7,6 @@ type ParsedRulesConfigs = {
 };
 
 async function parse(context: YAMLContext): Promise<ParsedRulesConfigs> {
-  // nothing to do, set default if empty
   const { rulesConfigs } = context.assets;
 
   if (!rulesConfigs) return { rulesConfigs: null };

--- a/src/context/yaml/handlers/tenant.ts
+++ b/src/context/yaml/handlers/tenant.ts
@@ -2,16 +2,14 @@ import { clearTenantFlags } from '../../../utils';
 import { sessionDurationsToMinutes } from '../../../sessionDurationsToMinutes';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedTenant =
-  | {
-      tenant: unknown[];
-    }
-  | {};
+type ParsedTenant = {
+  tenant: Asset | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedTenant> {
-  // Nothing to do
-  if (!context.assets.tenant) return {};
+  if (!context.assets.tenant) return { tenant: null };
 
   /* eslint-disable camelcase */
   const {
@@ -29,6 +27,7 @@ async function parse(context: YAMLContext): Promise<ParsedTenant> {
   const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
 
   return {
+    //@ts-ignore
     tenant: {
       ...tenant,
       ...sessionDurations,

--- a/src/context/yaml/handlers/tenant.ts
+++ b/src/context/yaml/handlers/tenant.ts
@@ -27,7 +27,6 @@ async function parse(context: YAMLContext): Promise<ParsedTenant> {
   const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
 
   return {
-    //@ts-ignore
     tenant: {
       ...tenant,
       ...sessionDurations,
@@ -36,7 +35,9 @@ async function parse(context: YAMLContext): Promise<ParsedTenant> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedTenant> {
-  const tenant = { ...(context.assets.tenant || {}) };
+  const tenant = context.assets.tenant;
+
+  if (!tenant) return { tenant: null };
 
   clearTenantFlags(tenant);
 

--- a/src/context/yaml/handlers/triggers.ts
+++ b/src/context/yaml/handlers/triggers.ts
@@ -1,15 +1,14 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset } from '../../../types';
 
-type ParsedTriggers =
-  | {
-      triggers: unknown[];
-    }
-  | {};
+type ParsedTriggers = {
+  triggers: Asset[] | null;
+};
 
 async function parse(context: YAMLContext): Promise<ParsedTriggers> {
   // Load the script file for each action
-  if (!context.assets.triggers) return {};
+  if (!context.assets.triggers) return { triggers: null };
   return {
     triggers: context.assets.triggers,
   };
@@ -18,7 +17,7 @@ async function parse(context: YAMLContext): Promise<ParsedTriggers> {
 async function dump(context: YAMLContext): Promise<ParsedTriggers> {
   const { triggers } = context.assets;
   // Nothing to do
-  if (!triggers) return {};
+  if (!triggers) return { triggers: null };
   return {
     triggers: triggers,
   };

--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -1,7 +1,7 @@
 import DefaultHandler from './default';
 import constants from '../../constants';
 import log from '../../../logger';
-import { Asset } from '../../../types';
+import { Asset, Assets } from '../../../types';
 
 export const schema = {
   type: 'object',
@@ -68,11 +68,11 @@ export default class BrandingHandler extends DefaultHandler {
     }
   }
 
-  async processChanges(assets) {
+  async processChanges(assets: Assets) {
     const { branding } = assets;
 
     // quit early if there's no branding to process.
-    if (!branding) return;
+    if (branding === null) return;
 
     // remove templates, we only want top level branding settings for this API call
     const brandingSettings = { ...branding };

--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -72,7 +72,7 @@ export default class BrandingHandler extends DefaultHandler {
     const { branding } = assets;
 
     // quit early if there's no branding to process.
-    if (branding === null) return;
+    if (!branding) return;
 
     // remove templates, we only want top level branding settings for this API call
     const brandingSettings = { ...branding };

--- a/src/tools/auth0/handlers/clientGrants.ts
+++ b/src/tools/auth0/handlers/clientGrants.ts
@@ -66,7 +66,7 @@ export default class ClientGrantsHandler extends DefaultHandler {
     const excludedClients = convertClientNamesToIds(excludedClientsByNames, clients);
 
     // Convert clients by name to the id
-    const formatted = assets.clientGrants.map((clientGrant) => {
+    const formatted = clientGrants.map((clientGrant) => {
       const grant = { ...clientGrant };
       const found = clients.find((c) => c.name === grant.client_id);
       if (found) grant.client_id = found.client_id;

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -124,7 +124,7 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     const { connections } = assets;
 
     // Do nothing if not set
-    if (connections === null)
+    if (!connections)
       return {
         del: [],
         create: [],

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -124,7 +124,7 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     const { connections } = assets;
 
     // Do nothing if not set
-    if (!connections)
+    if (connections === null)
       return {
         del: [],
         create: [],
@@ -138,7 +138,7 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
       paginate: true,
       include_totals: true,
     });
-    const formatted = assets.connections.map((connection) => ({
+    const formatted = connections.map((connection) => ({
       ...connection,
       ...this.getFormattedOptions(connection, clients),
       enabled_clients: getEnabledClients(assets, connection, existingConnections, clients),

--- a/src/tools/auth0/index.ts
+++ b/src/tools/auth0/index.ts
@@ -67,8 +67,11 @@ export default class Auth0 {
   }
 
   async validate(): Promise<void> {
-    const ajv = new Ajv({ useDefaults: true });
-    const valid = ajv.validate(schema, this.assets);
+    const ajv = new Ajv({ useDefaults: true, nullable: true });
+    const nonNullAssets = Object.keys(this.assets)
+      .filter((k) => this.assets[k] != null)
+      .reduce((a, k) => ({ ...a, [k]: this.assets[k] }), {});
+    const valid = ajv.validate(schema, nonNullAssets);
     if (!valid) {
       throw new Error(`Schema validation failed loading ${JSON.stringify(ajv.errors, null, 4)}`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,41 +176,43 @@ export type Config = {
 export type Asset = { [key: string]: any };
 
 export type Assets = {
-  actions: Asset[];
-  attackProtection: Asset;
-  branding: Asset;
-  clients: Asset[];
-  clientGrants: Asset[];
-  connections: Asset[];
-  databases: Asset[];
-  emailProvider: Asset;
-  emailTemplates: Asset[];
-  guardianFactorProviders: Asset[];
-  guardianFactors: Asset[];
-  guardianFactorTemplates: Asset[];
+  actions: Asset[] | null;
+  attackProtection: Asset | null;
+  branding: {
+    templates?: { template: string; body: string }[] | null;
+  } | null;
+  clients: Asset[] | null;
+  clientGrants: Asset[] | null;
+  connections: Asset[] | null;
+  databases: Asset[] | null;
+  emailProvider: Asset | null;
+  emailTemplates: Asset[] | null;
+  guardianFactorProviders: Asset[] | null;
+  guardianFactors: Asset[] | null;
+  guardianFactorTemplates: Asset[] | null;
   guardianPhoneFactorMessageTypes: {
     message_types: Asset[]; //TODO: eliminate this intermediate level for consistency
-  };
-  guardianPhoneFactorSelectedProvider: Asset;
+  } | null;
+  guardianPhoneFactorSelectedProvider: Asset | null;
   guardianPolicies: {
     policies: Asset[]; //TODO: eliminate this intermediate level for consistency
-  };
-  hooks: Asset[];
-  logStreams: Asset[];
-  migrations: Asset[];
-  organizations: Asset[];
-  pages: Asset[];
-  resourceServers: Asset[];
-  roles: Asset[];
-  rules: Asset[];
-  rulesConfigs: Asset[];
-  tenant: Asset;
-  triggers: Asset[];
+  } | null;
+  hooks: Asset[] | null;
+  logStreams: Asset[] | null;
+  migrations: Asset[] | null;
+  organizations: Asset[] | null;
+  pages: Asset[] | null;
+  resourceServers: Asset[] | null;
+  roles: Asset[] | null;
+  rules: Asset[] | null;
+  rulesConfigs: Asset[] | null;
+  tenant: Asset | null;
+  triggers: Asset[] | null;
   //non-resource types
   exclude?: {
     [key: string]: string[];
   };
-  clientsOrig: Asset[];
+  clientsOrig: Asset[] | null;
 };
 
 export type CalculatedChanges = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,7 +175,7 @@ export type Config = {
 
 export type Asset = { [key: string]: any };
 
-export type Assets = {
+export type Assets = Partial<{
   actions: Asset[] | null;
   attackProtection: Asset | null;
   branding: {
@@ -213,7 +213,7 @@ export type Assets = {
     [key: string]: string[];
   };
   clientsOrig: Asset[] | null;
-};
+}>;
 
 export type CalculatedChanges = {
   del: Asset[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,7 @@ type ImportantFields = {
 };
 
 export function formatResults(item: any): Partial<ImportantFields> {
-  if (typeof item !== 'object') {
+  if (!item || typeof item !== 'object') {
     return item;
   }
   const importantFields: ImportantFields = {

--- a/test/context/directory/context.test.js
+++ b/test/context/directory/context.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 
 import Context from '../../../src/context/directory';
 import { cleanThenMkdir, testDataDir } from '../../utils';
+import handlers from '../../../src/context/directory/handlers';
 
 describe('#directory context validation', () => {
   it('should do nothing on empty repo', async () => {
@@ -14,11 +15,21 @@ describe('#directory context validation', () => {
     const context = new Context({ AUTH0_INPUT_FILE: dir });
     await context.load();
 
-    Object.entries(context.assets).forEach(([k, v]) => {
-      if (typeof v === 'undefined') delete context.assets[k];
+    expect(Object.keys(context.assets).length).to.equal(Object.keys(handlers).length + 1);
+    Object.keys(context.assets).forEach((key) => {
+      if (key === 'exclude') {
+        expect(context.assets[key]).to.deep.equal({
+          rules: [],
+          clients: [],
+          databases: [],
+          connections: [],
+          resourceServers: [],
+          defaults: [],
+        });
+      } else {
+        expect(context.assets[key]).to.equal(null);
+      }
     });
-
-    expect(context.assets).to.have.all.keys('exclude');
   });
 
   it('should load excludes', async () => {

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -105,8 +105,6 @@ describe('#YAML context validation', () => {
     await context.dump();
     const yaml = jsYaml.load(fs.readFileSync(tenantFile));
 
-    console.log({ testDataDir, yaml });
-
     expect(yaml).to.deep.equal({
       branding: {
         templates: [],

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -18,15 +18,15 @@ describe('#YAML context validation', () => {
     const context = new Context(config, mockMgmtClient());
     await context.load();
 
-    expect(context.assets.rules).to.deep.equal(undefined);
-    expect(context.assets.databases).to.deep.equal(undefined);
-    expect(context.assets.pages).to.deep.equal(undefined);
-    expect(context.assets.clients).to.deep.equal(undefined);
-    expect(context.assets.resourceServers).to.deep.equal(undefined);
-    expect(context.assets.clientGrants).to.deep.equal(undefined);
-    expect(context.assets.connections).to.deep.equal(undefined);
-    expect(context.assets.rulesConfigs).to.deep.equal(undefined);
-    expect(context.assets.organizations).to.deep.equal(undefined);
+    expect(context.assets.rules).to.deep.equal(null);
+    expect(context.assets.databases).to.deep.equal(null);
+    expect(context.assets.pages).to.deep.equal(null);
+    expect(context.assets.clients).to.deep.equal(null);
+    expect(context.assets.resourceServers).to.deep.equal(null);
+    expect(context.assets.clientGrants).to.deep.equal(null);
+    expect(context.assets.connections).to.deep.equal(null);
+    expect(context.assets.rulesConfigs).to.deep.equal(null);
+    expect(context.assets.organizations).to.deep.equal(null);
   });
 
   it('should load excludes', async () => {
@@ -101,10 +101,12 @@ describe('#YAML context validation', () => {
     const dir = path.resolve(testDataDir, 'yaml', 'dump');
     cleanThenMkdir(dir);
     const tenantFile = path.join(dir, 'tenant.yml');
-    const config = { AUTH0_INPUT_FILE: tenantFile };
-    const context = new Context(config, mockMgmtClient());
+    const context = new Context({ AUTH0_INPUT_FILE: tenantFile }, mockMgmtClient());
     await context.dump();
     const yaml = jsYaml.load(fs.readFileSync(tenantFile));
+
+    console.log({ testDataDir, yaml });
+
     expect(yaml).to.deep.equal({
       branding: {
         templates: [],


### PR DESCRIPTION
## ✏️ Changes

This PR standardizes the treatment of empty and null resources. This subtle distinction is a very important one to make. Consider: 

**Empty:** The actual and intentional empty set of a particular resource. A fresh tenant will have several empty resource types when initialized. Empty sets may also be used to delete all of a particular resource on a tenant. Can best be thought of as an empty array, example: `{ hooks: [] }`

**Null:** The absence, omission or otherwise unintentional emptiness of a set. The omission of a resource may indicate the intentional omission of a resource from the purview of management. It could also indicate some 
Can best be thought of as a null value, example: `{ hooks: null }`

The current codebase heavily relies on the practice of explicitly defining values as `undefined` to signal an empty value, but this practice is not fully consistent. Some other resource types will rely on `void`, `null`, `{}` and `[]` to signify null values. The large deviation in approach of distinguishing between null and empty resource sets makes it difficult to apply singular code treatments to all resource types at once.


## 🎯 Testing

Changes in testing to assert that `null` values are returned instead of `undefined`.
