### PR TITLE
DXCDT-145: "Terraform Provider" doc page [9/10]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Excluding from Management Purview](docs/excluding-from-management.md)
 - [Available Resource Formats](docs/available-resource-config-formats.md)
 - [Terraform Provider](docs/terraform-provider.md)
-- [How to Contribute](#)
+- [How to Contribute](docs/how-to-contribute.md)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Using as a CLI](docs/using-as-cli.md)
 - [Using as a Node Module](docs/using-as-node-module.md)
 - [Configuring the Deploy CLI](docs/configuring-the-deploy-cli.md)
-- [Keyword Replacement](#)
+- [Keyword Replacement](docs/keyword-replacement.md)
 - [Incorporating Into Multi-environment Workflows](#)
 - [Excluding from Management Purview](#)
 - [Available Resource Formats](#)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
 - [Excluding from Management Purview](docs/excluding-from-management.md)
 - [Available Resource Formats](docs/available-resource-config-formats.md)
-- [Terraform Provider](#)
+- [Terraform Provider](docs/terraform-provider.md)
 - [How to Contribute](#)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Configuring the Deploy CLI](docs/configuring-the-deploy-cli.md)
 - [Keyword Replacement](docs/keyword-replacement.md)
 - [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
-- [Excluding from Management Purview](#)
+- [Excluding from Management Purview](docs/excluding-from-management.md)
 - [Available Resource Formats](#)
 - [Terraform Provider](#)
 - [How to Contribute](#)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Keyword Replacement](docs/keyword-replacement.md)
 - [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
 - [Excluding from Management Purview](docs/excluding-from-management.md)
-- [Available Resource Formats](#)
+- [Available Resource Formats](docs/available-resource-config-formats.md)
 - [Terraform Provider](#)
 - [How to Contribute](#)
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 
 ## Documentation
 
-- [Using as a CLI](#)
-- [Using as a Node Module](#)
+- [Using as a CLI](docs/using-as-cli.md)
+- [Using as a Node Module](docs/using-as-node-module.md)
 - [Configuring the Deploy CLI](docs/configuring-the-deploy-cli.md)
 - [Keyword Replacement](#)
 - [Incorporating Into Multi-environment Workflows](#)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Using as a Node Module](docs/using-as-node-module.md)
 - [Configuring the Deploy CLI](docs/configuring-the-deploy-cli.md)
 - [Keyword Replacement](docs/keyword-replacement.md)
-- [Incorporating Into Multi-environment Workflows](#)
+- [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
 - [Excluding from Management Purview](#)
 - [Available Resource Formats](#)
 - [Terraform Provider](#)

--- a/docs/available-resource-config-formats.md
+++ b/docs/available-resource-config-formats.md
@@ -13,3 +13,7 @@ The directory format separates resource types into separate directories, with ea
 ## How to Choose
 
 The decision to select which format to use primarily made off of preference. Both formats are tenable solutions that achieve the same task, but with subtly different strengths and weaknesses described above. Be sure to evaluate each in the context of your context. Importantly, **this choice is not permanent**, and switching from one to the other via the import command is an option at your disposal.
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/available-resource-config-formats.md
+++ b/docs/available-resource-config-formats.md
@@ -1,0 +1,15 @@
+# Available Resource Config Formats
+
+Auth0 resource state is expressed in two available different configuration file formats: YAML and JSON (aka “directory”). When using the Deploy CLI’s export command, you will be prompted with the choice of one versus the other.
+
+## YAML
+
+The YAML format is expressed mostly as a flat `tenant.yaml` file with supplemental code files for resources like actions and email templates. The single file makes tracking changes over time in version control more straightforward. Additionally, the single file eliminates a bit of ambiguity with directory and file names, which may not be immediately obvious.
+
+## Directory (JSON)
+
+The directory format separates resource types into separate directories, with each single resource living inside a dedicated JSON file. This format allows for easier conceptual separation between each type of resource as well as the individual resources themselves. Also, the Deploy CLI closely mirrors the data shapes defined in the [Auth0 Management API](https://auth0.com/docs/api/management/v2), so referencing the JSON examples in the docs may provide useful when using this format.
+
+## How to Choose
+
+The decision to select which format to use primarily made off of preference. Both formats are tenable solutions that achieve the same task, but with subtly different strengths and weaknesses described above. Be sure to evaluate each in the context of your context. Importantly, **this choice is not permanent**, and switching from one to the other via the import command is an option at your disposal.

--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -19,7 +19,7 @@ Example **config.json** file:
 }
 ```
 
-> ⚠️ **NOTE:** Hard-coding credentials is not recommended, and risks secret leakage should this file ever be committed to a public version control system. Instead, passing credentials as [environment variables](#) is considered best practice.
+> ⚠️ **NOTE:** Hard-coding credentials is not recommended, and risks secret leakage should this file ever be committed to a public version control system. Instead, passing credentials as [environment variables](#Environment variables) is considered best practice.
 
 ### Environment variables
 
@@ -29,7 +29,7 @@ Non-primitive configuration values like `AUTH0_KEYWORD_MAPPING` and `AUTH0_EXCLU
 
 To **disable** the consumption of environment variables for either the `import` or `export` commands, pass the `--env=false` argument.
 
-#### Examples:
+#### Examples
 
 ```shell
 # Deploying configuration for YAML formats without a config.json file
@@ -83,7 +83,7 @@ Array of strings. Excludes entire resource types from being managed, bi-directio
 
 ### `AUTH0_KEYWORD_REPLACE_MAPPINGS`
 
-Mapping of specific keywords to facilities dynamic replacement. See also: keyword replacement mapping.
+Mapping of specific keywords to facilities dynamic replacement. See also: [keyword replacement](keyword-replacement.md).
 
 #### Example
 

--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -71,7 +71,7 @@ Boolean. When enabled, will allow the tool to delete resources. Default: `false`
 
 ### `AUTH0_EXCLUDED`
 
-Array of strings. Excludes entire resource types from being managed, bi-directionally. See also: [excluding resources from management](#). Possible values: `actions`, `attackProtection`, `branding`, `clientGrants`, `clients`, `connections`, `customDomains`, `databases`, `emailProvider`, `emailTemplates`, `guardianFactorProviders`, `guardianFactorTemplates`, `guardianFactors`, `guardianPhoneFactorMessageTypes`, `guardianPhoneFactorSelectedProvider`, `guardianPolicies`, `hooks`, `logStreams`, `migrations`, `organizations`, `pages`, `prompts`, `resourceServers`, `roles`, `rules`, `rulesConfigs`, `tenant`, `triggers`
+Array of strings. Excludes entire resource types from being managed, bi-directionally. See also: [excluding resources from management](excluding-from-management.md). Possible values: `actions`, `attackProtection`, `branding`, `clientGrants`, `clients`, `connections`, `customDomains`, `databases`, `emailProvider`, `emailTemplates`, `guardianFactorProviders`, `guardianFactorTemplates`, `guardianFactors`, `guardianPhoneFactorMessageTypes`, `guardianPhoneFactorSelectedProvider`, `guardianPolicies`, `hooks`, `logStreams`, `migrations`, `organizations`, `pages`, `prompts`, `resourceServers`, `roles`, `rules`, `rulesConfigs`, `tenant`, `triggers`
 
 #### Example
 
@@ -116,20 +116,20 @@ String. Separate value from audience value while retrieving an access token for 
 
 ### `AUTH0_EXCLUDED_RULES`
 
-Array of strings. Excludes the management of specific rules by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](#).
+Array of strings. Excludes the management of specific rules by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
 
 ### `AUTH0_EXCLUDED_CLIENTS`
 
-Array of strings. Excludes the management of specific clients by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](#).
+Array of strings. Excludes the management of specific clients by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
 
 ### `AUTH0_EXCLUDED_DATABASES`
 
-Array of strings. Excludes the management of specific databases by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](#).
+Array of strings. Excludes the management of specific databases by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
 
 ### `AUTH0_EXCLUDED_CONNECTIONS`
 
-Array of strings. Excludes the management of specific connections by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](#).
+Array of strings. Excludes the management of specific connections by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
 
 ### `AUTH0_EXCLUDED_RESOURCE_SERVERS`
 
-Array of strings. Excludes the management of specific resource servers by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](#).
+Array of strings. Excludes the management of specific resource servers by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).

--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -133,3 +133,7 @@ Array of strings. Excludes the management of specific connections by ID. **Note:
 ### `AUTH0_EXCLUDED_RESOURCE_SERVERS`
 
 Array of strings. Excludes the management of specific resource servers by ID. **Note:** This configuration may be subject to deprecation in the future. See: [excluding resources from management](excluding-from-management.md).
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/excluding-from-management.md
+++ b/docs/excluding-from-management.md
@@ -1,0 +1,79 @@
+# Excluding from Management
+
+In many cases, you may find it useful to exclude resources from being managed. This could be because your tenant has a large number of a particular resource and thus operationally burdensome to manage. Other times, you may wish to exclude them as your development workflow only pertains to a specific subset of resources and you’d like to omit all other resources for performance. Regardless of the use case, there are several options available for expressing exclusions in the Deploy CLI.
+
+## Excluding entire resources by type
+
+For more complex tenants, you may find yourself wanting to omit entire resource types. Some common use cases for wanting this capability:
+
+- Enterprise tenant with thousands of organizations, managing all would be operationally burdensome
+- CI/CD process only focuses on managing roles, you may wish to exclude all others
+- Feature development pertains to hook, you may wish to temporarily exclude all others to optimize performance
+
+This type of exclusion is expressed by passing an array of resource names into the `AUTH0_EXCLUDED` configuration property. This exclusion works **bi-directionally**, that is, both when export from Auth0 and importing to Auth0, regardless if resource configuration files exist or not.
+
+All supported resource values for exclusion:
+
+```
+["actions", "attackProtection", "branding", "clientGrants", "clients", "connections", "customDomains", "databases", "emailProvider", "emailTemplates", "guardianFactorProviders", "guardianFactorTemplates", "guardianFactors", "guardianPhoneFactorMessageTypes", "guardianPhoneFactorSelectedProvider", "guardianPolicies", "hooks", "logStreams", "migrations", "organizations", "pages", "prompts", "resourceServers", "roles", "rules", "rulesConfigs", "tenant", "themes", "triggers"]
+```
+
+### Example
+
+The following example excludes `clients`, `connections`, `databases` and `organizations` from being managed by the Deploy CLI. However, this example is arbitrary and your use case may require you to exclude less or more types.
+
+```json
+{
+  "AUTH0_DOMAIN": "example-site.us.auth0.com",
+  "AUTH0_CLIENT_ID": "<YOUR_AUTH0_CLIENT_ID>",
+  "AUTH0_EXCLUDED": ["clients", "connections", "databases", "organizations"]
+}
+```
+
+## Excluding single resources by ID
+
+Some resource types support exclusions of individual resource by ID. This is primarily useful if you work in a multi-environment context and wish to omit a production single, specific resource from your lower-level environments. The by-ID method of exclusion is supported for rules, clients, databases, connections and resource servers with the `AUTH0_EXCLUDED_RULES` ,`AUTH0_EXCLUDED_CLIENTS`, `AUTH0_EXCLUDED_DATABASES`, `AUTH0_EXCLUDED_CONNECTIONS`, `AUTH0_EXCLUDED_RESOURCE_SERVERS` configuration values respectively.
+
+```json
+{
+  "AUTH0_DOMAIN": "example-site.us.auth0.com",
+  "AUTH0_CLIENT_ID": "<YOUR_AUTH0_CLIENT_ID>",
+  "AUTH0_EXCLUDED_CLIENTS": ["PdmQpGy72sHksV6ueVNZVrV4GDlDDm76"],
+  "AUTH0_EXCLUDED_CONNECTIONS": ["con_O1H3KyRMFP1IWRq3", "con_9avEYuj19ihqKBOs"]
+}
+```
+
+> ⚠️ **NOTE:** Excluding resources by ID is being considered for deprecation in future major versions. See the [resource exclusion proposal](https://github.com/auth0/auth0-deploy-cli/issues/451) for more details.
+
+## Omission vs excluded vs empty
+
+The above sections pertain to exclusion which forcefully ignore configurations bi-directionally. It is worth noting similar but very different concepts: “omissions” and “empty” states.
+
+### Omission
+
+Resource configuration that is absent, either intentionally or unintentionally, will be skipped during import. That is, if you resource configuration were deleted, those configurations would be skipped during import and will not alter the remote tenant state. There is no concept of omission for exporting; unless specifically excluded, all your tenant configurations will write to resource configuration files.
+
+### Example of omission
+
+```yaml
+roles: # roles configuration is not omitted
+  - name: Admin
+    description: Can read and write things
+    permissions: []
+  - name: Reader
+    description: Can only read things
+    permissions: []
+# The omission of all other configurations means they'll be skipped over
+```
+
+### Empty
+
+Resource configuration that is explicitly defined as empty. For set-based configurations like hooks, organizations and actions, setting these configurations to an empty set expresses an intentional emptying of those resources. In practice, this would signal a deletion, so long as the [`AUTH0_ALLOW_DELETE` deletion configuration property](configuring-the-deploy-cli.md#AUTH0_ALLOW_DELETE) is enabled. For non-set-based resource configuration like tenant and branding, the concept of emptiness does not apply, will not trigger any deletions or removals.
+
+#### Example of emptiness
+
+```yaml
+hooks: [] # Empty hooks
+connections: [] # Empty connections
+tenant: {} # Effectively a no-op, emptiness does not apply to non-set resource config
+```

--- a/docs/excluding-from-management.md
+++ b/docs/excluding-from-management.md
@@ -77,3 +77,7 @@ hooks: [] # Empty hooks
 connections: [] # Empty connections
 tenant: {} # Effectively a no-op, emptiness does not apply to non-set resource config
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,0 +1,49 @@
+# How to Contribute
+
+While we may not prioritize some issues and feature requests, we are much more inclined to address them if accompanied with a code contribution. Please feel empowered to make a code contribution through a Github pull request. Please read the following for the best contributor experience.
+
+## Getting started with development
+
+The only requirement for development is having [node](https://nodejs.dev/) installed. Most modern versions will work but LTS is recommended.
+
+Once node is installed, fork the Deploy CLI repository. Once code is downloaded to local development machine, run the following commands:
+
+```shell
+npm install # Installs all dependencies
+npm run dev # Runs compiler, continuously observes source file changes
+```
+
+## Running tests
+
+In order to run the entire test suite, execute `npm run test`.
+
+To run a single test file or single test execute:
+
+```shell
+npx ts-mocha --timeout=5000 -p tsconfig.json <PATH_TO_TEST_FILE> -g=<OPTIONAL_NAME_OF_TEST>
+```
+
+### Examples
+
+```shell
+# Runs all tests within a file
+npx ts-mocha --timeout=5000 -p tsconfig.json test/tools/auth0/handlers/actions.tests.js
+
+# Runs a single test within a file
+npx ts-mocha --timeout=5000 -p tsconfig.json \
+test/tools/auth0/handlers/actions.tests.js \
+-g="should create action"
+```
+
+## Code Contribution Checklist
+
+Before finally submitting a PR, please ensure to complete the following:
+
+- [ ] All code written in Typescript and compiles
+- [ ] Accompanying tests for functional changes
+- [ ] Any necessary documentation changes to pages in the /docs directory
+- [ ] PR includes thorough description about what code does and why it was added
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -1,0 +1,41 @@
+# Keyword Replacement
+
+The Deploy CLI supports dynamic keyword replacement with environment-specific values. This enables a scalable multi-tenant workflow where all tenants share the same resource configuration files but inject subtly different values.
+
+To use the keyword replacement, the `AUTH0_KEYWORD_REPLACEMENT_MAPPINGS` configuration property needs to contain the appropriate mappings. Then, in the resource configuration files, keywords can be injected through one of two ways:
+
+- `@@EXAMPLE_KEY@@`: Using the `@` symbols causes the tool to perform a `JSON.stringify` on your value before replacing it. So if your value is a string, the tool will add quotes; if your value is an array or object, the tool will add braces.
+- `##EXAMPLE_KEY##`: Using the `#` symbol causes the tool to perform a literal replacement; it will not add quotes or brackets.
+
+### Example `config.json`
+
+```json
+{
+  "AUTH0_DOMAIN": "test-tenant.us.auth0.com",
+  "AUTH0_CLIENT_ID": "FOO",
+  "AUTH0_CLIENT_SECRET": "BAR",
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
+    "ENVIRONMENT": "dev",
+    "ALLOWED_LOGOUTS": ["https://dev-test-site.com/logout", "localhost:3000/logout"],
+    "ALLOWED_ORIGINS": ["https://dev-test-site.com", "localhost:3000"]
+  }
+}
+```
+
+### Example `tenant.yaml`
+
+```yaml
+tenant:
+  friendly_name: My ##ENVIRONMENT## tenant
+  allowed_logout_urls: @@ALLOWED_LOGOUTS@@
+  enabled_locales:
+    - en
+clients:
+  - name: Test App
+    allowed_origins: @@ALLOWED_ORIGINS@@
+    allowed_logout_urls: @@ALLOWED_LOGOUTS@@
+```
+
+## Uni-directional Limitation
+
+Currently, the Deploy CLI only preserves keywords during import. Once added, keywords are overwritten with subsequent exports. For this reason, it is recommended that if a workflow heavily depends on keyword replacement, to only perform imports in perpetuity. This limitation is noted in [this Github issue](https://github.com/auth0/auth0-deploy-cli/issues/328).

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -39,3 +39,7 @@ clients:
 ## Uni-directional Limitation
 
 Currently, the Deploy CLI only preserves keywords during import. Once added, keywords are overwritten with subsequent exports. For this reason, it is recommended that if a workflow heavily depends on keyword replacement, to only perform imports in perpetuity. This limitation is noted in [this Github issue](https://github.com/auth0/auth0-deploy-cli/issues/328).
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/multi-environment-workflow.md
+++ b/docs/multi-environment-workflow.md
@@ -1,0 +1,94 @@
+# Incorporating into multi-environment workflows
+
+The Deploy CLI is most powerful when working within a multi-tenant, multi-environment context. When integrated into your CI/CD development workflows, can be used to propagate Auth0 changes from feature development all the way through production.
+
+In general, the advised workflow is as follows:
+
+- Create a separate Auth0 tenant for each environment (ex: dev, staging, prod)
+- Create a single repository of resource configuration files for all environments
+- Add a step in your CI/CD pipeline when deploying to environments that applies the Auth0 resource configurations to the appropriate Auth0 tenant
+
+## Tenant to Environment
+
+It is recommended to have a separate Auth0 tenant/account for each environment you have. For example:
+
+| Environment | Tenant        |
+| ----------- | ------------- |
+| Development | travel0-dev   |
+| Testing     | travel0-uat   |
+| Staging     | travel0-stage |
+| Production  | travel0-prod  |
+
+## Resource configuration repository
+
+When exported, your Auth0 tenant state will be represented as a set of resource configuration files, either in a [YAML or JSON format](#). In a multi-environment context it is expected to have a single repository of resource configurations that is applied to all environments. In practice, this may exist as a directory in your project’s codebase or in a separate codebase altogether.
+
+You should have at least one branch for each tenant in your repository, which allows you to make changes without deploying them (the changes would only deploy when you merged your branch into the master, or primary, branch). With this setup, you can have a continuous integration task for each environment that automatically deploys changes to the targeted environment whenever the master branch receives updates.
+
+Your workflow would, therefore, look something like this:
+
+1. Make changes to development.
+2. Merge changes to testing (or `uat`).
+3. Test changes to `uat`. When ready, move and merge the changes to `staging`.
+4. Test `staging`. When ready, move and merge the changes to `production`.
+
+You may want to set your production environment to deploy only when triggered manually.
+
+## Uni-directional Flow
+
+The multi-environment workflow works best when changes are propagated “up” in a single direction. Changes to the resource configuration files should first be applied to the lowest level environment (ex: dev) and then incrementally applied up through all other environments until applied to production. This uni-directional practice ensures sufficient testing and approval for changes to your tenant. Once set, it is recommended to not apply configurations directly to production through other means such as the Auth0 Dashboard or Management API unless those changes are captured by a subsequent Deploy CLI export. Otherwise, those changes are subject to overwrite.
+
+## Environment-specific values
+
+While it is expected that all environments will share the same set of resource configuration files, environment-specific values can be expressed through separate tool configuration files and dynamic [keyword replacement](keyword-replacement.md).
+
+### Separate Config Files
+
+Specifying a separate tool configuration file per environment can be used to keep the resource configuration files agnostic of environment but still cater for the needs of each environment. At a minimum, you will need to provide separate credentials for each environment, but it is also possible to exclude certain resources, enable deletion and perform dynamic keyword replacement on a per-environment basis.
+
+### Example file structure
+
+```
+project-root
+│
+└───auth0
+│   │   config-dev.json   # Dev env config file
+│   │   config-test.json  # Test env config file
+│   │   config-prod.json  # Prod env config file
+│   │   ... all other resource configuration files
+│
+└───src
+    │   ... your project code
+```
+
+### Dynamic Values via Keyword Replacement
+
+Once separate configurations files are adopted for each environment, keyword replacement via the `AUTH0_KEYWORD_REPLACE_MAPPINGS` configuration property can be used to express the dynamic replacement values depending on the environment. For example, you may find it necessary to have a separate set of allowed origins for your clients (see below). To learn more, see [Keyword Replacement](keyword-replacement.md).
+
+#### Example `config-dev.json`
+
+```json
+{
+  "AUTH0_DOMAIN": "travel0-dev.us.auth0.com",
+  "AUTH0_CLIENT_ID": "PdwQpGy62sHcsV6ufZNEVrV4GDlDhm74",
+  "AUTH0_ALLOW_DELETE": true,
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
+    "ENV": "dev",
+    "ALLOWED_ORIGINS": ["http://localhost:3000", "http://dev.travel0.com"]
+  }
+}
+```
+
+#### Example `config-prod.json`
+
+```json
+{
+  "AUTH0_DOMAIN": "travel0.us.auth0.com",
+  "AUTH0_CLIENT_ID": "vZCEFsDYzXc1x9IomB8dF185e4cdVah5",
+  "AUTH0_ALLOW_DELETE": false,
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
+    "ENV": "prod",
+    "ALLOWED_ORIGINS": ["http://travel0.com"]
+  }
+}
+```

--- a/docs/multi-environment-workflow.md
+++ b/docs/multi-environment-workflow.md
@@ -92,3 +92,7 @@ Once separate configurations files are adopted for each environment, keyword rep
   }
 }
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/multi-environment-workflow.md
+++ b/docs/multi-environment-workflow.md
@@ -21,7 +21,7 @@ It is recommended to have a separate Auth0 tenant/account for each environment y
 
 ## Resource configuration repository
 
-When exported, your Auth0 tenant state will be represented as a set of resource configuration files, either in a [YAML or JSON format](#). In a multi-environment context it is expected to have a single repository of resource configurations that is applied to all environments. In practice, this may exist as a directory in your project’s codebase or in a separate codebase altogether.
+When exported, your Auth0 tenant state will be represented as a set of resource configuration files, either in a [YAML or JSON format](./available-resource-config-formats.md). In a multi-environment context it is expected to have a single repository of resource configurations that is applied to all environments. In practice, this may exist as a directory in your project’s codebase or in a separate codebase altogether.
 
 You should have at least one branch for each tenant in your repository, which allows you to make changes without deploying them (the changes would only deploy when you merged your branch into the master, or primary, branch). With this setup, you can have a continuous integration task for each environment that automatically deploys changes to the targeted environment whenever the master branch receives updates.
 

--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -14,3 +14,7 @@ You may **not** want to consider the Auth0 Terraform Provider if:
 - Your development workflow does not use Terraform, requiring extra setup upfront
 - Your development workflows are primarily concerned with managing your tenants in bulk
 - Your tenant has lots of existing resources, may require significant effort to “import”
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -12,5 +12,5 @@ You may want to consider the Auth0 Terraform Provider if:
 You may **not** want to consider the Auth0 Terraform Provider if:
 
 - Your development workflow does not use Terraform, requiring extra setup upfront
-- Your development workflows are primarily concerned with managing your tenants in bulk, working mostly in a [multi-environment context](multi-environment-workflow.md)
+- Your development workflows are primarily concerned with managing your tenants in bulk
 - Your tenant has lots of existing resources, may require significant effort to “import”

--- a/docs/terraform-provider.md
+++ b/docs/terraform-provider.md
@@ -1,0 +1,16 @@
+# Auth0 Terraform Provider
+
+The Deploy CLI is not the only tool available for managing your Auth0 tenant configuration, there is also an [officially supported Terraform Provider](https://github.com/auth0/terraform-provider-auth0). [Terraform](https://terraform.io/) is a third-party tool for representing your cloud resources’s configurations as code. It has an established plug-in framework that supports a wide array of cloud providers, including Auth0.
+
+Both the Deploy CLI and Terraform Provider exist to help you manage your Auth0 tenant configurations, but each has their own set of pros and cons.
+
+You may want to consider the Auth0 Terraform Provider if:
+
+- Your development workflows already leverages Terraform
+- Your tenant management needs are granular or only pertain to a few specific resources
+
+You may **not** want to consider the Auth0 Terraform Provider if:
+
+- Your development workflow does not use Terraform, requiring extra setup upfront
+- Your development workflows are primarily concerned with managing your tenants in bulk, working mostly in a [multi-environment context](multi-environment-workflow.md)
+- Your tenant has lots of existing resources, may require significant effort to “import”

--- a/docs/using-as-cli.md
+++ b/docs/using-as-cli.md
@@ -83,3 +83,7 @@ a0deploy import -c=config.json --input_file=local
 # Deploying configuration with environment variables ignored
 a0deploy import -c=config.json --input_file=local/tenant.yaml --env=false
 ```
+
+---
+
+[[table of contents]](../README.md#documentation)

--- a/docs/using-as-node-module.md
+++ b/docs/using-as-node-module.md
@@ -104,3 +104,7 @@ console.log("Auth0 configuration applied to tenant successful")
 }).catch((err)=>{
 console.log("Error when applying configuration to Auth0 tenant:",err)
 })
+
+---
+
+[[table of contents]](../README.md#documentation)


### PR DESCRIPTION
## ✏️ Changes

The ninth of a ten PR cascade to publish the content from the Deploy CLI's documentation overhaul. This one focuses on the "Terraform Provider" page.

## 🔗 References

- [Documentation content outline](https://oktawiki.atlassian.net/wiki/spaces/DXCDT/pages/2632975220/Deploy+CLI+Docs+Content+Outline)
- ["Terraform Provider" draft](https://oktawiki.atlassian.net/wiki/spaces/DXCDT/pages/2654340014/Terraform+Provider+Deploy+CLI+Docs)