### PR TITLE
Prevent the updating of migration flags

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -90,7 +90,7 @@ export const sanitizeMigrationFlags = (
   tenant. See: https://github.com/auth0/auth0-deploy-cli/issues/374
   */
 
-  const TENANT_MIGRATION_FLAGS = [
+  const tenantMigrationFlags = [
     'disable_clickjack_protection_headers',
     'enable_mgmt_api_v1',
     'trust_azure_adfs_email_verified_connection_property',
@@ -100,7 +100,7 @@ export const sanitizeMigrationFlags = (
 
   return Object.keys(proposedFlags).reduce(
     (acc: Tenant['flags'], proposedKey: string): Tenant['flags'] => {
-      const isMigrationFlag = TENANT_MIGRATION_FLAGS.includes(proposedKey);
+      const isMigrationFlag = tenantMigrationFlags.includes(proposedKey);
       if (!isMigrationFlag)
         return {
           ...acc,

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -63,7 +63,7 @@ export default class TenantHandler extends DefaultHandler {
     // Do nothing if not set
     if (!tenant) return;
 
-    const existingTenant = this.existing || this.getType();
+    const existingTenant = this.existing || (await this.getType());
 
     const updatedTenant = {
       ...tenant,

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -67,7 +67,10 @@ export default class TenantHandler extends DefaultHandler {
 
     const updatedTenant = {
       ...tenant,
-      flags: sanitizeMigrationFlags(tenant.flags, existingTenant.flags),
+      flags: sanitizeMigrationFlags({
+        existingFlags: existingTenant.flags,
+        proposedFlags: tenant.flags,
+      }),
     };
 
     if (updatedTenant && Object.keys(updatedTenant).length > 0) {
@@ -78,10 +81,13 @@ export default class TenantHandler extends DefaultHandler {
   }
 }
 
-export const sanitizeMigrationFlags = (
-  existingFlags: Tenant['flags'] = {},
-  proposedFlags: Tenant['flags'] = {}
-): Tenant['flags'] => {
+export const sanitizeMigrationFlags = ({
+  existingFlags = {},
+  proposedFlags = {},
+}: {
+  existingFlags: Tenant['flags'];
+  proposedFlags: Tenant['flags'];
+}): Tenant['flags'] => {
   /*
   Tenants can only update migration flags that are already configured.
   If moving configuration from one tenant to another, there may be instances

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -3,11 +3,13 @@ import ValidationError from '../../validationError';
 import DefaultHandler, { order } from './default';
 import { supportedPages, pageNameMap } from './pages';
 import { convertJsonToString } from '../../utils';
-import { Asset, Assets } from '../../../types';
+import { Asset, Assets, Language } from '../../../types';
 
 export const schema = {
   type: 'object',
 };
+
+export type Tenant = Asset & { enabled_locales: Language[]; flags: { [key: string]: boolean } };
 
 const blockPageKeys = [
   ...Object.keys(pageNameMap),
@@ -16,6 +18,8 @@ const blockPageKeys = [
 ];
 
 export default class TenantHandler extends DefaultHandler {
+  existing: Tenant;
+
   constructor(options: DefaultHandler) {
     super({
       ...options,
@@ -25,6 +29,9 @@ export default class TenantHandler extends DefaultHandler {
 
   async getType(): Promise<Asset> {
     const tenant = await this.client.tenant.getSettings();
+
+    this.existing = tenant;
+
     blockPageKeys.forEach((key) => {
       if (tenant[key]) delete tenant[key];
     });
@@ -53,6 +60,13 @@ export default class TenantHandler extends DefaultHandler {
   async processChanges(assets: Assets): Promise<void> {
     const { tenant } = assets;
 
+    // Do nothing if not set
+    if (!tenant) return;
+
+    const existingTenant = this.existing || this.getType();
+
+    const sanitizedFlags = removeUnapplicableMigrationFlags(tenant.flags, existingTenant.flags);
+
     if (tenant && Object.keys(tenant).length > 0) {
       await this.client.tenant.updateSettings(tenant);
       this.updated += 1;
@@ -60,3 +74,45 @@ export default class TenantHandler extends DefaultHandler {
     }
   }
 }
+
+export const removeUnapplicableMigrationFlags = (
+  existingFlags: Tenant['flags'] = {},
+  proposedFlags: Tenant['flags'] = {}
+): Tenant['flags'] => {
+  /*
+  Tenants can only update migration flags that are already configured.
+  If moving configuration from one tenant to another, there may be instances
+  where different migration flags exist and cause an error on update. This 
+  function removes any migration flags that aren't already present on the target
+  tenant. See: https://github.com/auth0/auth0-deploy-cli/issues/374
+  */
+
+  const TENANT_MIGRATION_FLAGS = [
+    'disable_clickjack_protection_headers',
+    'enable_mgmt_api_v1',
+    'trust_azure_adfs_email_verified_connection_property',
+    'include_email_in_reset_pwd_redirect',
+    'include_email_in_verify_email_redirect',
+  ];
+
+  return Object.keys(proposedFlags).reduce(
+    (acc: Tenant['flags'], proposedKey: string): Tenant['flags'] => {
+      const isMigrationFlag = TENANT_MIGRATION_FLAGS.includes(proposedKey);
+      if (!isMigrationFlag)
+        return {
+          ...acc,
+          [proposedKey]: proposedFlags[proposedKey],
+        };
+
+      const keyCurrentlyExists = existingFlags[proposedKey] !== undefined;
+      if (keyCurrentlyExists)
+        return {
+          ...acc,
+          [proposedKey]: proposedFlags[proposedKey],
+        };
+
+      return acc;
+    },
+    {}
+  );
+};

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -65,17 +65,20 @@ export default class TenantHandler extends DefaultHandler {
 
     const existingTenant = this.existing || this.getType();
 
-    const sanitizedFlags = removeUnapplicableMigrationFlags(tenant.flags, existingTenant.flags);
+    const updatedTenant = {
+      ...tenant,
+      flags: sanitizeMigrationFlags(tenant.flags, existingTenant.flags),
+    };
 
-    if (tenant && Object.keys(tenant).length > 0) {
-      await this.client.tenant.updateSettings(tenant);
+    if (updatedTenant && Object.keys(updatedTenant).length > 0) {
+      await this.client.tenant.updateSettings(updatedTenant);
       this.updated += 1;
-      this.didUpdate(tenant);
+      this.didUpdate(updatedTenant);
     }
   }
 }
 
-export const removeUnapplicableMigrationFlags = (
+export const sanitizeMigrationFlags = (
   existingFlags: Tenant['flags'] = {},
   proposedFlags: Tenant['flags'] = {}
 ): Tenant['flags'] => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import {
   PromptsCustomText,
   PromptSettings,
 } from './tools/auth0/handlers/prompts';
-
+import { Tenant } from './tools/auth0/handlers/tenant';
 import { Theme } from './tools/auth0/handlers/themes';
 
 type SharedPaginationParams = {
@@ -145,8 +145,8 @@ export type BaseAuth0APIClient = {
     getAll: () => Promise<Asset[]>;
   };
   tenant: APIClientBaseFunctions & {
-    getSettings: () => Promise<Asset & { enabled_locales: Language[] }>;
-    updateSettings: (arg0: Asset) => Promise<void>;
+    getSettings: () => Promise<Tenant>;
+    updateSettings: (arg0: Partial<Tenant>) => Promise<Tenant>;
   };
   triggers: APIClientBaseFunctions & {
     getTriggerBindings: () => Promise<Asset>;
@@ -230,7 +230,7 @@ export type Assets = Partial<{
   roles: Asset[] | null;
   rules: Asset[] | null;
   rulesConfigs: Asset[] | null;
-  tenant: Asset | null;
+  tenant: Tenant | null;
   triggers: Asset[] | null;
   //non-resource types
   exclude?: {

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -38,6 +38,10 @@ describe('#tenant handler', () => {
     it('should update tenant settings', async () => {
       const auth0 = {
         tenant: {
+          getSettings: () => ({
+            friendly_name: 'Test',
+            default_directory: 'users',
+          }),
           updateSettings: (data) => {
             expect(data).to.be.an('object');
             expect(data.sandbox_version).to.equal('4');

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -103,7 +103,10 @@ describe('#tenant handler', () => {
         'some-flag-2': true,
       };
 
-      const result = tenant.sanitizeMigrationFlags(flags, flags);
+      const result = tenant.sanitizeMigrationFlags({
+        existingFlags: flags,
+        proposedFlags: flags,
+      });
 
       expect(result).to.deep.equal(flags);
     });
@@ -120,7 +123,10 @@ describe('#tenant handler', () => {
         'some-flag-2': true,
       };
 
-      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags({
+        existingFlags,
+        proposedFlags,
+      });
 
       const expectedFlags = (() => {
         const expected = proposedFlags;
@@ -144,7 +150,7 @@ describe('#tenant handler', () => {
         'some-flag-2': false,
       };
 
-      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags({ existingFlags, proposedFlags });
 
       expect(result).to.deep.equal(proposedFlags);
     });
@@ -161,7 +167,7 @@ describe('#tenant handler', () => {
         'some-flag-3': true, // Doesn't currently exist
       };
 
-      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags({ existingFlags, proposedFlags });
 
       expect(result).to.deep.equal(proposedFlags);
     });
@@ -173,9 +179,15 @@ describe('#tenant handler', () => {
         'some-flag-2': true, // Doesn't currently exist
       };
 
-      expect(() => tenant.sanitizeMigrationFlags({}, {})).to.not.throw();
-      expect(() => tenant.sanitizeMigrationFlags(mockFlags, {})).to.not.throw();
-      expect(() => tenant.sanitizeMigrationFlags({}, mockFlags)).to.not.throw();
+      expect(() =>
+        tenant.sanitizeMigrationFlags({ existingFlags: {}, proposedFlags: {} })
+      ).to.not.throw();
+      expect(() =>
+        tenant.sanitizeMigrationFlags({ existingFlags: mockFlags, proposedFlags: {} })
+      ).to.not.throw();
+      expect(() =>
+        tenant.sanitizeMigrationFlags({ existingFlags: {}, proposedFlags: mockFlags })
+      ).to.not.throw();
     });
   });
 });

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -53,7 +53,7 @@ describe('#tenant handler', () => {
     });
   });
 
-  describe('#removeUnapplicableMigrationFlags function', () => {
+  describe('#sanitizeMigrationFlags function', () => {
     it('should not alter flags if existing and proposed are identical', () => {
       const flags = {
         trust_azure_adfs_email_verified_connection_property: true,
@@ -61,7 +61,7 @@ describe('#tenant handler', () => {
         'some-flag-2': true,
       };
 
-      const result = tenant.removeUnapplicableMigrationFlags(flags, flags);
+      const result = tenant.sanitizeMigrationFlags(flags, flags);
 
       expect(result).to.deep.equal(flags);
     });
@@ -78,7 +78,7 @@ describe('#tenant handler', () => {
         'some-flag-2': true,
       };
 
-      const result = tenant.removeUnapplicableMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
 
       const expectedFlags = (() => {
         const expected = proposedFlags;
@@ -102,7 +102,7 @@ describe('#tenant handler', () => {
         'some-flag-2': false,
       };
 
-      const result = tenant.removeUnapplicableMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
 
       expect(result).to.deep.equal(proposedFlags);
     });
@@ -119,7 +119,7 @@ describe('#tenant handler', () => {
         'some-flag-3': true, // Doesn't currently exist
       };
 
-      const result = tenant.removeUnapplicableMigrationFlags(existingFlags, proposedFlags);
+      const result = tenant.sanitizeMigrationFlags(existingFlags, proposedFlags);
 
       expect(result).to.deep.equal(proposedFlags);
     });
@@ -131,9 +131,9 @@ describe('#tenant handler', () => {
         'some-flag-2': true, // Doesn't currently exist
       };
 
-      expect(() => tenant.removeUnapplicableMigrationFlags({}, {})).to.not.throw();
-      expect(() => tenant.removeUnapplicableMigrationFlags(mockFlags, {})).to.not.throw();
-      expect(() => tenant.removeUnapplicableMigrationFlags({}, mockFlags)).to.not.throw();
+      expect(() => tenant.sanitizeMigrationFlags({}, {})).to.not.throw();
+      expect(() => tenant.sanitizeMigrationFlags(mockFlags, {})).to.not.throw();
+      expect(() => tenant.sanitizeMigrationFlags({}, mockFlags)).to.not.throw();
     });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

While working on an adjacent issue with the recurring `You are not allowed to set flag '<SOME_FLAG>' for this tenant.` error, I realized the cause of the issue. It's occurs when taking configuration from one tenant to the next and attempting to apply a migration flag that does not exist on the target tenant. Migration flags are special feature flags that are only configured for certain applicable tenants, users are not able to modify these directly unless already configured. The solution here is to look at the target tenant and see if it has any of the designated migration flags and only allowing those configurations to pass through if they exist.

## 🔗 References

Related issues:

- #374 
- #270 
- #267

## 🎯 Testing

Added unit testing for new flag sanitizing function, also integration tests for this specific scenario. Also performed manual verification testing.