### PR TITLE
Fix: Ambiguous argument type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -43,12 +43,12 @@ export type ApiResponse = {
 
 export type BaseAuth0APIClient = {
   actions: APIClientBaseFunctions & {
-    deploy: ({ id: string }) => Promise<void>;
+    deploy: (arg0: { id: string }) => Promise<void>;
     getAllTriggers: () => Promise<{ triggers: Asset[] }>;
-    getTriggerBindings: ({ trigger_id: string }) => Promise<{ bindings: Asset[] }>;
+    getTriggerBindings: (arg0: { trigger_id: string }) => Promise<{ bindings: Asset[] }>;
     updateTriggerBindings: (
-      { trigger_id: string },
-      { bindings: Object }
+      arg0: { trigger_id: string },
+      arg1: { bindings: Object }
     ) => Promise<{ bindings: Asset[] }>;
   };
   attackProtection: APIClientBaseFunctions & {
@@ -104,10 +104,10 @@ export type BaseAuth0APIClient = {
     updatePhoneFactorSelectedProvider: (arg0: {}, arg1: Asset) => Promise<void>;
   };
   hooks: APIClientBaseFunctions & {
-    get: ({ id: string }) => Promise<Asset>;
+    get: (arg0: { id: string }) => Promise<Asset>;
     removeSecrets: (arg0: {}, arg1: Asset) => Promise<void>;
     updateSecrets: (arg0: {}, arg1: Asset) => Promise<void>;
-    getSecrets: ({ id: string }) => Promise<Promise<Asset[]>>;
+    getSecrets: (arg0: { id: string }) => Promise<Promise<Asset[]>>;
     addSecrets: (arg0: {}, arg1: Asset) => Promise<void>;
   };
   logStreams: APIClientBaseFunctions;


### PR DESCRIPTION
## ✏️ Changes

A routine [Typescript upgrade from 4.7.4 to 4.8.2](https://github.com/auth0/auth0-deploy-cli/pull/639) has imposed stricter checks on argument type definitions. More specifically, forbidding "unused property renaming in destructuring binding in function types" as described in [this Typescipt project PR](https://github.com/microsoft/TypeScript/pull/41044). 

This was tripping up CircleCI when [running the E2E CLI tests](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1853/workflows/21ab49ca-7cf0-4e8e-8b13-320925524472/jobs/4295) during the Typescript compilation step. The errors looked something like this:

```shell
src/types.ts:46:20 - error TS2842: 'string' is an unused renaming of 'id'. Did you intend to use it as a type annotation?

46     deploy: ({ id: string }) => Promise<void>;
                      ~~~~~~

  src/types.ts:46:28
    46     deploy: ({ id: string }) => Promise<void>;
                                  ~
    We can only write a type for 'id' by adding a type for the entire parameter here.

src/types.ts:48:40 - error TS2842: 'string' is an unused renaming of 'trigger_id'. Did you intend to use it as a type annotation?

48     getTriggerBindings: ({ trigger_id: string }) => Promise<{ bindings: Asset[] }>;
```

For this project, it just means being a little more explicit with the argument definition.

## 🔗 References

- [Related Typescript PR](https://github.com/microsoft/TypeScript/pull/41044)
- [Deploy CLI TS Upgrade PR](https://github.com/auth0/auth0-deploy-cli/pull/639)

## 🎯 Testing

No additional tests necessary. Typescript compiler succeeds now.