### PR TITLE
Removing `flatMap` to prevent Node v10 crashes

### DIFF
--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -191,24 +191,26 @@ export default class PromptsHandler extends DefaultHandler {
       .then(({ enabled_locales }) => enabled_locales);
 
     const data = await Promise.all(
-      supportedLanguages.flatMap((language) => {
-        return promptTypes.map((promptType) => {
-          return this.client.prompts
-            .getCustomTextByLanguage({
-              prompt: promptType,
-              language,
-            })
-            .then((customTextData) => {
-              if (isEmpty(customTextData)) return null;
-              return {
+      supportedLanguages
+        .map((language) => {
+          return promptTypes.map((promptType) => {
+            return this.client.prompts
+              .getCustomTextByLanguage({
+                prompt: promptType,
                 language,
-                [promptType]: {
-                  ...customTextData,
-                },
-              };
-            });
-        });
-      })
+              })
+              .then((customTextData) => {
+                if (isEmpty(customTextData)) return null;
+                return {
+                  language,
+                  [promptType]: {
+                    ...customTextData,
+                  },
+                };
+              });
+          });
+        })
+        .reduce((acc, val) => acc.concat(val), []) // TODO: replace .map().reduce() with .flatMap() once we officially eliminate Node v10 support
     ).then((customTextData) => {
       return customTextData
         .filter((customTextData) => {


### PR DESCRIPTION
## ✏️ Changes

A customer reported the error: `supportedLanguages.flatMap is not a function`. It's caused by [this line of code ](https://github.com/auth0/auth0-deploy-cli/blob/677388a512fbe320c99b72e520f5dfa22b7db9eb/src/tools/auth0/handlers/prompts.ts#L194). Customer is using Node v10 which does not support the usage of `.flatMap`. Long term, we should probably be more critical towards the version of node that we support; version 10 reached end of life over a year ago. However, it isn't the right time to have that conversation and this change is easy enough to make.

## 🔗 References

- [ESD-20252](https://auth0team.atlassian.net/browse/ESD-20252)
- [ Line of code in question](https://github.com/auth0/auth0-deploy-cli/blob/677388a512fbe320c99b72e520f5dfa22b7db9eb/src/tools/auth0/handlers/prompts.ts#L194)

## 🎯 Testing

No changes to tests necessary.