### PR TITLE
Fix: Throw error if passwordless email template is missing

### DIFF
--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -35,12 +35,12 @@ function parse(context: DirectoryContext): ParsedConnections {
         ensureProp(connection, 'options.email.body');
         const htmlFileName = path.join(connectionsFolder, connection.options.email.body);
 
-        if (isFile(htmlFileName)) {
-          connection.options.email.body = loadFileAndReplaceKeywords(
-            htmlFileName,
-            context.mappings
+        if (!isFile(htmlFileName)) {
+          throw new Error(
+            `Passwordless email template purportedly located at ${htmlFileName} does not exist for connection. Ensure the existence of this file to proceed with deployment.`
           );
         }
+        connection.options.email.body = loadFileAndReplaceKeywords(htmlFileName, context.mappings);
       }
 
       return connection;

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -31,9 +31,12 @@ async function parse(context: YAMLContext): Promise<ParsedConnections> {
           ensureProp(connection, 'options.email.body');
           const htmlFileName = path.join(connectionsFolder, connection.options.email.body);
 
-          if (isFile(htmlFileName)) {
-            connection.options.email.body = context.loadFile(htmlFileName);
+          if (!isFile(htmlFileName)) {
+            const missingTemplateErrorMessage = `Passwordless email template purportedly located at ${htmlFileName} does not exist for connection. Ensure the existence of this file to proceed with deployment.`;
+            log.error(missingTemplateErrorMessage);
+            throw new Error(missingTemplateErrorMessage);
           }
+          connection.options.email.body = context.loadFile(htmlFileName);
         }
 
         return connection;

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -197,4 +197,32 @@ describe('#directory context connections', () => {
       'client3',
     ]);
   });
+
+  it('should throw error and halt deployment if passwordless email template is missing', async () => {
+    const files = {
+      [constants.CONNECTIONS_DIRECTORY]: {
+        'email.json':
+          '{  "name": "email", "strategy": "email", "options": { "email": { "body": "./email.html" } } }',
+      },
+    };
+
+    const repoDir = path.join(testDataDir, 'directory', 'connections4');
+    createDir(repoDir, files);
+    // Intentionally skip creation of `./email.html` file
+
+    const context = new Context(
+      {
+        AUTH0_INPUT_FILE: repoDir,
+      },
+      mockMgmtClient()
+    );
+
+    await expect(context.load()).to.be.eventually.rejectedWith(
+      `Passwordless email template purportedly located at ${path.join(
+        repoDir,
+        'connections',
+        'email.html'
+      )} does not exist for connection. Ensure the existence of this file to proceed with deployment.`
+    );
+  });
 });

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -119,7 +119,7 @@ describe('#YAML context connections', () => {
     const connectionsPath = path.join(dir, 'connections');
     fs.writeFileSync(yamlFile, yaml);
     fs.ensureDirSync(connectionsPath);
-    // Intentionally skip creating the `./email.html` file
+    // Intentionally skip creation of `./email.html` file
 
     const context = new Context(
       {


### PR DESCRIPTION
## ✏️ Changes

As discovered in #607, if a passwordless email connection's  path to the email template is missing for whatever reason, the body of the email template gets replaced with that path. 

Consider the following configuration:

```yaml
connections:
  - name: email
    strategy: email
    enabled_clients:
      - 3glCfiBX6R8pZBPIaI89F1u5McZ3zoHB
      - PewQpGx73sHcsV6ufVNZNrV4GDlDDm71
    is_domain_connection: false
    options:
      name: email
      email:
        body: ./this-path-wont-resolve/email.html # NOTE THIS PATH
        from: '{{ application.name }} <root@auth0.com>'
        syntax: liquid
        subject: Welcome to {{ application.name }}
      disable_signup: false
      brute_force_protection: true
```

If the above is applied, the process will succeed despite the email template being missing. Further, the body of the template will be literally replaced with the string `./this-path-wont-resolve/email.html`. 

This PR introduces safeguards that will prevent this unintentional destruction from occurring. It works by throwing and thus halting the deployment process from proceeding to the process stage (API requests). This is implemented for both the YAML and directory formats.

## 🔗 References

Original Github issue: #607 

## 🎯 Testing

Added unit tests for both cases.