### PR TITLE
Resource-specific docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configura
 - [Keyword Replacement](docs/keyword-replacement.md)
 - [Incorporating Into Multi-environment Workflows](docs/multi-environment-workflow.md)
 - [Excluding Resources From Management](docs/excluding-from-management.md)
+- [Resource-specific Documentation](docs/resource-specific-documentation.md)
 - [Available Resource Formats](docs/available-resource-config-formats.md)
 - [Terraform Provider](docs/terraform-provider.md)
 - [How to Contribute](docs/how-to-contribute.md)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ In order for the Deploy CLI to call the Management API, a dedicated Auth0 applic
    b. Select the appropriate permissions for the resources you wish to manage. Refer to the [Client Scopes](#client-scopes) section for more information.
    c. Click “Authorize”
 
+> ⚠️ **NOTE:** The Deploy CLI's own client grant is unconfigurable by itself to [prevent potentially destructive changes](./docs/resource-specific-documentation.md#client-grants).
+
 #### Client Scopes
 
 The designated application needs to be granted scopes in order to allow the Deploy CLI to execute Management operations.

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -6,7 +6,7 @@ However, there are some notable nuances to be aware of:
 
 ## Client Grants
 
-The c
+The Deploy CLI's own client grant is intentionally not exported nor configurable by itself. This is done to prevent breaking changes, otherwise the tool could potentially revoke access or otherwise crash in the midst of an import. In a multi-tenant, multi-environment context, it is expect that new tenants will have a designated client already established for the Deploy CLI, as mentioned in the [getting started instructions](./../README.md#create-a-dedicated-auth0-application).
 
 ## Prompts
 

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -17,7 +17,7 @@ Multilingual custom text prompts follow a particular hierarchy. Under the root-l
 ```yaml
 prompts:
   customText:
-    <LANGUAGE>: #two character language code
+    <LANGUAGE>: # two character language code
       <PROMPT_ID>: # prompt ID
         <SCREEN_ID>: # prompt screen ID
           <TEXT_ID>: 'Some text'

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -1,0 +1,46 @@
+# Resource-specific Documentation
+
+In general, the Deploy CLI resource configuration files closely match the payload schemas of the [Management API](https://auth0.com/docs/api/management/v2).
+
+However, there are some notable nuances to be aware of:
+
+## Client Grants
+
+The c
+
+## Prompts
+
+Multilingual custom text prompts follow a particular hierarchy. Under the root-level `prompts` resource property is a proprietary `customText` property that is an invention to bundle custom text translations with other prompts settings. Underneath `customText` is the two-character language code. Thirdly is the prompt ID, followed by the screen ID, followed by text ID.
+
+**Hierarchy**
+
+```yaml
+prompts:
+  customText:
+    <LANGUAGE>: #two character language code
+      <PROMPT_ID>: # prompt ID
+        <SCREEN_ID>: # prompt screen ID
+          <TEXT_ID>: 'Some text'
+```
+
+**Example**
+
+```yaml
+prompts:
+  identifier_first: true
+  universal_login_experience: classic
+  customText:
+    en:
+      login:
+        login:
+          description: Login description in english
+          buttonText: Button text
+      mfa:
+        mfa-detect-browser-capabilities:
+          pickAuthenticatorText: 'Try another method'
+          reloadButtonText: 'Reload'
+          noJSErrorTitle: 'JavaScript Required'
+        mfa-login-options:
+          pageTitle: 'Log in to ${clientName}'
+          authenticatorNamesSMS: 'SMS'
+```

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -10,7 +10,7 @@ The Deploy CLI's own client grant is intentionally not exported nor configurable
 
 ## Prompts
 
-Multilingual custom text prompts follow a particular hierarchy. Under the root-level `prompts` resource property is a proprietary `customText` property that is an invention to bundle custom text translations with other prompts settings. Underneath `customText` is the two-character language code. Thirdly is the prompt ID, followed by the screen ID, followed by text ID.
+Multilingual custom text prompts follow a particular hierarchy. Under the root-level `prompts` resource property is a proprietary `customText` property that is used to bundle custom text translations with other prompts settings. Underneath `customText` is the two-character language code. Thirdly is the prompt ID, followed by the screen ID, followed by text ID.
 
 **Hierarchy**
 


### PR DESCRIPTION
## ✏️ Changes

There is a void in documentation about specific resource nuances. This PR is an attempt to establish a dedicated section to document those and provide more insight on how to configure on a per-resource basis. We can see a general ask for this type of documentation with: #132, #142, #197, #286 and #207.

Over time, this section will build up, but for now, I've just started with documenting prompts and client grants. Specifically, noting that the Deploy CLI's own client grant is unmodifiable (#132).

## 🔗 References

Related issues: #132, #142, #197, #286 and #207

## 🎯 Testing

Not necessary.