### PR TITLE
DXCDT-141: "Multi-environment Workflows" doc page [6/10]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Configuring the Deploy CLI](docs/configuring-the-deploy-cli.md)
 - [Keyword Replacement](docs/keyword-replacement.md)
 - [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
-- [Excluding resources from management](docs/excluding-from-management.md)
-- [Available Resource Formats](#)
-- [Terraform Provider](#)
-- [How to Contribute](#)
+- [Excluding Resources From Management](docs/excluding-from-management.md)
+- [Available Resource Formats](docs/available-resource-config-formats.md)
+- [Terraform Provider](docs/terraform-provider.md)
+- [How to Contribute](docs/how-to-contribute.md)
 
 ## Getting Started
 

--- a/docs/available-resource-config-formats.md
+++ b/docs/available-resource-config-formats.md
@@ -1,0 +1,19 @@
+# Available Resource Config Formats
+
+Auth0 resource state is expressed in two available different configuration file formats: YAML and JSON (aka “directory”). When using the Deploy CLI’s export command, you will be prompted with the choice of one versus the other.
+
+## YAML
+
+The YAML format is expressed mostly as a flat `tenant.yaml` file with supplemental code files for resources like actions and email templates. The single file makes tracking changes over time in version control more straightforward. Additionally, the single file eliminates a bit of ambiguity with directory and file names, which may not be immediately obvious.
+
+## Directory (JSON)
+
+The directory format separates resource types into separate directories, with each single resource living inside a dedicated JSON file. This format allows for easier conceptual separation between each type of resource as well as the individual resources themselves. Also, the Deploy CLI closely mirrors the data shapes defined in the [Auth0 Management API](https://auth0.com/docs/api/management/v2), so referencing the JSON examples in the docs may provide useful when using this format.
+
+## How to Choose
+
+The decision to select which format to use should be primarily made off of preference. Both formats are tenable solutions that achieve the same task, but with subtly different strengths and weaknesses described above. Be sure to evaluate each in the context of your context. Importantly, **this choice is not permanent**, and switching from one to the other via the import command is an option at your disposal.
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -133,3 +133,7 @@ Array of strings. Excludes the management of specific connections by ID. **Note:
 ### `AUTH0_EXCLUDED_RESOURCE_SERVERS`
 
 Array of strings. Excludes the management of specific resource servers by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/excluding-from-management.md
+++ b/docs/excluding-from-management.md
@@ -75,3 +75,7 @@ hooks: [] # Empty hooks
 connections: [] # Empty connections
 tenant: {} # Effectively a no-op, emptiness does not apply to non-set resource config
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,0 +1,49 @@
+# How to Contribute
+
+While we may not prioritize some issues and feature requests, we are much more inclined to address them if accompanied with a code contribution. Please feel empowered to make a code contribution through a Github pull request. Please read the following for the best contributor experience.
+
+## Getting started with development
+
+The only requirement for development is having [node](https://nodejs.dev/) installed. Most modern versions will work but LTS is recommended.
+
+Once node is installed, fork the Deploy CLI repository. Once code is downloaded to local development machine, run the following commands:
+
+```shell
+npm install # Installs all dependencies
+npm run dev # Runs compiler, continuously observes source file changes
+```
+
+## Running tests
+
+In order to run the entire test suite, execute `npm run test`.
+
+To run a single test file or single test execute:
+
+```shell
+npx ts-mocha --timeout=5000 -p tsconfig.json <PATH_TO_TEST_FILE> -g=<OPTIONAL_NAME_OF_TEST>
+```
+
+### Examples
+
+```shell
+# Runs all tests within a file
+npx ts-mocha --timeout=5000 -p tsconfig.json test/tools/auth0/handlers/actions.tests.js
+
+# Runs a single test within a file
+npx ts-mocha --timeout=5000 -p tsconfig.json \
+test/tools/auth0/handlers/actions.tests.js \
+-g="should create action"
+```
+
+## Code Contribution Checklist
+
+Before finally submitting a PR, please ensure to complete the following:
+
+- [ ] All code written in Typescript and compiles
+- [ ] Accompanying tests for functional changes
+- [ ] Any necessary documentation changes to pages in the /docs directory
+- [ ] PR includes thorough description about what code does and why it was added
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -39,3 +39,7 @@ clients:
 ## Uni-directional Limitation
 
 Currently, the Deploy CLI only preserves keywords during import. Once added, keywords are overwritten with subsequent exports. For this reason, it is recommended that if a workflow heavily depends on keyword replacement, to only perform imports in perpetuity. This limitation is noted in [this Github issue](https://github.com/auth0/auth0-deploy-cli/issues/328).
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/multi-environment-workflow.md
+++ b/docs/multi-environment-workflow.md
@@ -21,7 +21,7 @@ It is recommended to have a separate Auth0 tenant/account for each environment y
 
 ## Resource configuration repository
 
-When exported, your Auth0 tenant state will be represented as a set of resource configuration files, either in a [YAML or JSON format](#). In a multi-environment context it is expected to have a single repository of resource configurations that is applied to all environments. In practice, this may exist as a directory in your project’s codebase or in a separate codebase altogether.
+When exported, your Auth0 tenant state will be represented as a set of resource configuration files, either in a [YAML or JSON format](./available-resource-config-formats.md). In a multi-environment context it is expected to have a single repository of resource configurations that is applied to all environments. In practice, this may exist as a directory in your project’s codebase or in a separate codebase altogether.
 
 You should have at least one branch for each tenant in your repository, which allows you to make changes without deploying them (the changes would only deploy when you merged your branch into the master, or primary, branch). With this setup, you can have a continuous integration task for each environment that automatically deploys changes to the targeted environment whenever the master branch receives updates.
 
@@ -92,3 +92,7 @@ Once separate configurations files are adopted for each environment, keyword rep
   }
 }
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -1,0 +1,20 @@
+# Auth0 Terraform Provider
+
+The Deploy CLI is not the only tool available for managing your Auth0 tenant configuration, there is also an [officially supported Terraform Provider](https://github.com/auth0/terraform-provider-auth0). [Terraform](https://terraform.io/) is a third-party tool for representing your cloud resources’s configurations as code. It has an established plug-in framework that supports a wide array of cloud providers, including Auth0.
+
+Both the Deploy CLI and Terraform Provider exist to help you manage your Auth0 tenant configurations, but each has their own set of pros and cons.
+
+You may want to consider the Auth0 Terraform Provider if:
+
+- Your development workflows already leverages Terraform
+- Your tenant management needs are granular or only pertain to a few specific resources
+
+You may **not** want to consider the Auth0 Terraform Provider if:
+
+- Your development workflow does not use Terraform, requiring extra setup upfront
+- Your development workflows are primarily concerned with managing your tenants in bulk
+- Your tenant has lots of existing resources, may require significant effort to “import”
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/using-as-cli.md
+++ b/docs/using-as-cli.md
@@ -83,3 +83,7 @@ a0deploy import -c=config.json --input_file=local
 # Deploying configuration with environment variables ignored
 a0deploy import -c=config.json --input_file=local/tenant.yaml --env=false
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/using-as-node-module.md
+++ b/docs/using-as-node-module.md
@@ -104,3 +104,7 @@ console.log("Auth0 configuration applied to tenant successful")
 }).catch((err)=>{
 console.log("Error when applying configuration to Auth0 tenant:",err)
 })
+
+---
+
+[[table of contents]](../README.md#documentation)


### PR DESCRIPTION
## ✏️ Changes

The sixth of a ten PR cascade to publish the content from the Deploy CLI's documentation overhaul. This one focuses on the "Incorporating into multi-environment workflows" page.

## 🔗 References

- [Documentation content outline](https://oktawiki.atlassian.net/wiki/spaces/DXCDT/pages/2632975220/Deploy+CLI+Docs+Content+Outline)
- [I"ncorporating into Mult-environment Workflows" draft](https://oktawiki.atlassian.net/wiki/spaces/DXCDT/pages/2650711997/Incorporating+into+multi-environment+workflows)