### PR TITLE
Adding CI job to ensure code compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
           name: Unit tests with Node LTS
           v: "lts"
       - unit_test:
-          name: Unit tests with current Node version
+          name: Unit tests with Node current
           v: "current"
 
   test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,15 @@ jobs:
           name: Publish package
           command: npm publish
 
+  does_typescript_compile: 
+    docker:
+      - image: cimg/node:<< parameters.v >>
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npx tsc --noEmit
+
 workflows:
   version: 2
 
@@ -79,6 +88,9 @@ workflows:
 
   unit_test:
     jobs:
+      - does_typescript_compile:
+          name: Does Typescript compile?
+          v: "lts"
       - unit_test:
           name: test_lts
           v: "lts"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,10 @@ workflows:
 
   e2e_test:
     jobs:
-      - e2e_test_as_node_module
+      - e2e_test_as_node_module:
+          name: E2E tests as Node module
       - e2e_test_as_cli:
+          name: E2E tests as CLI
           filters:
             branches:
               only: master
@@ -91,16 +93,16 @@ workflows:
       - does_typescript_compile:
           name: Does Typescript compile?
       - unit_test:
-          name: test_lts
+          name: Unit tests with Node LTS
           v: "lts"
       - unit_test:
-          name: test_current
+          name: Unit tests with current Node version
           v: "current"
 
   test_and_deploy:
     jobs:
       - unit_test:
-          name: test_lts
+          name: Unit tests with Node LTS
           v: "lts"
           filters:
             branches:
@@ -108,9 +110,10 @@ workflows:
             tags:
               only: /^v.*/
       - deploy:
+          name: Publish to NPM
           v: "lts"
           requires:
-            - test_lts
+            - Unit tests with Node LTS
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
   does_typescript_compile: 
     docker:
-      - image: cimg/node:<< parameters.v >>
+      - image: cimg/node:current
     working_directory: ~/repo
     steps:
       - checkout
@@ -90,7 +90,6 @@ workflows:
     jobs:
       - does_typescript_compile:
           name: Does Typescript compile?
-          v: "lts"
       - unit_test:
           name: test_lts
           v: "lts"

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,7 @@ export type BaseAuth0APIClient = {
     getMigrations: () => Promise<{ flags: Asset[] }>;
     updateMigrations: (arg0: { flags: Asset[] }) => Promise<void>;
   };
-  organizzations: APIClientBaseFunctions & {
+  organizations: APIClientBaseFunctions & {
     updateEnabledConnection: (arg0: {}, arg1: Asset) => Promise<void>;
     addEnabledConnection: (arg0: {}, arg1: Asset) => Promise<void>;
     removeEnabledConnection: (arg0: Asset) => Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,7 @@ export type BaseAuth0APIClient = {
     getMigrations: () => Promise<{ flags: Asset[] }>;
     updateMigrations: (arg0: { flags: Asset[] }) => Promise<void>;
   };
-  organizations: APIClientBaseFunctions & {
+  organizzations: APIClientBaseFunctions & {
     updateEnabledConnection: (arg0: {}, arg1: Asset) => Promise<void>;
     addEnabledConnection: (arg0: {}, arg1: Asset) => Promise<void>;
     removeEnabledConnection: (arg0: Asset) => Promise<void>;


### PR DESCRIPTION
## ✏️ Changes

#639, which should have been a routine dependency dependabot upgrade, led to an [eventual build failure](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1853/workflows/21ab49ca-7cf0-4e8e-8b13-320925524472/jobs/4295) when merged into master. The error was due to a stricter rules employed by the Typescript compiler. This build failure was caught in the E2E CLI tests, which build the code, but at no point before then do we check to see if the code compiles. This PR addresses this issue by simply ensuring that the code compiles without generating any artifacts.

Additionally, adding names to some of the other jobs because it looks so much better in the PR view.

## 🔗 References

- Original build failure: https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1853/workflows/21ab49ca-7cf0-4e8e-8b13-320925524472/jobs/4295
- Culprit PR that could've been prevented by this job: #639 

## 🎯 Testing

No functional changes. Confirmed working in CircleCI by pushing a bunk code change and job caught it. 