### PR TITLE
Fixing error where updateRules was undefined

### DIFF
--- a/src/tools/auth0/handlers/rules.ts
+++ b/src/tools/auth0/handlers/rules.ts
@@ -190,8 +190,8 @@ export default class RulesHandler extends DefaultHandler {
       .addEachTask({
         data: changes.reOrder,
         generator: (rule) =>
-          this.client
-            .updateRule({ id: rule.id }, stripFields(rule, this.stripUpdateFields))
+          this.client.rules
+            .update({ id: rule.id }, stripFields(rule, this.stripUpdateFields))
             .then(() => {
               const updated = {
                 name: rule.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,6 @@ export type BaseAuth0APIClient = {
   triggers: APIClientBaseFunctions & {
     getTriggerBindings: () => Promise<Asset>;
   };
-  updateRule: (arg0: { id: string }, arg1: Asset) => Promise<Asset>;
 }; // TODO: replace with a more accurate representation of the Auth0APIClient type
 
 export type Auth0APIClient = BaseAuth0APIClient & {


### PR DESCRIPTION
## ✏️ Changes

For some reason, the Deploy CLI doesn't like using the `updateRules` alias, which while does exist as an exported method in the Node SDK, is not defined per #522 . This PR swaps `this.client.updateRules` for `this.client.rules.update` , which is more consistent with rest of the codebase anyway. 

## 🔗 References

Original Github issue: #522 

## 🎯 Testing

Manually tested and verified.