### PR TITLE
DXCDT-208: Analytics headers

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { AuthenticationClient, ManagementClient } from 'auth0';
 import YAMLContext from './yaml';
 import DirectoryContext from './directory';
@@ -80,12 +81,18 @@ export const setupContext = async (config: Config): Promise<DirectoryContext | Y
     return clientCredentials.access_token;
   })();
 
+  const nodeVersion = process.version.replace('v', '');
+
   const mgmtClient = new ManagementClient({
     domain: config.AUTH0_DOMAIN,
     token: accessToken,
     retry: { maxRetries: config.AUTH0_API_MAX_RETRIES || 10, enabled: true },
     headers: {
-      'User-agent': `deploy-cli/${packageVersion} (node.js/${process.version.replace('v', '')})`,
+      'User-agent': `deploy-cli/${packageVersion} (node.js/${nodeVersion})`,
+      'Auth0-deploy-cli-version': packageVersion,
+      'Auth0-deploy-cli-node-version': nodeVersion,
+      'Auth0-deploy-cli-os': process.platform,
+      'Auth0-deploy-cli-session': randomUUID(),
     },
   });
 


### PR DESCRIPTION
## ✏️ Changes

Some of the downstream data pipelines and analytics platforms struggle with parsing data from the user-agent header. This PR separates these data attributes into their own specific header. In theory, this _should_ be possible through modifying the correct data pipelines, but that is a much straightforward process. These changes may be reverted when the data pipeline is able to perform this type of parsing.

These are data properties that will help us better understand the usage of this tool to then be able to make data-driven decisions about all aspects of this project.

In addition to the HTTP header separation, this PR also adds a random and arbitrary UUID to mark unique "sessions" this is just an extra data point that will inform how often the tool is invoked.

## 🎯 Testing

This needs to be tested by making a test request and detecting the presence (or absence) of these values in data pipeline. **Still a draft until confirmed**.
