### PR TITLE
ParsedAsset generic type

### DIFF
--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -7,11 +7,9 @@ import { getFiles, existsMustBeDir, loadJSON, sanitize } from '../../../utils';
 import log from '../../../logger';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedActions = {
-  actions: Asset[] | null;
-};
+type ParsedActions = ParsedAsset<'actions', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedActions {
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -4,15 +4,16 @@ import { constants } from '../../../tools';
 import { dumpJSON, existsMustBeDir, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedAttackProtection = {
-  attackProtection: {
+type ParsedAttackProtection = ParsedAsset<
+  'attackProtection',
+  {
     breachedPasswordDetection: Asset;
     bruteForceProtection: Asset;
     suspiciousIpThrottling: Asset;
-  } | null;
-};
+  }
+>;
 
 function attackProtectionFiles(filePath: string): {
   directory: string;

--- a/src/context/directory/handlers/branding.ts
+++ b/src/context/directory/handlers/branding.ts
@@ -4,11 +4,9 @@ import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 import { dumpJSON, existsMustBeDir, getFiles, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedBranding = {
-  branding: Asset | null;
-};
+type ParsedBranding = ParsedAsset<'branding', Asset>;
 
 function parse(context: DirectoryContext): ParsedBranding {
   const brandingDirectory = path.join(context.filePath, constants.BRANDING_DIRECTORY);

--- a/src/context/directory/handlers/clientGrants.ts
+++ b/src/context/directory/handlers/clientGrants.ts
@@ -12,11 +12,13 @@ import {
 } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedClientGrants = {
   clientGrants: Asset[] | null;
 };
+
+type ParsedBranding = ParsedAsset<'branding', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedClientGrants {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);

--- a/src/context/directory/handlers/clientGrants.ts
+++ b/src/context/directory/handlers/clientGrants.ts
@@ -14,11 +14,7 @@ import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedClientGrants = {
-  clientGrants: Asset[] | null;
-};
-
-type ParsedBranding = ParsedAsset<'branding', Asset[]>;
+type ParsedClientGrants = ParsedAsset<'clientGrants', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedClientGrants {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -12,13 +12,11 @@ import {
   sanitize,
   clearClientArrays,
 } from '../../../utils';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 
-type ParsedClients = {
-  clients: Asset[] | null;
-};
+type ParsedClients = ParsedAsset<'clients', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedClients {
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -17,9 +17,7 @@ import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedConnections = {
-  connections: Asset[] | null;
-};
+type ParsedConnections = ParsedAsset<'connections', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedConnections {
   const connectionDirectory =

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedConnections = {
   connections: Asset[] | null;

--- a/src/context/directory/handlers/databases.ts
+++ b/src/context/directory/handlers/databases.ts
@@ -14,11 +14,9 @@ import {
 
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedDatabases = {
-  databases: Asset[] | null;
-};
+type ParsedDatabases = ParsedAsset<'databases', Asset[]>;
 
 type DatabaseMetadata = {
   options?: {

--- a/src/context/directory/handlers/emailProvider.ts
+++ b/src/context/directory/handlers/emailProvider.ts
@@ -6,11 +6,9 @@ import { existsMustBeDir, isFile, dumpJSON, loadJSON } from '../../../utils';
 import { emailProviderDefaults } from '../../defaults';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedEmailProvider = {
-  emailProvider: Asset | null;
-};
+type ParsedEmailProvider = ParsedAsset<'emailProvider', Asset>;
 
 function parse(context: DirectoryContext): ParsedEmailProvider {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);

--- a/src/context/directory/handlers/emailTemplates.ts
+++ b/src/context/directory/handlers/emailTemplates.ts
@@ -6,11 +6,9 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedEmailTemplates = {
-  emailTemplates: Asset[] | null;
-};
+type ParsedEmailTemplates = ParsedAsset<'emailTemplates', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedEmailTemplates {
   const emailsFolder = path.join(context.filePath, constants.EMAIL_TEMPLATES_DIRECTORY);

--- a/src/context/directory/handlers/guardianFactorProviders.ts
+++ b/src/context/directory/handlers/guardianFactorProviders.ts
@@ -5,11 +5,9 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorProviders = {
-  guardianFactorProviders: Asset[] | null;
-};
+type ParsedGuardianFactorProviders = ParsedAsset<'guardianFactorProviders', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedGuardianFactorProviders {
   const factorProvidersFolder = path.join(

--- a/src/context/directory/handlers/guardianFactorTemplates.ts
+++ b/src/context/directory/handlers/guardianFactorTemplates.ts
@@ -5,11 +5,9 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorTemplates = {
-  guardianFactorTemplates: Asset[] | null;
-};
+type ParsedGuardianFactorTemplates = ParsedAsset<'guardianFactorTemplates', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedGuardianFactorTemplates {
   const factorTemplatesFolder = path.join(

--- a/src/context/directory/handlers/guardianFactors.ts
+++ b/src/context/directory/handlers/guardianFactors.ts
@@ -7,9 +7,7 @@ import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactors = {
-  guardianFactors: Asset[] | null;
-};
+type ParsedGuardianFactors = ParsedAsset<'guardianFactors', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedGuardianFactors {
   const factorsFolder = path.join(

--- a/src/context/directory/handlers/guardianFactors.ts
+++ b/src/context/directory/handlers/guardianFactors.ts
@@ -5,7 +5,7 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedGuardianFactors = {
   guardianFactors: Asset[] | null;

--- a/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorMessageTypes.ts
@@ -4,11 +4,9 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorMessageTypes = {
-  guardianPhoneFactorMessageTypes: Asset | null;
-};
+type ParsedGuardianFactorMessageTypes = ParsedAsset<'guardianPhoneFactorMessageTypes', Asset>;
 
 function parse(context: DirectoryContext): ParsedGuardianFactorMessageTypes {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);

--- a/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/context/directory/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -4,11 +4,12 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorSelectedProvider = {
-  guardianPhoneFactorSelectedProvider: Asset | null;
-};
+type ParsedGuardianFactorSelectedProvider = ParsedAsset<
+  'guardianPhoneFactorSelectedProvider',
+  Asset
+>;
 
 function parse(context: DirectoryContext): ParsedGuardianFactorSelectedProvider {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);

--- a/src/context/directory/handlers/guardianPolicies.ts
+++ b/src/context/directory/handlers/guardianPolicies.ts
@@ -4,11 +4,9 @@ import { constants } from '../../../tools';
 import { existsMustBeDir, dumpJSON, loadJSON, isFile } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianPolicies = {
-  guardianPolicies: Asset[] | null;
-};
+type ParsedGuardianPolicies = ParsedAsset<'guardianPolicies', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedGuardianPolicies {
   const guardianFolder = path.join(context.filePath, constants.GUARDIAN_DIRECTORY);

--- a/src/context/directory/handlers/hooks.ts
+++ b/src/context/directory/handlers/hooks.ts
@@ -6,11 +6,9 @@ import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../.
 import log from '../../../logger';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedHooks = {
-  hooks: Asset[] | null;
-};
+type ParsedHooks = ParsedAsset<'hooks', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedHooks {
   const hooksFolder = path.join(context.filePath, constants.HOOKS_DIRECTORY);

--- a/src/context/directory/handlers/logStreams.ts
+++ b/src/context/directory/handlers/logStreams.ts
@@ -4,11 +4,9 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedLogStreams = {
-  logStreams: Asset[] | null;
-};
+type ParsedLogStreams = ParsedAsset<'logStreams', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedLogStreams {
   const logStreamsDirectory = path.join(context.filePath, constants.LOG_STREAMS_DIRECTORY);

--- a/src/context/directory/handlers/migrations.ts
+++ b/src/context/directory/handlers/migrations.ts
@@ -2,11 +2,9 @@ import path from 'path';
 import { existsMustBeDir, isFile, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedMigrations = {
-  migrations: Asset[] | null;
-};
+type ParsedMigrations = ParsedAsset<'migrations', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedMigrations {
   const baseFolder = path.join(context.filePath);

--- a/src/context/directory/handlers/organizations.ts
+++ b/src/context/directory/handlers/organizations.ts
@@ -5,11 +5,9 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedOrganizations = {
-  organizations: Asset[] | null;
-};
+type ParsedOrganizations = ParsedAsset<'organizations', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedOrganizations {
   const organizationsFolder = path.join(context.filePath, 'organizations');

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -6,11 +6,9 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedPages = {
-  pages: Asset[] | null;
-};
+type ParsedPages = ParsedAsset<'pages', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedPages {
   const pagesFolder = path.join(context.filePath, constants.PAGES_DIRECTORY);

--- a/src/context/directory/handlers/resourceServers.ts
+++ b/src/context/directory/handlers/resourceServers.ts
@@ -4,11 +4,9 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedResourceServers = {
-  resourceServers: Asset[] | null;
-};
+type ParsedResourceServers = ParsedAsset<'resourceServers', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedResourceServers {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);

--- a/src/context/directory/handlers/roles.ts
+++ b/src/context/directory/handlers/roles.ts
@@ -6,11 +6,9 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRoles = {
-  roles: Asset[] | null;
-};
+type ParsedRoles = ParsedAsset<'roles', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedRoles {
   const rolesFolder = path.join(context.filePath, constants.ROLES_DIRECTORY);

--- a/src/context/directory/handlers/rules.ts
+++ b/src/context/directory/handlers/rules.ts
@@ -7,11 +7,9 @@ import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../.
 
 import { DirectoryHandler } from './index';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRules = {
-  rules: Asset[] | null;
-};
+type ParsedRules = ParsedAsset<'rules', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedRules {
   const rulesFolder = path.join(context.filePath, constants.RULES_DIRECTORY);

--- a/src/context/directory/handlers/rulesConfigs.ts
+++ b/src/context/directory/handlers/rulesConfigs.ts
@@ -6,9 +6,7 @@ import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRulesConfigs = {
-  rulesConfigs: Asset[] | null;
-};
+type ParsedRulesConfigs = ParsedAsset<'rulesConfigs', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedRulesConfigs {
   const rulesConfigsFolder = path.join(context.filePath, constants.RULES_CONFIGS_DIRECTORY);

--- a/src/context/directory/handlers/rulesConfigs.ts
+++ b/src/context/directory/handlers/rulesConfigs.ts
@@ -4,7 +4,7 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedRulesConfigs = {
   rulesConfigs: Asset[] | null;

--- a/src/context/directory/handlers/tenant.ts
+++ b/src/context/directory/handlers/tenant.ts
@@ -3,18 +3,17 @@ import { existsMustBeDir, isFile, dumpJSON, loadJSON, clearTenantFlags } from '.
 import { sessionDurationsToMinutes } from '../../../sessionDurationsToMinutes';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedTenant = {
-  tenant:
-    | ({
-        session_lifetime: number;
-        idle_session_lifetime: number;
-      } & {
-        [key: string]: Asset;
-      })
-    | null;
-};
+type ParsedTenant = ParsedAsset<
+  'tenant',
+  {
+    session_lifetime: number;
+    idle_session_lifetime: number;
+  } & {
+    [key: string]: Asset;
+  }
+>;
 
 function parse(context: DirectoryContext): ParsedTenant {
   const baseFolder = path.join(context.filePath);

--- a/src/context/directory/handlers/triggers.ts
+++ b/src/context/directory/handlers/triggers.ts
@@ -8,9 +8,7 @@ import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import log from '../../../logger';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedTriggers = {
-  triggers: Asset[] | null;
-};
+type ParsedTriggers = ParsedAsset<'triggers', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedTriggers {
   const triggersFolder = path.join(context.filePath, constants.TRIGGERS_DIRECTORY);

--- a/src/context/directory/handlers/triggers.ts
+++ b/src/context/directory/handlers/triggers.ts
@@ -6,7 +6,7 @@ import DirectoryContext from '..';
 
 import { getFiles, existsMustBeDir, loadJSON } from '../../../utils';
 import log from '../../../logger';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedTriggers = {
   triggers: Asset[] | null;

--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -6,11 +6,9 @@ import { sanitize } from '../../../utils';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedActions = {
-  actions: Asset[] | null;
-};
+type ParsedActions = ParsedAsset<'actions', Asset[]>;
 
 type Secret = { name: string; value: string };
 

--- a/src/context/yaml/handlers/attackProtection.ts
+++ b/src/context/yaml/handlers/attackProtection.ts
@@ -1,18 +1,30 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedAttackProtection = {
-  attackProtection: Asset | null;
-};
+type ParsedAttackProtection = ParsedAsset<
+  'attackProtection',
+  {
+    breachedPasswordDetection: Asset;
+    bruteForceProtection: Asset;
+    suspiciousIpThrottling: Asset;
+  }
+>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedAttackProtection> {
   const { attackProtection } = context.assets;
 
   if (!attackProtection) return { attackProtection: null };
 
+  const { suspiciousIpThrottling, breachedPasswordDetection, bruteForceProtection } =
+    attackProtection;
+
   return {
-    attackProtection,
+    attackProtection: {
+      suspiciousIpThrottling,
+      breachedPasswordDetection,
+      bruteForceProtection,
+    },
   };
 }
 

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -4,20 +4,19 @@ import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type BrandingTemplate = {
   template: string;
   body: string;
 };
 
-type ParsedBranding = {
-  branding:
-    | ({ [key: string]: Asset } & {
-        templates?: BrandingTemplate[];
-      })
-    | null;
-};
+type ParsedBranding = ParsedAsset<
+  'branding',
+  { [key: string]: Asset } & {
+    templates?: BrandingTemplate[];
+  }
+>;
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
   // Load the HTML file for each page

--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -1,11 +1,9 @@
 import { convertClientIdToName } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedClientGrants = {
-  clientGrants: Asset[] | null;
-};
+type ParsedClientGrants = ParsedAsset<'clientGrants', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
   const { clientGrants } = context.assets;

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -5,11 +5,9 @@ import log from '../../../logger';
 import { isFile, sanitize, clearClientArrays } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedClients = {
-  clients: Asset[] | null;
-};
+type ParsedClients = ParsedAsset<'clients', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedClients> {
   // Load the HTML file for custom_login_page

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -12,11 +12,9 @@ import {
 } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedConnections = {
-  connections: Asset[] | null;
-};
+type ParsedConnections = ParsedAsset<'connections', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedConnections> {
   const { connections } = context.assets;

--- a/src/context/yaml/handlers/databases.ts
+++ b/src/context/yaml/handlers/databases.ts
@@ -4,11 +4,9 @@ import { mapClientID2NameSorted, sanitize } from '../../../utils';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedDatabases = {
-  databases: Asset[] | null;
-};
+type ParsedDatabases = ParsedAsset<'databases', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedDatabases> {
   // Load the script file for custom db

--- a/src/context/yaml/handlers/emailProvider.ts
+++ b/src/context/yaml/handlers/emailProvider.ts
@@ -1,11 +1,9 @@
 import { emailProviderDefaults } from '../../defaults';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedEmailProvider = {
-  emailProvider: Asset | null;
-};
+type ParsedEmailProvider = ParsedAsset<'emailProvider', Asset>;
 
 async function parse(context: YAMLContext): Promise<ParsedEmailProvider> {
   const { emailProvider } = context.assets;

--- a/src/context/yaml/handlers/emailTemplates.ts
+++ b/src/context/yaml/handlers/emailTemplates.ts
@@ -3,11 +3,9 @@ import path from 'path';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedEmailTemplates = {
-  emailTemplates: Asset[] | null;
-};
+type ParsedEmailTemplates = ParsedAsset<'emailTemplates', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedEmailTemplates> {
   // Load the HTML file for each page

--- a/src/context/yaml/handlers/guardianFactorProviders.ts
+++ b/src/context/yaml/handlers/guardianFactorProviders.ts
@@ -1,6 +1,6 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedGuardianFactorProviders = {
   guardianFactorProviders: Asset[] | null;

--- a/src/context/yaml/handlers/guardianFactorProviders.ts
+++ b/src/context/yaml/handlers/guardianFactorProviders.ts
@@ -2,9 +2,7 @@ import { YAMLHandler } from '.';
 import YAMLContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorProviders = {
-  guardianFactorProviders: Asset[] | null;
-};
+type ParsedGuardianFactorProviders = ParsedAsset<'guardianFactorProviders', Asset[]>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorProviders> {
   const { guardianFactorProviders } = context.assets;

--- a/src/context/yaml/handlers/guardianFactorTemplates.ts
+++ b/src/context/yaml/handlers/guardianFactorTemplates.ts
@@ -1,6 +1,6 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedGuardianFactorTemplates = {
   guardianFactorTemplates: Asset[] | null;

--- a/src/context/yaml/handlers/guardianFactorTemplates.ts
+++ b/src/context/yaml/handlers/guardianFactorTemplates.ts
@@ -2,9 +2,7 @@ import { YAMLHandler } from '.';
 import YAMLContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorTemplates = {
-  guardianFactorTemplates: Asset[] | null;
-};
+type ParsedGuardianFactorTemplates = ParsedAsset<'guardianFactorTemplates', Asset[]>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorTemplates> {
   const { guardianFactorTemplates } = context.assets;

--- a/src/context/yaml/handlers/guardianFactors.ts
+++ b/src/context/yaml/handlers/guardianFactors.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactors = {
-  guardianFactors: Asset[] | null;
-};
+type ParsedGuardianFactors = ParsedAsset<'guardianFactors', Asset[]>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactors> {
   const { guardianFactors } = context.assets;

--- a/src/context/yaml/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/context/yaml/handlers/guardianPhoneFactorMessageTypes.ts
@@ -1,9 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianFactorMessageTypes = {
-  guardianPhoneFactorMessageTypes: unknown;
-};
+type ParsedGuardianFactorMessageTypes = ParsedAsset<'guardianPhoneFactorMessageTypes', Asset>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianFactorMessageTypes> {
   const { guardianPhoneFactorMessageTypes } = context.assets;

--- a/src/context/yaml/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/context/yaml/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -1,9 +1,11 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianPhoneFactorSelectedProvider = {
-  guardianPhoneFactorSelectedProvider: unknown;
-};
+type ParsedGuardianPhoneFactorSelectedProvider = ParsedAsset<
+  'guardianPhoneFactorSelectedProvider',
+  Asset
+>;
 
 async function parseAndDump(
   context: YAMLContext

--- a/src/context/yaml/handlers/guardianPolicies.ts
+++ b/src/context/yaml/handlers/guardianPolicies.ts
@@ -1,9 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedGuardianPolicies = {
-  guardianPolicies: unknown;
-};
+type ParsedGuardianPolicies = ParsedAsset<'guardianPolicies', { policies: Asset[] }>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedGuardianPolicies> {
   const { guardianPolicies } = context.assets;

--- a/src/context/yaml/handlers/hooks.ts
+++ b/src/context/yaml/handlers/hooks.ts
@@ -7,11 +7,9 @@ import log from '../../../logger';
 
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedHooks = {
-  hooks: Asset[] | null;
-};
+type ParsedHooks = ParsedAsset<'hooks', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedHooks> {
   const { hooks } = context.assets;

--- a/src/context/yaml/handlers/index.ts
+++ b/src/context/yaml/handlers/index.ts
@@ -29,7 +29,7 @@ import YAMLContext from '..';
 import { AssetTypes } from '../../../types';
 
 export type YAMLHandler<T> = {
-  dump: (context: YAMLContext) => Promise<T | {}>; //May return empty object to signal
+  dump: (context: YAMLContext) => Promise<T>;
   parse: (context: YAMLContext) => Promise<T>;
 };
 

--- a/src/context/yaml/handlers/logStreams.ts
+++ b/src/context/yaml/handlers/logStreams.ts
@@ -2,9 +2,7 @@ import { YAMLHandler } from '.';
 import YAMLContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedLogStreams = {
-  logStreams: Asset[] | null;
-};
+type ParsedLogStreams = ParsedAsset<'logStreams', Asset[]>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedLogStreams> {
   const { logStreams } = context.assets;

--- a/src/context/yaml/handlers/logStreams.ts
+++ b/src/context/yaml/handlers/logStreams.ts
@@ -1,6 +1,6 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedLogStreams = {
   logStreams: Asset[] | null;

--- a/src/context/yaml/handlers/migrations.ts
+++ b/src/context/yaml/handlers/migrations.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedMigrations = {
-  migrations: Asset | null;
-};
+type ParsedMigrations = ParsedAsset<'migrations', Asset[]>;
 
 async function parseAndDump(context: YAMLContext): Promise<ParsedMigrations> {
   const { migrations } = context.assets;

--- a/src/context/yaml/handlers/organizations.ts
+++ b/src/context/yaml/handlers/organizations.ts
@@ -1,6 +1,6 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedOrganizations = {
   organizations: Asset[] | null;

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -4,11 +4,9 @@ import fs from 'fs-extra';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedPages = {
-  pages: Asset[] | null;
-};
+type ParsedPages = ParsedAsset<'pages', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedPages> {
   // Load the HTML file for each page

--- a/src/context/yaml/handlers/resourceServers.ts
+++ b/src/context/yaml/handlers/resourceServers.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedResourceServers = {
-  resourceServers: Asset[] | null;
-};
+type ParsedResourceServers = ParsedAsset<'resourceServers', Asset[]>;
 
 async function dumpAndParse(context: YAMLContext): Promise<ParsedResourceServers> {
   const { resourceServers } = context.assets;

--- a/src/context/yaml/handlers/roles.ts
+++ b/src/context/yaml/handlers/roles.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRoles = {
-  roles: Asset[] | null;
-};
+type ParsedRoles = ParsedAsset<'roles', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedRoles> {
   const { roles } = context.assets;

--- a/src/context/yaml/handlers/rules.ts
+++ b/src/context/yaml/handlers/rules.ts
@@ -6,11 +6,9 @@ import log from '../../../logger';
 
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRules = {
-  rules: Asset[] | null;
-};
+type ParsedRules = ParsedAsset<'rules', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedRules> {
   const { rules } = context.assets;

--- a/src/context/yaml/handlers/rulesConfigs.ts
+++ b/src/context/yaml/handlers/rulesConfigs.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedRulesConfigs = {
-  rulesConfigs: Asset[] | null;
-};
+type ParsedRulesConfigs = ParsedAsset<'rulesConfigs', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedRulesConfigs> {
   const { rulesConfigs } = context.assets;

--- a/src/context/yaml/handlers/tenant.ts
+++ b/src/context/yaml/handlers/tenant.ts
@@ -4,9 +4,7 @@ import { YAMLHandler } from '.';
 import YAMLContext from '..';
 import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedTenant = {
-  tenant: Asset | null;
-};
+type ParsedTenant = ParsedAsset<'tenant', Asset>;
 
 async function parse(context: YAMLContext): Promise<ParsedTenant> {
   if (!context.assets.tenant) return { tenant: null };

--- a/src/context/yaml/handlers/tenant.ts
+++ b/src/context/yaml/handlers/tenant.ts
@@ -2,7 +2,7 @@ import { clearTenantFlags } from '../../../utils';
 import { sessionDurationsToMinutes } from '../../../sessionDurationsToMinutes';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
 type ParsedTenant = {
   tenant: Asset | null;

--- a/src/context/yaml/handlers/triggers.ts
+++ b/src/context/yaml/handlers/triggers.ts
@@ -1,10 +1,8 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset } from '../../../types';
+import { Asset, ParsedAsset } from '../../../types';
 
-type ParsedTriggers = {
-  triggers: Asset[] | null;
-};
+type ParsedTriggers = ParsedAsset<'triggers', Asset[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedTriggers> {
   // Load the script file for each action

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -113,7 +113,7 @@ export default class YAMLContext {
         .map(async ([name, handler]) => {
           try {
             const data = await handler.dump(this);
-            if (data) {
+            if (!!data) {
               log.info(`Exporting ${name}`);
               Object.entries(data).forEach(([k, v]) => {
                 this.assets[k] = Array.isArray(v)

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,3 +251,7 @@ export type AssetTypes =
   | 'logStreams';
 
 export type KeywordMappings = { [key: string]: (string | number)[] | string | number };
+
+export type ParsedAsset<Key extends AssetTypes, T> = {
+  [key in Key]: T | null;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,7 @@ type ImportantFields = {
 };
 
 export function formatResults(item: any): Partial<ImportantFields> {
-  if (typeof item !== 'object') {
+  if (!item || typeof item !== 'object') {
     return item;
   }
   const importantFields: ImportantFields = {


### PR DESCRIPTION
## ✏️ Changes

Building off the standardization of empty vs null resources (#512), this PR introduces the `ParsedAsset` generic type to be used for typing the YAML and JSON handlers during parsing. These `ParsedFoo` types are critical for the upstream systems to know what data does and doesn't exist within the configuration files. The addition of this new generic type applies two constraints:

- Forces the key name of the parsed to exist in the `AssetTypes` type, which 
- Forces the key value to be some defined type or null to denote omission, instead of `undefined`, `{}`, `[]` or some other empty-like type.
