### PR TITLE
Fix: Allowing partial attack protection configurations

### DIFF
--- a/src/tools/auth0/handlers/attackProtection.ts
+++ b/src/tools/auth0/handlers/attackProtection.ts
@@ -32,17 +32,27 @@ export default class AttackProtectionHandler extends DefaultAPIHandler {
   }
 
   objString(item: Asset): string {
-    return super.objString({
-      'breached-password-protection': {
-        enabled: item.breachedPasswordDetection.enabled,
-      },
-      'brute-force-protection': {
-        enabled: item.bruteForceProtection.enabled,
-      },
-      'suspicious-ip-throttling': {
-        enabled: item.suspiciousIpThrottling.enabled,
-      },
-    });
+    const objectString = (() => {
+      let obj = {};
+      if (item.breachedPasswordDetection?.enabled) {
+        obj['breached-password-protection'] = {
+          enabled: item.breachedPasswordDetection.enabled,
+        };
+      }
+      if (item.bruteForceProtection?.enabled) {
+        obj['brute-force-protection'] = {
+          enabled: item.bruteForceProtection.enabled,
+        };
+      }
+      if (item.suspiciousIpThrottling?.enabled) {
+        obj['suspicious-ip-throttling'] = {
+          enabled: item.suspiciousIpThrottling.enabled,
+        };
+      }
+      return obj;
+    })();
+
+    return super.objString(objectString);
   }
 
   async getType(): Promise<Asset> {


### PR DESCRIPTION
## ✏️ Changes

As reported in #637 , a partially configured attack protection resource would result in the following error:

```shell
2022-08-25T18:19:17.173Z - error: Problem running command import during stage processChanges when processing type attackProtection
2022-08-25T18:19:17.173Z - error: Cannot read property 'enabled' of undefined
```

**Example configuration:**
```yaml
attackProtection:
  bruteForceProtection:
    enabled: true
    shields:
      - block
      - user_notification
    mode: count_per_identifier
    max_attempts: 6
```

The root cause is the `objString` which is a generic logging function responsible for printing update summaries for each individual resource. This function for attack protection relied on all of the three sub-properties to exist: `breachedPasswordDetection`,  `bruteForceProtection` and `suspiciousIpThrottling`. However this tool should enable the flexibility to only configure a subset of these.

## 🔗 References

Original Github issue: #637 

## 🎯 Testing

I manually tested these changes but decided to not add any automated tests because this is hardly a functional change.