### PR TITLE
Fix screen types per prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ignore-path .eslintignore --ignore-pattern webpack . && kacl lint",
     "format": "npx prettier --write .",
     "pretest": "rimraf ./.nyc_output",
-    "test": "ts-mocha -p tsconfig.json --recursive 'test/**/*.test*'",
+    "test": "ts-mocha -p tsconfig.json --recursive 'test/**/*.test*' --timeout 5000",
     "build": "rimraf ./lib && npx tsc",
     "dev": "npx tsc --watch",
     "prepare": "npm run build",

--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -2,7 +2,7 @@ import DefaultHandler from './default';
 import { Assets, Language, languages } from '../../../types';
 import { isEmpty } from 'lodash';
 
-const promptScreenTypes = [
+const promptTypes = [
   'login',
   'login-id',
   'login-password',
@@ -30,6 +30,69 @@ const promptScreenTypes = [
   'common',
 ] as const;
 
+export type PromptTypes = typeof promptTypes[number];
+
+const screenTypes = [
+  'login',
+  'login-id',
+  'login-password',
+  'login-email-verification',
+  'signup',
+  'signup-id',
+  'signup-password',
+  'reset-password-request',
+  'reset-password-email',
+  'reset-password',
+  'reset-password-success',
+  'reset-password-error',
+  'consent',
+  'status',
+  'mfa-detect-browser-capabilities',
+  'mfa-enroll-result',
+  'mfa-login-options',
+  'mfa-begin-enroll-options',
+  'mfa-otp-enrollment-qr',
+  'mfa-otp-enrollment-code',
+  'mfa-otp-challenge',
+  'mfa-voice-challenge',
+  'mfa-sms-challenge',
+  'mfa-recovery-code-enrollment',
+  'mfa-recovery-code-challenge',
+  'mfa-country-codes',
+  'mfa-sms-enrollment',
+  'mfa-voice-enrollment',
+  'mfa-phone-challenge',
+  'mfa-phone-enrollment',
+  'mfa-webauthn-roaming-enrollment',
+  'mfa-webauthn-platform-enrollment',
+  'mfa-webauthn-platform-challenge',
+  'mfa-webauthn-roaming-challenge',
+  'mfa-webauthn-change-key-nickname',
+  'mfa-webauthn-enrollment-success',
+  'mfa-webauthn-error',
+  'mfa-webauthn-not-available-error',
+  'mfa-sms-list',
+  'mfa-email-challenge',
+  'mfa-email-list',
+  'mfa-push-welcome',
+  'mfa-push-list',
+  'mfa-push-enrollment-qr',
+  'mfa-push-enrollment-code',
+  'mfa-push-success',
+  'mfa-push-challenge-push',
+  'device-code-activation',
+  'device-code-activation-allowed',
+  'device-code-activation-denied',
+  'device-code-confirmation',
+  'email-verification-result',
+  'email-otp-challenge',
+  'redeem-ticket',
+  'organization-selection',
+  'accept-invitation',
+] as const;
+
+export type ScreenTypes = typeof screenTypes[number];
+
 export const schema = {
   type: 'object',
   properties: {
@@ -50,11 +113,19 @@ export const schema = {
           ...acc,
           [language]: {
             type: 'object',
-            properties: promptScreenTypes.reduce((acc, screenType) => {
+            properties: promptTypes.reduce((acc, promptTypes) => {
               return {
                 ...acc,
-                [screenType]: {
+                [promptTypes]: {
                   type: 'object',
+                  properties: screenTypes.reduce((acc, screenTypes) => {
+                    return {
+                      ...acc,
+                      [screenTypes]: {
+                        type: 'object',
+                      },
+                    };
+                  }, {}),
                 },
               };
             }, {}),
@@ -65,8 +136,6 @@ export const schema = {
   },
 };
 
-export type PromptScreenTypes = typeof promptScreenTypes[number];
-
 export type PromptSettings = {
   universal_login_experience?: 'new' | 'classic';
   webauthn_platform_first_factor?: boolean;
@@ -74,9 +143,11 @@ export type PromptSettings = {
 };
 
 export type PromptsCustomText = {
-  [key in PromptScreenTypes]: {
-    [key: string]: string;
-  };
+  [key in PromptTypes]: Partial<{
+    [key in ScreenTypes]: {
+      [key: string]: string;
+    };
+  }>;
 };
 
 export type Prompts = Partial<
@@ -121,17 +192,19 @@ export default class PromptsHandler extends DefaultHandler {
 
     const data = await Promise.all(
       supportedLanguages.flatMap((language) => {
-        return promptScreenTypes.map((screenType) => {
+        return promptTypes.map((promptType) => {
           return this.client.prompts
             .getCustomTextByLanguage({
-              prompt: screenType,
+              prompt: promptType,
               language,
             })
             .then((customTextData) => {
               if (isEmpty(customTextData)) return null;
               return {
                 language,
-                ...customTextData,
+                [promptType]: {
+                  ...customTextData,
+                },
               };
             });
         });
@@ -187,16 +260,12 @@ export default class PromptsHandler extends DefaultHandler {
 
         if (!languageScreenTypes) return [];
 
-        return Object.keys(languageScreenTypes).map((prompt: PromptScreenTypes) => {
-          const body = languageScreenTypes[prompt];
+        return Object.keys(languageScreenTypes).map((prompt: PromptTypes) => {
+          const body = languageScreenTypes[prompt] || {};
           return this.client.prompts.updateCustomTextByLanguage({
             prompt,
             language,
-            //@ts-ignore
-            body:
-              {
-                [prompt]: languageScreenTypes[prompt],
-              } || {},
+            body,
           });
         });
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import {
-  PromptScreenTypes,
+  PromptTypes,
+  ScreenTypes,
   Prompts,
   PromptsCustomText,
   PromptSettings,
@@ -115,12 +116,12 @@ export type BaseAuth0APIClient = {
   };
   prompts: {
     updateCustomTextByLanguage: (arg0: {
-      prompt: PromptScreenTypes;
+      prompt: PromptTypes;
       language: Language;
-      body: { [key: string]: string };
+      body: Partial<{ [key in ScreenTypes]: { [key: string]: string } }>;
     }) => Promise<void>;
     getCustomTextByLanguage: (arg0: {
-      prompt: PromptScreenTypes;
+      prompt: PromptTypes;
       language: Language;
     }) => Promise<Partial<PromptsCustomText>>;
     getSettings: () => Promise<PromptSettings>;

--- a/test/context/directory/prompts.test.ts
+++ b/test/context/directory/prompts.test.ts
@@ -24,18 +24,24 @@ describe('#directory context prompts', () => {
         [customTextFile]: JSON.stringify({
           en: {
             login: {
-              buttonText: '##BUTTON_TEXT_ENGLISH##',
-              description: 'english login description text',
+              login: {
+                buttonText: '##BUTTON_TEXT_ENGLISH##',
+                description: 'english login description text',
+              },
             },
             'signup-password': {
-              buttonText: '##BUTTON_TEXT_ENGLISH##',
-              description: 'english signup password description text',
+              'signup-password': {
+                buttonText: '##BUTTON_TEXT_ENGLISH##',
+                description: 'english signup password description text',
+              },
             },
           },
           fr: {
             login: {
-              buttonText: '##BUTTON_TEXT_FRENCH##',
-              description: 'french login description text',
+              login: {
+                buttonText: '##BUTTON_TEXT_FRENCH##',
+                description: 'french login description text',
+              },
             },
           },
         }),
@@ -61,18 +67,24 @@ describe('#directory context prompts', () => {
       customText: {
         en: {
           login: {
-            buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_ENGLISH}`,
-            description: 'english login description text',
+            login: {
+              buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_ENGLISH}`,
+              description: 'english login description text',
+            },
           },
           'signup-password': {
-            buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_ENGLISH}`,
-            description: 'english signup password description text',
+            'signup-password': {
+              buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_ENGLISH}`,
+              description: 'english signup password description text',
+            },
           },
         },
         fr: {
           login: {
-            buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_FRENCH}`,
-            description: 'french login description text',
+            login: {
+              buttonText: `${config.AUTH0_KEYWORD_REPLACE_MAPPINGS.BUTTON_TEXT_FRENCH}`,
+              description: 'french login description text',
+            },
           },
         },
       },
@@ -155,14 +167,18 @@ describe('#directory context prompts', () => {
       customText: {
         en: {
           login: {
-            buttonText: 'English login button text',
-            description: 'English login description',
+            login: {
+              buttonText: 'English login button text',
+              description: 'English login description',
+            },
           },
         },
         fr: {
           login: {
-            buttonText: 'French login button text',
-            description: 'French login description',
+            login: {
+              buttonText: 'French login button text',
+              description: 'French login description',
+            },
           },
         },
       },

--- a/test/context/yaml/prompts.test.ts
+++ b/test/context/yaml/prompts.test.ts
@@ -18,29 +18,50 @@ describe('#YAML context prompts', () => {
         customText:
           en:
             login:
-              description: text in english
-              title: this is title
-              buttonText: Button text
+              login:
+                description: text in english
+                title: this is title
+                buttonText: Button text
+            mfa:
+              mfa-detect-browser-capabilities:
+                pickAuthenticatorText: "Try another method"
+                reloadButtonText: "Reload"
+                noJSErrorTitle: "JavaScript Required"
+              mfa-login-options:
+                pageTitle: "Log in to \${clientName}"
+                backText: "Go back"
+                title: "Other Methods"
+                authenticatorNamesSMS: "SMS"
+              mfa-enroll-result:
+                pageTitle: "Secure Your Account"
+                enrolledTitle: "You're All Set!"
+                enrolledDescription: "You have successfully added a new authentication factor."
+                invalidTicketTitle: "Invalid Link"
+              mfa-begin-enroll-options:
+                pageTitle: "Log in to \${clientName}"
+                backText: "Go back"
+                title: "Keep Your Account Safe"
             signup-password:
-              buttonText: Continue signup password
-              description: Set your password for \${companyName} to continue to \${clientName}
-              editEmailText: Edit
-              editLinkScreenReadableText: Edit email address
-              emailPlaceholder: Email address
-              federatedConnectionButtonText: Continue with \${connectionName}
-              footerLinkText: Log in
-              footerText: Already have an account?
-              invitationDescription: >-
-                Sign Up to accept \${inviterName}'s invitation to join \${companyName}
-                on \${clientName}.
-              loginActionLinkText: \${footerLinkText}
-              loginActionText: \${footerText}
-              logoAltText: \${companyName}
-              pageTitle: Create a password to sign up | \${clientName}
-              passwordPlaceholder: Password
-              passwordSecurityText: 'Your password must contain:'
-              title: Create Your Account!
-              usernamePlaceholder: Username
+              signup-password:
+                buttonText: Continue signup password
+                description: Set your password for \${companyName} to continue to \${clientName}
+                editEmailText: Edit
+                editLinkScreenReadableText: Edit email address
+                emailPlaceholder: Email address
+                federatedConnectionButtonText: Continue with \${connectionName}
+                footerLinkText: Log in
+                footerText: Already have an account?
+                invitationDescription: >-
+                  Sign Up to accept \${inviterName}'s invitation to join \${companyName}
+                  on \${clientName}.
+                loginActionLinkText: \${footerLinkText}
+                loginActionText: \${footerText}
+                logoAltText: \${companyName}
+                pageTitle: Create a password to sign up | \${clientName}
+                passwordPlaceholder: Password
+                passwordSecurityText: 'Your password must contain:'
+                title: Create Your Account!
+                usernamePlaceholder: Username
     `;
 
     const yamlFile = path.join(dir, 'config.yaml');
@@ -54,29 +75,57 @@ describe('#YAML context prompts', () => {
       customText: {
         en: {
           login: {
-            buttonText: 'Button text',
-            description: 'text in english',
-            title: 'this is title',
+            login: {
+              buttonText: 'Button text',
+              description: 'text in english',
+              title: 'this is title',
+            },
+          },
+          mfa: {
+            'mfa-begin-enroll-options': {
+              backText: 'Go back',
+              pageTitle: 'Log in to ${clientName}',
+              title: 'Keep Your Account Safe',
+            },
+            'mfa-detect-browser-capabilities': {
+              noJSErrorTitle: 'JavaScript Required',
+              pickAuthenticatorText: 'Try another method',
+              reloadButtonText: 'Reload',
+            },
+            'mfa-enroll-result': {
+              enrolledDescription: 'You have successfully added a new authentication factor.',
+              enrolledTitle: "You're All Set!",
+              invalidTicketTitle: 'Invalid Link',
+              pageTitle: 'Secure Your Account',
+            },
+            'mfa-login-options': {
+              authenticatorNamesSMS: 'SMS',
+              backText: 'Go back',
+              pageTitle: 'Log in to ${clientName}',
+              title: 'Other Methods',
+            },
           },
           'signup-password': {
-            buttonText: 'Continue signup password',
-            description: 'Set your password for ${companyName} to continue to ${clientName}',
-            editEmailText: 'Edit',
-            editLinkScreenReadableText: 'Edit email address',
-            emailPlaceholder: 'Email address',
-            federatedConnectionButtonText: 'Continue with ${connectionName}',
-            footerLinkText: 'Log in',
-            footerText: 'Already have an account?',
-            invitationDescription:
-              "Sign Up to accept ${inviterName}'s invitation to join ${companyName} on ${clientName}.",
-            loginActionLinkText: '${footerLinkText}',
-            loginActionText: '${footerText}',
-            logoAltText: '${companyName}',
-            pageTitle: 'Create a password to sign up | ${clientName}',
-            passwordPlaceholder: 'Password',
-            passwordSecurityText: 'Your password must contain:',
-            title: 'Create Your Account!',
-            usernamePlaceholder: 'Username',
+            'signup-password': {
+              buttonText: 'Continue signup password',
+              description: 'Set your password for ${companyName} to continue to ${clientName}',
+              editEmailText: 'Edit',
+              editLinkScreenReadableText: 'Edit email address',
+              emailPlaceholder: 'Email address',
+              federatedConnectionButtonText: 'Continue with ${connectionName}',
+              footerLinkText: 'Log in',
+              footerText: 'Already have an account?',
+              invitationDescription:
+                "Sign Up to accept ${inviterName}'s invitation to join ${companyName} on ${clientName}.",
+              loginActionLinkText: '${footerLinkText}',
+              loginActionText: '${footerText}',
+              logoAltText: '${companyName}',
+              pageTitle: 'Create a password to sign up | ${clientName}',
+              passwordPlaceholder: 'Password',
+              passwordSecurityText: 'Your password must contain:',
+              title: 'Create Your Account!',
+              usernamePlaceholder: 'Username',
+            },
           },
         },
       },
@@ -93,14 +142,32 @@ describe('#YAML context prompts', () => {
       customText: {
         en: {
           login: {
-            buttonText: 'English login button text',
-            description: 'English login description',
+            login: {
+              buttonText: 'English login button text',
+              description: 'English login description',
+            },
+          },
+          mfa: {
+            'mfa-begin-enroll-options': {
+              title: 'Keep Your Account Safe',
+            },
+            'mfa-detect-browser-capabilities': {
+              noJSErrorTitle: 'JavaScript Required',
+            },
+            'mfa-enroll-result': {
+              enrolledDescription: 'You have successfully added a new authentication factor.',
+            },
+            'mfa-login-options': {
+              title: 'Other Methods',
+            },
           },
         },
         fr: {
           login: {
-            buttonText: 'French login button text',
-            description: 'French login description',
+            login: {
+              buttonText: 'French login button text',
+              description: 'French login description',
+            },
           },
         },
       },

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -15,22 +15,28 @@ describe('#prompts handler', () => {
 
       const englishCustomText = {
         'signup-password': {
-          buttonText: 'signup password button text in english',
-          description: 'signup password description in english',
-          editEmailText: 'signup password edit in english',
+          'signup-password': {
+            buttonText: 'signup password button text in english',
+            description: 'signup password description in english',
+            editEmailText: 'signup password edit in english',
+          },
         },
         login: {
-          description: 'login description in english',
-          title: 'login title in english',
-          buttonText: 'login button text in english',
+          login: {
+            description: 'login description in english',
+            title: 'login title in english',
+            buttonText: 'login button text in english',
+          },
         },
         'mfa-webauthn': {},
       };
       const frenchCustomText = {
         login: {
-          description: 'login description in french',
-          title: 'login title in french',
-          buttonText: 'login button text in french',
+          login: {
+            description: 'login description in french',
+            title: 'login title in french',
+            buttonText: 'login button text in french',
+          },
         }, // Only has the single login prompt
         'signup-password': {},
         'mfa-webauthn': {},

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -67,9 +67,7 @@ describe('#prompts handler', () => {
             if (customTextValue === undefined || _.isEmpty(customTextValue))
               return Promise.resolve({});
 
-            return Promise.resolve({
-              [prompt]: customTextValue,
-            });
+            return Promise.resolve(customTextValue);
           },
         },
       };


### PR DESCRIPTION
## ✏️ Changes

As reported in #539 , the recent prompts feature addition does not adequately handle the hierarchy of prompts with "screens" as an immediate descendant. Sometimes the "prompt" and "screen" are identical, like the `login` prompt for example: 

```json
{
   "login": {
      "login": {
        "description": "login description",
        "title": "login title",
        "buttonText": "login button text"
      }
    },
}
```

However, consider the `mfa` prompt type which has very distinct screen types underneath the MFA grouping:

```json
{
  "mfa": {
      "mfa-begin-enroll-options": {
        "title": "foo"
      },
      "mfa-detect-browser-capabilities": {
        "pickAuthenticatorText": "bar"
      },
      "mfa-enroll-result": {
        "genericError": "baz"
      }
    }
}
```

The error previously was not identifying this hierarchy during feature development, causing issues when some custom text was attempting to be updated. This PR rectifies this issue by fully respecting and preserving the hierachy as it is handled in the API. 

## 🔗 References

- Original Github issue: #539 
- [Auth0 Prompts Documentation](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts)

## 🎯 Testing

All existing prompts test have been updated to reflect this change.