### PR TITLE
Gracefully handle custom domains if not supported by tenant

### DIFF
--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -45,16 +45,27 @@ export default class CustomDomainsHadnler extends DefaultAPIHandler {
     return super.objString(item.domain);
   }
 
-  async getType(): Promise<Asset> {
-    if (this.existing) {
-      return this.existing;
+  async getType(): Promise<Asset | null> {
+    try {
+      if (this.existing) {
+        return this.existing;
+      }
+
+      const customDomains = await this.client.customDomains.getAll({ paginate: false });
+
+      this.existing = customDomains;
+
+      return customDomains;
+    } catch (err) {
+      if (
+        err.statusCode === 403 &&
+        err.message ===
+          'The account is not allowed to perform this operation, please contact our support team'
+      ) {
+        return null;
+      }
+      throw err;
     }
-
-    const customDomains = await this.client.customDomains.getAll({ paginate: false });
-
-    this.existing = customDomains;
-
-    return customDomains;
   }
 
   async processChanges(assets: Assets): Promise<void> {

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -44,6 +44,34 @@ describe('#customDomains handler', () => {
     expect(data).to.deep.equal({ customDomains });
   });
 
+  it('should handle error gracefully if custom domains not supported by tenant', async () => {
+    const auth0ApiClientMock = {
+      customDomains: {
+        getAll: async () => {
+          throw {
+            statusCode: 403,
+            message:
+              'The account is not allowed to perform this operation, please contact our support team',
+          };
+        },
+        create: async () => {},
+        update: async () => {},
+        delete: async () => {},
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    //@ts-ignore
+    const handler = new customDomainsHandler({ client: auth0ApiClientMock });
+    const data = await handler.load();
+
+    expect(data).to.deep.equal({ customDomains: null });
+  });
+
   it('should create custom domains', async () => {
     let didCreateFunctionGetCalled = false;
     let didUpdateFunctionGetCalled = false;


### PR DESCRIPTION
## ✏️ Changes

Custom domains is a feature that is only supported in paid tiers. In the cases of free-tiered tenants and other subscriptions that do not support them, a 403 error is thrown with the following message: `The account is not allowed to perform this operation, please contact our support team`. This was reported in #537 after the 7.12 release that added custom domains support. 

## 🔗 References

- Original issue: #537 
- [Custom Domains Technical Documentation](https://auth0.com/docs/customize/custom-domains)

## 🎯 Testing

Added test case to the custom domains API handler to simulate this error. Also manually verified against a free-tiered tenant.