### PR TITLE
Adding `ApiMethodOverride` type for API function overrides

### DIFF
--- a/src/tools/auth0/handlers/actions.ts
+++ b/src/tools/auth0/handlers/actions.ts
@@ -70,7 +70,7 @@ function isActionsDisabled(err) {
 export default class ActionHandler extends DefaultAPIHandler {
   existing: Asset[] | null;
 
-  constructor(options) {
+  constructor(options: DefaultAPIHandler) {
     super({
       ...options,
       type: 'actions',

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -33,10 +33,7 @@ export default class CustomDomainsHadnler extends DefaultAPIHandler {
       identifiers: ['domain'],
       stripCreateFields: ['status', 'primary', 'verification'],
       functions: {
-        //@ts-ignore
-        delete: (args) => {
-          return this.client.customDomains.delete({ id: args.custom_domain_id });
-        },
+        delete: (args) => this.client.customDomains.delete({ id: args.custom_domain_id }),
       },
     });
   }

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -59,7 +59,7 @@ export default class APIHandler {
       update?: ApiMethodOverride;
       create?: ApiMethodOverride;
       delete?: ApiMethodOverride;
-    }; //TODO: understand if any resource types pass in any additional functions
+    };
   }) {
     this.config = options.config;
     this.type = options.type;

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -20,6 +20,8 @@ export function order(value) {
   };
 }
 
+type ApiMethodOverride = string | Function;
+
 export default class APIHandler {
   config: ConfigFunction;
   id: string;
@@ -36,11 +38,11 @@ export default class APIHandler {
   stripCreateFields: string[]; //Fields to strip from payload when creating
   name?: string; // TODO: understand if any handlers actually leverage `name` property
   functions: {
-    getAll: string;
-    update: string;
-    create: string;
-    delete: string;
-  }; // TODO: delete this enum object in favor of tighter typing
+    getAll: ApiMethodOverride;
+    update: ApiMethodOverride;
+    create: ApiMethodOverride;
+    delete: ApiMethodOverride;
+  };
 
   constructor(options: {
     id?: APIHandler['id'];
@@ -53,10 +55,10 @@ export default class APIHandler {
     sensitiveFieldsToObfuscate?: APIHandler['sensitiveFieldsToObfuscate'];
     stripCreateFields?: APIHandler['stripCreateFields'];
     functions: {
-      getAll?: string;
-      update?: string;
-      create?: string;
-      delete?: string;
+      getAll?: ApiMethodOverride;
+      update?: ApiMethodOverride;
+      create?: ApiMethodOverride;
+      delete?: ApiMethodOverride;
     }; //TODO: understand if any resource types pass in any additional functions
   }) {
     this.config = options.config;

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -85,7 +85,7 @@ export default class APIHandler {
     this.deleted = 0;
   }
 
-  getClientFN(fn: string | Function): Function {
+  getClientFN(fn: ApiMethodOverride): Function {
     if (typeof fn === 'string') {
       const client = this.client[this.type];
       return client[fn].bind(client);


### PR DESCRIPTION
## ✏️ Changes

Adding the `ApiMethodOverride` type to facilitate stronger typing when the API controllers override the default set of CRUD methods. This override is necessary for times when the Node SDK's exported methods for a specific resource don't match the expected `create`, `update` and `delete` naming conventions. Additionally, this override behavior is used to alter the arguments passed into those CRUD functions. For example, the actions controller overrides the create and delete functions in its API controller:

```
functions: {
        create: (action) => this.createAction(action),
        delete: (action) => this.deleteAction(action),
},
```

The override mechanism works either by passing in a string to denote the client method name or a function which will override the function altogether. The underlying mechanism still remains, but the addition of the `ApiMethodOverride` type just makes the contract a bit stronger and allows us to remove a couple `//@ts-ignore`s. 