### PR TITLE
Fix: Allow login page to have no html

### DIFF
--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -35,7 +35,7 @@ function parse(context: DirectoryContext): ParsedPages {
       log.warn(`Skipping pages file ${html} as missing the corresponding '.json' file`);
       return [];
     }
-    if (!html && key === 'error_page') {
+    if (!html && ['error_page', 'login'].includes(key)) {
       //Error pages don't require an HTML template, it is valid to redirect errors to URL
       return {
         ...loadJSON(meta, context.mappings),


### PR DESCRIPTION
## ✏️ Changes

As pointed out by #417, attempting to manage the login page without an accompanying HTML template will result in that page getting skipped during import and the following warning to be presented:

```
warn: Skipping pages file ./local/pages/login.json as missing corresponding '.html' file
```

However, it is legitimate to want to apply changes to the login template settings without actually providing an HTML value. For instance, if you were to disable the login template, in which which case providing an HTML template wouldn't make sense. 

It is worth noting that the presence or absence of HTML value for this page does not dictate wether or not it gets used, that's . Which is to say, there is nothing wrong with having a disabled login page _and_ providing an HTML template at the same time. 

## 🔗 References

Original Github issue: #417 

## 🎯 Testing

Added test case and manually tested.
