### PR TITLE
Prevent crash when writing page templates with YAML handler

### DIFF
--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -43,7 +43,7 @@ async function dump(context: YAMLContext): Promise<ParsedPages> {
     // Dump html to file
     const htmlFile = path.join(pagesFolder, `${page.name}.html`);
     log.info(`Writing ${htmlFile}`);
-    fs.writeFileSync(htmlFile, page.html);
+    fs.writeFileSync(htmlFile, page.html || '');
     return {
       ...page,
       html: `./pages/${page.name}.html`,

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -136,7 +136,7 @@ describe('#YAML context pages', () => {
   });
 
   it('should not throw if page HTML is not defined', async () => {
-    //See: https://github.com/auth0/auth0-deploy-cli/issues/365
+    // See: https://github.com/auth0/auth0-deploy-cli/issues/365
     const dir = path.join(testDataDir, 'yaml', 'pagesDump');
     cleanThenMkdir(dir);
     const context = new Context(
@@ -145,7 +145,7 @@ describe('#YAML context pages', () => {
     );
 
     context.assets.pages = [
-      { html: undefined, name: 'login' }, //HTML property is not defined here
+      { html: undefined, name: 'login' }, // HTML property is not defined here
     ];
 
     const dumped = await handler.dump(context);
@@ -159,8 +159,8 @@ describe('#YAML context pages', () => {
     });
 
     const pagesFolder = path.join(dir, 'pages');
-    expect(fs.readFileSync(path.join(pagesFolder, 'login.html'), 'utf8')).to.deep.equal("");
-    expect(fs.readdirSync(pagesFolder).length).to.equal(1)
+    expect(fs.readFileSync(path.join(pagesFolder, 'login.html'), 'utf8')).to.deep.equal('');
+    expect(fs.readdirSync(pagesFolder).length).to.equal(1);
   });
 
   it('should dump error_page with html undefined', async () => {

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -135,6 +135,34 @@ describe('#YAML context pages', () => {
     );
   });
 
+  it('should not throw if page HTML is not defined', async () => {
+    //See: https://github.com/auth0/auth0-deploy-cli/issues/365
+    const dir = path.join(testDataDir, 'yaml', 'pagesDump');
+    cleanThenMkdir(dir);
+    const context = new Context(
+      { AUTH0_INPUT_FILE: path.join(dir, 'tennat.yaml') },
+      mockMgmtClient()
+    );
+
+    context.assets.pages = [
+      { html: undefined, name: 'login' }, //HTML property is not defined here
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      pages: [
+        {
+          html: './pages/login.html',
+          name: 'login',
+        },
+      ],
+    });
+
+    const pagesFolder = path.join(dir, 'pages');
+    expect(fs.readFileSync(path.join(pagesFolder, 'login.html'), 'utf8')).to.deep.equal("");
+    expect(fs.readdirSync(pagesFolder).length).to.equal(1)
+  });
+
   it('should dump error_page with html undefined', async () => {
     const dir = path.join(testDataDir, 'yaml', 'pagesDump');
     cleanThenMkdir(dir);


### PR DESCRIPTION
## ✏️ Changes

As noted by #365, sometimes the tool crashes when trying to write an HTML template with an undefined value.I do not know why some pages have undefined HTML, and judging by the [GET tenant settings docs](https://auth0.com/docs/api/management/v2#!/Tenants/tenant_settings_route), those page HTML values _should_ be set. However, it is evident that this situation does occur in production. This PR prevents crashes by writing an empty HTML file, essentially forcing the value to an empty string instead of being undefined.

## 🔗 References

Original issue: #365 

## 🎯 Testing

Added test case for pages that return undefined HTML values.