### PR TITLE
Adding `publish-npm` context to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,3 +76,5 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+          context:
+            - publish-npm


### PR DESCRIPTION
## ✏️ Changes

To remove the personal NPM token associated with this project, we had to add the `publish-npm` CircleCI context to inject the NPM token to allow authenticated deploys to NPM.

## 🔗 References

- [Node Auth0's implementation](https://github.com/auth0/node-auth0/blob/master/.circleci/config.yml#L75)

## 🎯 Testing

Not necessary.