### PR TITLE
ESD-20252: Prevent crashing on non-array `enabled_locales` value

### DIFF
--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -186,9 +186,17 @@ export default class PromptsHandler extends DefaultHandler {
   }
 
   async getCustomTextSettings(): Promise<AllPromptsByLanguage> {
-    const supportedLanguages = await this.client.tenant
-      .getSettings()
-      .then(({ enabled_locales }) => enabled_locales);
+    const supportedLanguages = await (async () => {
+      const enabledLocales = await this.client.tenant
+        .getSettings()
+        .then(({ enabled_locales }) => enabled_locales);
+
+      if (!Array.isArray(enabledLocales)) {
+        return []; // For reasons unknown, enabled_locales is sometimes not an array. See: ESD-20252
+      }
+
+      return enabledLocales;
+    })();
 
     const data = await Promise.all(
       supportedLanguages.flatMap((language) => {

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -166,5 +166,31 @@ describe('#prompts handler', () => {
       expect(didCallUpdateCustomText).to.equal(true);
       expect(numberOfUpdateCustomTextCalls).to.equal(3);
     });
+
+    it('should return empty custom text object if API returns non-array `enabled_locales` value', async () => {
+      const NON_ARRAY_VALUE = null; // some arbitrary non-array value. See: ESD-20252
+
+      expect(Array.isArray(NON_ARRAY_VALUE)).to.equal(false);
+
+      const auth0 = {
+        tenant: {
+          getSettings: () =>
+            Promise.resolve({
+              enabled_locales: NON_ARRAY_VALUE,
+            }),
+        },
+        prompts: {
+          getSettings: () => mockPromptsSettings,
+        },
+      };
+
+      //@ts-ignore
+      const handler = new promptsHandler({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({
+        ...mockPromptsSettings,
+        customText: {},
+      });
+    });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

For some reason, one of our customers is experiencing the following error:

`supportedLanguages.flatMap is not a function`, [this line of code ](https://github.com/auth0/auth0-deploy-cli/blob/677388a512fbe320c99b72e520f5dfa22b7db9eb/src/tools/auth0/handlers/prompts.ts#L194) is the specific culprit. What's odd is that error will _only_ occur if the `enabled_locales` value returned from the GET tenant settings endpoint is _not_ an array. I'm not sure what that specific value is or exactly why it is occurring, but it demonstrates that unexpected invalid Management API results do indeed occur. 

This PR doesn't fix the underlying invalid `enabled_locales` data, but instead patches the behavior to prevent any crashes at runtime.

## 🔗 References

- [ESD-20252](https://auth0team.atlassian.net/browse/ESD-20252)
-[ Line of code in question](https://github.com/auth0/auth0-deploy-cli/blob/677388a512fbe320c99b72e520f5dfa22b7db9eb/src/tools/auth0/handlers/prompts.ts#L194)

## 🎯 Testing

Added a test case for if `enabled_locales` is not an array.