### PR TITLE
DXCDT-93: Adding custom domains support

### DIFF
--- a/src/context/directory/handlers/customDomains.ts
+++ b/src/context/directory/handlers/customDomains.ts
@@ -1,0 +1,46 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { constants } from '../../../tools';
+import { existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
+import { DirectoryHandler } from '.';
+import DirectoryContext from '..';
+import { Asset, ParsedAsset } from '../../../types';
+
+type ParsedCustomDomains = ParsedAsset<'customDomains', Asset[]>;
+
+const getCustomDomainsDirectory = (filePath: string) =>
+  path.join(filePath, constants.CUSTOM_DOMAINS_DIRECTORY);
+
+const getCustomDomainsFile = (filePath: string) =>
+  path.join(getCustomDomainsDirectory(filePath), 'custom-domains.json');
+
+function parse(context: DirectoryContext): ParsedCustomDomains {
+  const customDomainsDirectory = getCustomDomainsDirectory(context.filePath);
+  if (!existsMustBeDir(customDomainsDirectory)) return { customDomains: null }; // Skip
+
+  const customDomainsFile = getCustomDomainsFile(context.filePath);
+
+  return {
+    customDomains: loadJSON(customDomainsFile, context.mappings),
+  };
+}
+
+async function dump(context: DirectoryContext): Promise<void> {
+  const { customDomains } = context.assets;
+
+  if (!customDomains) return; // Skip, nothing to dump
+
+  // Create Rules folder
+  const customDomainsDirectory = getCustomDomainsDirectory(context.filePath);
+  fs.ensureDirSync(customDomainsDirectory);
+
+  const customDomainsFile = getCustomDomainsFile(context.filePath);
+  dumpJSON(customDomainsFile, customDomains);
+}
+
+const customDomainsHandler: DirectoryHandler<ParsedCustomDomains> = {
+  parse,
+  dump,
+};
+
+export default customDomainsHandler;

--- a/src/context/directory/handlers/index.ts
+++ b/src/context/directory/handlers/index.ts
@@ -24,6 +24,7 @@ import triggers from './triggers';
 import attackProtection from './attackProtection';
 import branding from './branding';
 import logStreams from './logStreams';
+import customDomains from './customDomains';
 
 import DirectoryContext from '..';
 import { AssetTypes, Asset } from '../../../types';
@@ -62,6 +63,7 @@ const directoryHandlers: {
   attackProtection,
   branding,
   logStreams,
+  customDomains,
 };
 
 export default directoryHandlers;

--- a/src/context/yaml/handlers/customDomains.ts
+++ b/src/context/yaml/handlers/customDomains.ts
@@ -1,0 +1,22 @@
+import { YAMLHandler } from '.';
+import YAMLContext from '..';
+import { Asset, ParsedAsset } from '../../../types';
+
+type ParsedCustomDomains = ParsedAsset<'customDomains', Asset[]>;
+
+async function parseAndDump(context: YAMLContext): Promise<ParsedCustomDomains> {
+  const { customDomains } = context.assets;
+
+  if (!customDomains) return { customDomains: null };
+
+  return {
+    customDomains,
+  };
+}
+
+const customDomainsHandler: YAMLHandler<ParsedCustomDomains> = {
+  parse: parseAndDump,
+  dump: parseAndDump,
+};
+
+export default customDomainsHandler;

--- a/src/context/yaml/handlers/index.ts
+++ b/src/context/yaml/handlers/index.ts
@@ -24,6 +24,7 @@ import triggers from './triggers';
 import attackProtection from './attackProtection';
 import branding from './branding';
 import logStreams from './logStreams';
+import customDomains from './customDomains';
 
 import YAMLContext from '..';
 import { AssetTypes } from '../../../types';
@@ -60,6 +61,7 @@ const yamlHandlers: { [key in AssetTypes]: YAMLHandler<{ [key: string]: unknown 
   attackProtection,
   branding,
   logStreams,
+  customDomains,
 };
 
 export default yamlHandlers;

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -16,7 +16,7 @@ export const schema = {
       primary: { type: 'boolean' },
       status: { type: 'string', enum: ['pending_verification', 'ready', 'disabled', 'pending'] },
       type: { type: 'string', enum: ['auth0_managed_certs', 'self_managed_certs'] },
-      verifications: { type: 'object' },
+      verification: { type: 'object' },
     },
     required: ['domain', 'type'],
   },

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -1,0 +1,89 @@
+import DefaultAPIHandler from './default';
+import { Asset, Assets } from '../../../types';
+
+export const schema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      custom_domain_id: { type: 'string' },
+      domain: { type: 'string' },
+      primary: { type: 'boolean' },
+      status: { type: 'string', enum: ['pending_verification', 'ready', 'disabled', 'pending'] },
+      type: { type: 'string', enum: ['auth0_managed_certs', 'self_managed_certs'] },
+      verifications: { type: 'object' },
+    },
+    required: ['domain'],
+  },
+};
+
+// type CustomDomain = {
+//   type: 'eventbridge' | 'eventgrid' | 'datadog' | 'http' | 'splunk' | 'sumo';
+//   name: string;
+//   id: string;
+//   status: 'active' | 'suspended' | 'paused';
+//   sink?: {
+//     [key: string]: string | boolean;
+//   };
+// };
+
+export default class CustomDomainsHadnler extends DefaultAPIHandler {
+  existing: Asset[] | null;
+
+  constructor(config: DefaultAPIHandler) {
+    super({
+      ...config,
+      type: 'customDomains',
+      id: 'custom_domain_id',
+      identifiers: ['domain'],
+      stripCreateFields: ['verification'],
+      functions: {
+        //@ts-ignore
+        delete: (args) => {
+          console.log({ args });
+          return new Promise(() => 5);
+        },
+      },
+    });
+  }
+
+  objString(item: Asset): string {
+    return super.objString(item.name);
+  }
+
+  async getType(): Promise<Asset> {
+    if (this.existing) {
+      return this.existing;
+    }
+
+    const customDomains = await this.client.customDomains.getAll({ paginate: false });
+
+    this.existing = customDomains;
+
+    return customDomains;
+  }
+
+  async processChanges(assets: Assets): Promise<void> {
+    const { customDomains } = assets;
+    // Do nothing if not set
+    if (!customDomains) return;
+    // Figure out what needs to be updated vs created
+    const changes = await this.calcChanges(assets).then((changes) => {
+      const changesWithoutUpdates = {
+        ...changes,
+        delete: changes.del.map((deleteToMake) => {
+          const deleteWithSDKCompatibleID = {
+            ...deleteToMake,
+            id: deleteToMake.custom_domain_id,
+          };
+          delete deleteWithSDKCompatibleID['custom_domain_id'];
+          return deleteWithSDKCompatibleID;
+        }),
+        update: [],
+      };
+      return changesWithoutUpdates;
+    });
+
+    await super.processChanges(assets, changes);
+  }
+}

--- a/src/tools/auth0/handlers/index.ts
+++ b/src/tools/auth0/handlers/index.ts
@@ -26,6 +26,7 @@ import * as triggers from './triggers';
 import * as organizations from './organizations';
 import * as attackProtection from './attackProtection';
 import * as logStreams from './logStreams';
+import * as customDomains from './customDomains';
 
 import { AssetTypes } from '../../../types';
 import APIHandler from './default';
@@ -59,6 +60,7 @@ const auth0ApiHandlers: { [key in AssetTypes]: any } = {
   organizations,
   attackProtection,
   logStreams,
+  customDomains,
 };
 
 export default auth0ApiHandlers as {

--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -167,6 +167,7 @@ const constants = {
   ],
   SUPPORTED_BRANDING_TEMPLATES: [UNIVERSAL_LOGIN_TEMPLATE],
   LOG_STREAMS_DIRECTORY: 'log-streams',
+  CUSTOM_DOMAINS_DIRECTORY: 'custom-domains',
 };
 
 export default constants;

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,7 @@ export type Assets = Partial<{
   clients: Asset[] | null;
   clientGrants: Asset[] | null;
   connections: Asset[] | null;
+  customDomains: Asset[] | null;
   databases: Asset[] | null;
   emailProvider: Asset | null;
   emailTemplates: Asset[] | null;
@@ -248,7 +249,8 @@ export type AssetTypes =
   | 'triggers'
   | 'attackProtection'
   | 'branding'
-  | 'logStreams';
+  | 'logStreams'
+  | 'customDomains';
 
 export type KeywordMappings = { [key: string]: (string | number)[] | string | number };
 

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -204,6 +204,7 @@ describe('#YAML context validation', () => {
         suspiciousIpThrottling: {},
       },
       logStreams: [],
+      customDomains: [],
     });
   });
 
@@ -311,6 +312,7 @@ describe('#YAML context validation', () => {
         suspiciousIpThrottling: {},
       },
       logStreams: [],
+      customDomains: [],
     });
   });
 
@@ -419,6 +421,7 @@ describe('#YAML context validation', () => {
         suspiciousIpThrottling: {},
       },
       logStreams: [],
+      customDomains: [],
     });
   });
 

--- a/test/context/yaml/customDomains.test.ts
+++ b/test/context/yaml/customDomains.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { expect } from 'chai';
+
+import Context from '../../../src/context/yaml';
+import handler from '../../../src/context/yaml/handlers/customDomains';
+import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
+
+describe('#YAML context custom domains', () => {
+  it('should process custom domains', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'custom_domains');
+    cleanThenMkdir(dir);
+
+    const yaml = `
+    customDomains:
+      - custom_client_ip_header: cf-connecting-ip
+        domain: auth.test-domain.com
+        type: self_managed_certs
+    `;
+
+    const yamlFile = path.join(dir, 'config.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    expect(context.assets.customDomains).to.deep.equal([
+      {
+        custom_client_ip_header: 'cf-connecting-ip',
+        domain: 'auth.test-domain.com',
+        type: 'self_managed_certs',
+      },
+    ]);
+  });
+
+  it('should dump tenant with custom domains', async () => {
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
+    context.assets.customDomains = [
+      {
+        custom_client_ip_header: 'cf-connecting-ip',
+        domain: 'auth.test-domain.com',
+        type: 'self_managed_certs',
+      },
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({ customDomains: context.assets.customDomains });
+  });
+});

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import { PromisePoolExecutor } from 'promise-pool-executor';
-import auth0ApiHandlers from '../../../../src/tools/auth0/handlers';
 import customDomainsHandler from '../../../../src/tools/auth0/handlers/customDomains';
 import { Auth0APIClient } from '../../../../src/types';
 
 const customDomains = [
   {
-    domain: 'auth.will-vedder12.com',
+    domain: 'auth.test-domain.com',
     primary: true,
     status: 'pending_verification',
     type: 'auth0_managed_certs',
@@ -14,7 +13,7 @@ const customDomains = [
       methods: [
         {
           name: 'cname',
-          record: 'will-vedder-cd-q8r7eqawrhd4o1oh.edge.tenants.us.auth0.com',
+          record: 'test-domain-555.edge.tenants.us.auth0.com',
         },
       ],
     },

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -1,0 +1,204 @@
+import { expect } from 'chai';
+import { PromisePoolExecutor } from 'promise-pool-executor';
+import auth0ApiHandlers from '../../../../src/tools/auth0/handlers';
+import customDomainsHandler from '../../../../src/tools/auth0/handlers/customDomains';
+import { Auth0APIClient } from '../../../../src/types';
+
+const customDomains = [
+  {
+    domain: 'auth.will-vedder12.com',
+    primary: true,
+    status: 'pending_verification',
+    type: 'auth0_managed_certs',
+    verification: {
+      methods: [
+        {
+          name: 'cname',
+          record: 'will-vedder-cd-q8r7eqawrhd4o1oh.edge.tenants.us.auth0.com',
+        },
+      ],
+    },
+    tls_policy: 'recommended',
+  },
+];
+
+const auth0ApiClientMock = {
+  customDomains: {
+    getAll: async () => customDomains,
+    create: async () => customDomains[0],
+    update: async () => {},
+    delete: async () => {},
+  },
+  pool: new PromisePoolExecutor({
+    concurrencyLimit: 3,
+    frequencyLimit: 8,
+    frequencyWindow: 1000, // 1 sec
+  }),
+};
+
+describe('#customDomains handler', () => {
+  it('should get custom domains', async () => {
+    const handler = new customDomainsHandler({ client: auth0ApiClientMock });
+    const data = await handler.load();
+
+    expect(data).to.deep.equal({ customDomains });
+  });
+
+  it('should create custom domains', async () => {
+    let didCreateFunctionGetCalled = false;
+    let didUpdateFunctionGetCalled = false;
+    let didDeleteFunctionGetCalled = false;
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => [],
+        create: async (args) => {
+          didCreateFunctionGetCalled = true;
+          expect(args).to.deep.equal({
+            domain: customDomains[0].domain,
+            type: customDomains[0].type,
+            tls_policy: customDomains[0].tls_policy,
+          });
+          return customDomains[0];
+        },
+        update: async () => {
+          didUpdateFunctionGetCalled = true;
+        },
+        delete: async () => {
+          didDeleteFunctionGetCalled = true;
+        },
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
+    const handler = new customDomainsHandler({
+      config: () => {},
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: customDomains });
+    expect(didCreateFunctionGetCalled).to.equal(true);
+    expect(didDeleteFunctionGetCalled).to.equal(false);
+    expect(didUpdateFunctionGetCalled).to.equal(false);
+  });
+
+  it('should delete custom domains if AUTH0_ALLOW_DELETE is enabled', async () => {
+    let didCreateFunctionGetCalled = false;
+    let didUpdateFunctionGetCalled = false;
+    let didDeleteFunctionGetCalled = false;
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => customDomains,
+        create: async (args) => {
+          didCreateFunctionGetCalled = true;
+        },
+        update: async () => {
+          didUpdateFunctionGetCalled = true;
+        },
+        delete: async () => {
+          didDeleteFunctionGetCalled = true;
+        },
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
+    const handler = new customDomainsHandler({
+      config: (key) => {
+        return { AUTH0_ALLOW_DELETE: true }[key];
+      },
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: [] });
+    expect(didUpdateFunctionGetCalled).to.equal(false); //The update function should not be called
+    expect(didDeleteFunctionGetCalled).to.equal(true);
+    expect(didCreateFunctionGetCalled).to.equal(false);
+  });
+
+  it('should not delete custom domains if AUTH0_ALLOW_DELETE is disabled', async () => {
+    let didCreateFunctionGetCalled = false;
+    let didUpdateFunctionGetCalled = false;
+    let didDeleteFunctionGetCalled = false;
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => customDomains,
+        create: async (args) => {
+          didCreateFunctionGetCalled = true;
+        },
+        update: async () => {
+          didUpdateFunctionGetCalled = true;
+        },
+        delete: async () => {
+          didDeleteFunctionGetCalled = true;
+        },
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
+    const handler = new customDomainsHandler({
+      config: (key) => {
+        return { AUTH0_ALLOW_DELETE: false }[key];
+      },
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: [] });
+    expect(didUpdateFunctionGetCalled).to.equal(false); //The update function should not be called
+    expect(didDeleteFunctionGetCalled).to.equal(false);
+    expect(didCreateFunctionGetCalled).to.equal(false);
+  });
+
+  it('should not update custom domains settings because not implemented by Auth0 Node SDK', async () => {
+    let didCreateFunctionGetCalled = false;
+    let didUpdateFunctionGetCalled = false;
+    let didDeleteFunctionGetCalled = false;
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => [],
+        create: async (args) => {
+          didCreateFunctionGetCalled = true;
+        },
+        update: async () => {
+          didUpdateFunctionGetCalled = true;
+        },
+        delete: async () => {
+          didDeleteFunctionGetCalled = true;
+        },
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
+    const handler = new customDomainsHandler({
+      config: () => {},
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: [] });
+    expect(didUpdateFunctionGetCalled).to.equal(false); //The update function should not be called
+    expect(didDeleteFunctionGetCalled).to.equal(false);
+    expect(didCreateFunctionGetCalled).to.equal(false);
+  });
+});

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -95,7 +95,7 @@ describe('#customDomains handler', () => {
     const auth0ApiClientMock = {
       customDomains: {
         getAll: async () => customDomains,
-        create: async (args) => {
+        create: async () => {
           didCreateFunctionGetCalled = true;
         },
         update: async () => {
@@ -134,7 +134,7 @@ describe('#customDomains handler', () => {
     const auth0ApiClientMock = {
       customDomains: {
         getAll: async () => customDomains,
-        create: async (args) => {
+        create: async () => {
           didCreateFunctionGetCalled = true;
         },
         update: async () => {
@@ -173,7 +173,7 @@ describe('#customDomains handler', () => {
     const auth0ApiClientMock = {
       customDomains: {
         getAll: async () => [],
-        create: async (args) => {
+        create: async () => {
           didCreateFunctionGetCalled = true;
         },
         update: async () => {

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -22,22 +22,23 @@ const customDomains = [
   },
 ];
 
-const auth0ApiClientMock = {
-  customDomains: {
-    getAll: async () => customDomains,
-    create: async () => customDomains[0],
-    update: async () => {},
-    delete: async () => {},
-  },
-  pool: new PromisePoolExecutor({
-    concurrencyLimit: 3,
-    frequencyLimit: 8,
-    frequencyWindow: 1000, // 1 sec
-  }),
-};
-
 describe('#customDomains handler', () => {
   it('should get custom domains', async () => {
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => customDomains,
+        create: async () => customDomains[0],
+        update: async () => {},
+        delete: async () => {},
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
     const handler = new customDomainsHandler({ client: auth0ApiClientMock });
     const data = await handler.load();
 

--- a/test/tools/auth0/handlers/rules.tests.js
+++ b/test/tools/auth0/handlers/rules.tests.js
@@ -152,64 +152,6 @@ describe('#rules handler', () => {
       expect(checker(newRulesOrder, reorderedRulesOrder)).to.be.equal(false);
     });
 
-    it('should allow for a temporary rules re-ordering if conflicts of order between config and remote', async () => {
-      let didUpdateGetCalled = false;
-
-      const auth0 = {
-        rules: {
-          getAll: () => [
-            {
-              id: 'rul_1',
-              name: 'Order 1 on tenant',
-              order: 1,
-            },
-            {
-              id: 'rul_2',
-              name: 'Order 2 on tenant',
-              order: 2,
-            },
-          ],
-          update: (args) => {
-            didUpdateGetCalled = true;
-            return new Promise(() => args);
-          },
-          delete: (args) => new Promise(() => args),
-          create: (args) => new Promise(() => args),
-        },
-        pool,
-      };
-
-      const handler = new rules.default({ client: auth0, config });
-      const calcChangesFn = Object.getPrototypeOf(handler).calcChanges;
-      const localRulesConfig = [
-        {
-          name: 'Order 1 on config',
-          order: 1,
-        },
-        {
-          name: 'Order 2 on config',
-          order: 2,
-        },
-      ];
-
-      const calculatedChanges = await calcChangesFn.apply(
-        handler,
-        [{ rules: localRulesConfig }],
-        true
-      );
-
-      expect(calculatedChanges.reOrder).to.deep.equal([
-        { id: 'rul_1', name: 'Order 1 on tenant', order: 3 },
-        { id: 'rul_2', name: 'Order 2 on tenant', order: 4 },
-      ]);
-
-      const processChangesFn = Object.getPrototypeOf(handler).processChanges;
-
-      await processChangesFn.apply(handler, [{ rules: localRulesConfig }], true);
-
-      expect(didUpdateGetCalled).to.equal(true);
-    });
-
     it('should not allow change stage', async () => {
       const auth0 = {
         rules: {

--- a/test/utils.js
+++ b/test/utils.js
@@ -107,6 +107,7 @@ export function mockMgmtClient() {
     },
     branding: { getSettings: () => ({}) },
     logStreams: { getAll: () => [] },
+    customDomains: { getAll: () => [] },
   };
 }
 


### PR DESCRIPTION
## ✏️ Changes

Adding support for managing (get, create, delete) custom domains, as requested in #443. 

Example `./custom-domains/custom-domains.json` file:
```json
[
    {
    "custom_client_ip_header": "cf-connecting-ip",
    "domain": "auth.test-domain.com",
    "type": "self_managed_certs"
  }
]
```

Example `tenant.yaml` file:
```yaml
customDomains:
  - custom_client_ip_header: cf-connecting-ip
    domain: auth.test-custom-domain.com
    type: self_managed_certs
```


**Note:** The Auth0 Node SDK, which this tool relies upon heavily, [does not currently support the updating of custom domains](https://github.com/auth0/node-auth0/blob/master/src/management/CustomDomainsManager.js). Thus, this tool won't be able to updates either, only creates and deletes. However, I don't believe this to be a huge burden on most users because the only updatedable properties are `custom_client_ip_header` and `tls_policy`. See:[ Update Custom Domains docs](https://auth0.com/docs/api/management/v2#!/Custom_Domains/patch_custom_domains_by_id).


## 🔗 References

Related Github Issue: #443 

## 🎯 Testing

Added unit tests as well as performed manual verification testing.
