### PR TITLE
Allowing themes API handler to handle payloads with theme IDs

### DIFF
--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -66,12 +66,21 @@ export default class ThemesHandler extends DefaultHandler {
 
     const currentThemes = await this.getThemes();
 
+    const themeReqPayload = ((): Omit<Theme, 'themeId'> => {
+      // Removing themeId from update and create payloads, otherwise API will error
+      // Theme ID may be required to handle if `--export_ids=true`
+      const payload = themes[0];
+      //@ts-ignore to quell non-optional themeId property, but we know that it's ok to delete
+      delete payload.themeId;
+      return payload;
+    })();
+
     if (currentThemes === null || currentThemes.length === 0) {
-      await this.client.branding.createTheme(themes[0]);
+      await this.client.branding.createTheme(themeReqPayload);
     } else {
       const currentTheme = currentThemes[0];
       // if theme exists, overwrite it otherwise create it
-      await this.client.branding.updateTheme({ id: currentTheme.themeId }, themes[0]);
+      await this.client.branding.updateTheme({ id: currentTheme.themeId }, themeReqPayload);
     }
 
     this.updated += 1;
@@ -98,7 +107,7 @@ export default class ThemesHandler extends DefaultHandler {
 export const schema = {
   type: 'array',
   items: {
-    additionalProperties: false,
+    additionalProperties: true,
     properties: {
       borders: {
         additionalProperties: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,8 +65,11 @@ export type BaseAuth0APIClient = {
     updateSettings: ({}, Asset) => Promise<void>;
     setUniversalLoginTemplate: ({}, Asset) => Promise<void>;
     getDefaultTheme: () => Promise<Theme>;
-    updateTheme: (arg0: { id: string }, Theme) => Promise<Omit<Theme, 'themeId'>>;
-    createTheme: (arg0: Theme) => Promise<Omit<Theme, 'themeId'>>;
+    updateTheme: (
+      arg0: { id: string },
+      arg1: Omit<Theme, 'themeId'>
+    ) => Promise<Omit<Theme, 'themeId'>>;
+    createTheme: (arg0: Omit<Theme, 'themeId'>) => Promise<Omit<Theme, 'themeId'>>;
     deleteTheme: (arg0: { id: string }) => Promise<void>;
   };
   clients: APIClientBaseFunctions;


### PR DESCRIPTION
## ✏️ Changes

Issue #602 reported that the themes handler breaks when exporting config with `--export_ids=true`. The resulting error message is: 

```
error: Problem running command import
error: Schema validation failed loading [
    {
        "keyword": "additionalProperties",
        "dataPath": ".themes[0]",
        "schemaPath": "#/properties/themes/items/additionalProperties",
        "params": {
            "additionalProperty": "themeId"
        },
        "message": "should NOT have additional properties"
    }
]
```

As made obvious by the error, the `themeId` is currently not allowed by schema validations. However, even if `themeId` was deemed valid, the Management API does not allow it to be passed in during the creation or update of themes. So this PR accommodates two changes:

- Allows for additional properties to exist, thereby allowing theme ID but also being a bit more flexible for future themes API changes in the future
- Removing the `themeId` from the themes payload right before making an update or create call to the Management API.

## 🔗 References

Original Github issue: #602 

## 🎯 Testing

Manually tested by exporting with `--export_ids=true` and then making a subsequent import.