### PR TITLE
Fix: permission denied error in CI during `npm install -g`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,7 @@ workflows:
       - e2e_test_as_cli:
           filters:
             branches:
-              only:
-                - master
-                - fix-ci-npm-install # Temporary to test to see if this works
+              only: master
 
   unit_test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ workflows:
       - e2e_test_as_cli:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - fix-ci-npm-install # Temporary to test to see if this works
 
   unit_test:
     jobs:

--- a/test/e2e/e2e-cli.sh
+++ b/test/e2e/e2e-cli.sh
@@ -9,7 +9,7 @@ npm run build
 npm ci --omit=dev #Remove dev dependencies
 
 TARBALL_PATH=$(npm pack)
-npm install -g $TARBALL_PATH
+sudo npm install -g $TARBALL_PATH
 
 echo "{
   \"AUTH0_DOMAIN\": \"$AUTH0_E2E_TENANT_DOMAIN\",


### PR DESCRIPTION
## ✏️ Changes

The updates to the E2E CLI script via #628 are incurring [an error in CI](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1829/workflows/0c98db5e-ec09-4c21-8de4-289ab3acb8fb/jobs/4211) during the global installation step of the tool:

```
Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/auth0-deploy-cli'
npm ERR!  [Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/auth0-deploy-cli'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'mkdir',
npm ERR!   path: '/usr/local/lib/node_modules/auth0-deploy-cli'
npm ERR! }
```


This PR is to fix this error, confirmed by [this successful test run](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1831/workflows/bfaa200b-5c45-4504-a183-8587d35f5f1d/jobs/4219).


## 🔗 References

Initial PR that introduced this work: #628 

## 🎯 Testing

Tested this in CI while this PR was a draft ([result](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1831/workflows/bfaa200b-5c45-4504-a183-8587d35f5f1d/jobs/4219))