### PR TITLE
Adding docs and tests for array concatenation via keyword replacement

### DIFF
--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -25,7 +25,7 @@ Example **config.json** file:
 
 By default, the Deploy CLI ingests environment variables, providing the ability to pass credentials and other configurations to the tool without needing to publish to the `config.json` file. Environment variables can either be used to augment the `config.json` file or replace it altogether depending on the project needs.
 
-Non-primitive configuration values like `AUTH0_KEYWORD_MAPPING` and `AUTH0_EXCLUDED` can also be passed in through environment variables so long as these values are properly serialized JSON.
+Non-primitive configuration values like `AUTH0_KEYWORD_REPLACE_MAPPINGS` and `AUTH0_EXCLUDED` can also be passed in through environment variables so long as these values are properly serialized JSON.
 
 To **disable** the consumption of environment variables for either the `import` or `export` commands, pass the `--env=false` argument.
 
@@ -34,8 +34,8 @@ To **disable** the consumption of environment variables for either the `import` 
 ```shell
 # Deploying configuration for YAML formats without a config.json file
 export AUTH0_DOMAIN=<YOUR_AUTH0_DOMAIN>
-export AUTH0_CLIENT_ID=<YOUR_CLIENT_ID> 
-export AUTH0_CLIENT_SECRET=<YOUR_CLIENT_SECRET> 
+export AUTH0_CLIENT_ID=<YOUR_CLIENT_ID>
+export AUTH0_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 
 a0deploy import --input_file=local/tenant.yaml
 

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -36,6 +36,24 @@ clients:
     allowed_logout_urls: @@ALLOWED_LOGOUTS@@
 ```
 
+## Array Concatenation
+
+You may encounter situations where you would want to concatenate values onto a static array through keyword replacement. There is no special syntax to support this case, however, it is possible to achieve this by escaping double quotes in a single string that contains the appropriate values and injecting with the `##` keyword syntax.
+
+### Example
+
+```json
+{
+  "AUTH0_KEYWORD_REPLACEMENT": {
+    "GLOBAL_WEB_ORIGINS": "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\""
+  }
+}
+```
+
+```yaml
+web_origins: [ "http://production-app.com", "https://production-app.com", ##GLOBAL_WEB_ORIGINS## ]
+```
+
 ## Uni-directional Limitation
 
 Currently, the Deploy CLI only preserves keywords during import. Once added, keywords are overwritten with subsequent exports. For this reason, it is recommended that if a workflow heavily depends on keyword replacement, to only perform imports in perpetuity. This limitation is noted in [this Github issue](https://github.com/auth0/auth0-deploy-cli/issues/328).

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -38,9 +38,9 @@ clients:
 
 ## Array Concatenation
 
-You may encounter situations where you would want to concatenate values onto a static array through keyword replacement. There is no special syntax to support this case, however, it is possible to achieve this by escaping double quotes in a single string that contains the appropriate values and injecting with the `##` keyword syntax.
+You may encounter situations where you would want to concatenate values onto a static array through keyword replacement. There is no special syntax to support this case, however, it is possible to achieve this by escaping double quotes in a single string that contains the appropriate values and injecting with the `##` keyword syntax. This technique works for both the [YAML and directory formats](./available-resource-config-formats.md).
 
-### Example
+### Example `config.json`
 
 ```json
 {
@@ -50,8 +50,12 @@ You may encounter situations where you would want to concatenate values onto a s
 }
 ```
 
+### Example `tenant.yaml`
+
 ```yaml
-web_origins: [ "http://production-app.com", "https://production-app.com", ##GLOBAL_WEB_ORIGINS## ]
+clients:
+  - name: Test App
+    web_origins: [ "http://production-app.com", "https://production-app.com", ##GLOBAL_WEB_ORIGINS## ]
 ```
 
 ## Uni-directional Limitation

--- a/docs/keyword-replacement.md
+++ b/docs/keyword-replacement.md
@@ -44,7 +44,7 @@ You may encounter situations where you would want to concatenate values onto a s
 
 ```json
 {
-  "AUTH0_KEYWORD_REPLACEMENT": {
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
     "GLOBAL_WEB_ORIGINS": "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\""
   }
 }

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -233,8 +233,8 @@ describe('#keywordReplacement', () => {
       const inputJSON = `{ 
       "web_origins": [
         ##GLOBAL_WEB_ORIGINS##,
-        "http://a.foo.com",
-        "https://a.foo.com"
+        "http://production-app.com",
+        "https://production-app.com"
       ]
     }`;
 
@@ -248,8 +248,8 @@ describe('#keywordReplacement', () => {
         'http://local.me:8080',
         'http://localhost',
         'http://localhost:3000',
-        'http://a.foo.com',
-        'https://a.foo.com',
+        'http://production-app.com',
+        'https://production-app.com',
       ]);
     });
 
@@ -260,7 +260,7 @@ describe('#keywordReplacement', () => {
       };
 
       const inputYAML =
-        'web_origins: [ ##GLOBAL_WEB_ORIGINS## , "http://a.foo.com", "https://a.foo.com"]';
+        'web_origins: [ ##GLOBAL_WEB_ORIGINS## , "http://production-app.com", "https://production-app.com"]';
 
       const output = utils.keywordReplace(inputYAML, mapping);
 
@@ -270,8 +270,8 @@ describe('#keywordReplacement', () => {
         'http://local.me:8080',
         'http://localhost',
         'http://localhost:3000',
-        'http://a.foo.com',
-        'https://a.foo.com',
+        'http://production-app.com',
+        'https://production-app.com',
       ]);
     });
   });

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -224,7 +224,7 @@ describe('#keywordReplacement', () => {
   });
 
   describe('#array concatenation with keyword replacement', function () {
-    it('should concatenate string array values in directory format', () => {
+    it('should concatenate string array values in directory format with workaround', () => {
       const mapping = {
         // prettier-ignore
         GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line
@@ -253,7 +253,7 @@ describe('#keywordReplacement', () => {
       ]);
     });
 
-    it('should concatenate string array values in YAML format', () => {
+    it('should concatenate string array values in YAML format with workaround', () => {
       const mapping = {
         // prettier-ignore
         GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -222,6 +222,35 @@ describe('#keywordReplacement', () => {
     expect(outputNoWhitespace).to.equal(expected);
   });
 
+  it('should be able to concatenate array string values with keyword replacement', () => {
+    const mapping = {
+      // prettier-ignore
+      GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"",
+    };
+
+    const inputJSON = `{ 
+      "web_origins": [
+        ##GLOBAL_WEB_ORIGINS##,
+        "http://a.foo.com",
+        "https://a.foo.com"
+      ]
+    }`;
+
+    const output = utils.keywordReplace(inputJSON, mapping);
+
+    expect(() => JSON.parse(output)).to.not.throw();
+
+    const parsed = JSON.parse(output);
+
+    expect(parsed.web_origins).to.deep.equal([
+      'http://local.me:8080',
+      'http://localhost',
+      'http://localhost:3000',
+      'http://a.foo.com',
+      'https://a.foo.com',
+    ]);
+  });
+
   describe('#keywordStringReplace', () => {
     const mapping = {
       STRING_REPLACEMENT: 'foo',

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { expect } from 'chai';
+import jsYaml from 'js-yaml';
 import * as utils from '../../src/tools/utils';
 import constants from '../../src/tools/constants';
 
@@ -222,13 +223,14 @@ describe('#keywordReplacement', () => {
     expect(outputNoWhitespace).to.equal(expected);
   });
 
-  it('should be able to concatenate array string values with keyword replacement', () => {
-    const mapping = {
-      // prettier-ignore
-      GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line
-    };
+  describe('#array concatenation with keyword replacement', function () {
+    it('should concatenate string array values in directory format', () => {
+      const mapping = {
+        // prettier-ignore
+        GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line
+      };
 
-    const inputJSON = `{ 
+      const inputJSON = `{ 
       "web_origins": [
         ##GLOBAL_WEB_ORIGINS##,
         "http://a.foo.com",
@@ -236,19 +238,42 @@ describe('#keywordReplacement', () => {
       ]
     }`;
 
-    const output = utils.keywordReplace(inputJSON, mapping);
+      const output = utils.keywordReplace(inputJSON, mapping);
 
-    expect(() => JSON.parse(output)).to.not.throw();
+      expect(() => JSON.parse(output)).to.not.throw();
 
-    const parsed = JSON.parse(output);
+      const parsed = JSON.parse(output);
 
-    expect(parsed.web_origins).to.deep.equal([
-      'http://local.me:8080',
-      'http://localhost',
-      'http://localhost:3000',
-      'http://a.foo.com',
-      'https://a.foo.com',
-    ]);
+      expect(parsed.web_origins).to.deep.equal([
+        'http://local.me:8080',
+        'http://localhost',
+        'http://localhost:3000',
+        'http://a.foo.com',
+        'https://a.foo.com',
+      ]);
+    });
+
+    it('should concatenate string array values in YAML format', () => {
+      const mapping = {
+        // prettier-ignore
+        GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line
+      };
+
+      const inputYAML =
+        'web_origins: [ ##GLOBAL_WEB_ORIGINS## , "http://a.foo.com", "https://a.foo.com"]';
+
+      const output = utils.keywordReplace(inputYAML, mapping);
+
+      const parsed = jsYaml.load(output);
+
+      expect(parsed.web_origins).to.deep.equal([
+        'http://local.me:8080',
+        'http://localhost',
+        'http://localhost:3000',
+        'http://a.foo.com',
+        'https://a.foo.com',
+      ]);
+    });
   });
 
   describe('#keywordStringReplace', () => {

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -225,7 +225,7 @@ describe('#keywordReplacement', () => {
   it('should be able to concatenate array string values with keyword replacement', () => {
     const mapping = {
       // prettier-ignore
-      GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"",
+      GLOBAL_WEB_ORIGINS: "\"http://local.me:8080\", \"http://localhost\", \"http://localhost:3000\"", // eslint-disable-line
     };
 
     const inputJSON = `{ 


### PR DESCRIPTION
## ✏️ Changes

Revisited #184 which poses the question of how to concatenate array string values with the keyword replacement syntax. At this point in time, it is unlikely that we would develop a formal method of handling this case. However, there is a fairly straightforward workaround that leverages the the existing set of features. 

This PR is meant to acknowledge the legitimacy of this use case by adding a reference of it in our documentation and adding tests cases to ensure that the workaround has continued support over time.

## 🔗 References

Original Github issue: #184 

## 🎯 Testing

Adding test cases for the provided workaround.