### PR TITLE
ESD-23225: Ignoring marketplace actions

### DIFF
--- a/src/context/yaml/handlers/actions.ts
+++ b/src/context/yaml/handlers/actions.ts
@@ -88,7 +88,6 @@ async function dump(context: YAMLContext): Promise<ParsedActions> {
       status: action.status,
       secrets: mapSecrets(action.secrets || []),
       supported_triggers: action.supported_triggers,
-      installed_integration_id: action.installed_integration_id,
     })),
   };
 }

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -1,4 +1,4 @@
-import { Asset, Assets } from '../../../types';
+import { Assets } from '../../../types';
 import log from '../../../logger';
 import DefaultHandler from './default';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Action } from './tools/auth0/handlers/actions';
 import {
   PromptTypes,
   ScreenTypes,
@@ -42,7 +43,11 @@ export type ApiResponse = {
 } & { [key in AssetTypes]: Asset[] };
 
 export type BaseAuth0APIClient = {
-  actions: APIClientBaseFunctions & {
+  actions: {
+    getAll: (arg0: SharedPaginationParams) => Promise<Action[]>;
+    create: (arg0: { id: string }) => Promise<Action>;
+    update: (arg0: {}, arg1: Action) => Promise<Action>;
+    delete: (arg0: Asset) => Promise<void>;
     deploy: (arg0: { id: string }) => Promise<void>;
     getAllTriggers: () => Promise<{ triggers: Asset[] }>;
     getTriggerBindings: (arg0: { trigger_id: string }) => Promise<{ bindings: Asset[] }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,7 +206,7 @@ export type Config = {
 export type Asset = { [key: string]: any };
 
 export type Assets = Partial<{
-  actions: Asset[] | null;
+  actions: Action[] | null;
   attackProtection: Asset | null;
   branding: {
     templates?: { template: string; body: string }[] | null;

--- a/test/context/directory/actions.test.js
+++ b/test/context/directory/actions.test.js
@@ -6,7 +6,7 @@ import { constants } from '../../../src/tools';
 
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/actions';
-import { loadJSON } from '../../../src/utils';
+import { getFiles, loadJSON } from '../../../src/utils';
 import { cleanThenMkdir, testDataDir, createDir, mockMgmtClient } from '../../utils';
 
 const actionFiles = {
@@ -143,5 +143,49 @@ describe('#directory context actions', () => {
     expect(fs.readFileSync(path.join(actionsFolder, actionName, 'code.js'), 'utf8')).to.deep.equal(
       codeValidation
     );
+  });
+
+  it('should exclude marketplace actions during dump', async () => {
+    const marketplaceAction = {
+      id: 'D1AF7CCF-7ZAB-417F-81C0-533595A926D8',
+      name: 'Travel0 Integration',
+      supported_triggers: [
+        {
+          id: 'post-login',
+          version: 'v1',
+        },
+      ],
+      created_at: '2022-08-22T23:57:45.856907897Z',
+      updated_at: '2022-08-22T23:57:45.856907897Z',
+      installed_integration_id: '73f156dc-e7aa-47b4-9dda-0ef741205c31',
+      integration: {
+        id: '046042e2-5732-48ef-9313-0a93778ea8b1',
+        catalog_id: 'travel0-action',
+        url_slug: 'travel0-sms',
+        partner_id: 'bea44019-d08d-47cd-b4f9-30074ca2ab69',
+        name: 'Travel0',
+        logo: 'https://cdn.auth0.com/travel0-logo.png',
+        updated_at: '2022-05-03T15:05:45.684007768Z',
+        created_at: '2021-08-24T20:49:30.446854653Z',
+        feature_type: 'action',
+        current_release: {
+          id: '',
+          semver: {},
+        },
+        all_changes_deployed: false,
+      },
+    };
+
+    const dir = path.join(testDataDir, 'directory', 'test4');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.actions = [marketplaceAction];
+
+    handler.dump(context);
+
+    const dumpedFiles = getFiles(dir, ['.json']);
+
+    expect(dumpedFiles).to.have.length(0);
   });
 });

--- a/test/context/yaml/actions.test.js
+++ b/test/context/yaml/actions.test.js
@@ -130,4 +130,50 @@ describe('#YAML context actions', () => {
       codeValidation
     );
   });
+
+  it('should exclude marketplace actions during dump', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'actionsDump');
+    cleanThenMkdir(dir);
+    const context = new Context(
+      { AUTH0_INPUT_FILE: path.join(dir, 'tenant.yaml') },
+      mockMgmtClient()
+    );
+
+    const marketplaceAction = {
+      id: 'D1AF7CCF-7ZAB-417F-81C0-533595A926D8',
+      name: 'Travel0 Integration',
+      supported_triggers: [
+        {
+          id: 'post-login',
+          version: 'v1',
+        },
+      ],
+      created_at: '2022-08-22T23:57:45.856907897Z',
+      updated_at: '2022-08-22T23:57:45.856907897Z',
+      installed_integration_id: '73f156dc-e7aa-47b4-9dda-0ef741205c31',
+      integration: {
+        id: '046042e2-5732-48ef-9313-0a93778ea8b1',
+        catalog_id: 'travel0-action',
+        url_slug: 'travel0-sms',
+        partner_id: 'bea44019-d08d-47cd-b4f9-30074ca2ab69',
+        name: 'Travel0',
+        logo: 'https://cdn.auth0.com/travel0-logo.png',
+        updated_at: '2022-05-03T15:05:45.684007768Z',
+        created_at: '2021-08-24T20:49:30.446854653Z',
+        feature_type: 'action',
+        current_release: {
+          id: '',
+          semver: {},
+        },
+        all_changes_deployed: false,
+      },
+    };
+
+    context.assets.actions = [marketplaceAction];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      actions: [],
+    });
+  });
 });

--- a/test/tools/auth0/handlers/actions.tests.js
+++ b/test/tools/auth0/handlers/actions.tests.js
@@ -385,5 +385,55 @@ describe('#actions handler', () => {
 
       await stageFn.apply(handler, [{ actions: [] }]);
     });
+
+    it('should not remove marketplace action', async () => {
+      let wasDeleteCalled = false;
+
+      const marketplaceAction = {
+        id: 'D1AF7CCF-7ZAB-417F-81C0-533595A926D8',
+        name: 'Travel0 Integration',
+        supported_triggers: [
+          {
+            id: 'post-login',
+            version: 'v1',
+          },
+        ],
+        created_at: '2022-08-22T23:57:45.856907897Z',
+        updated_at: '2022-08-22T23:57:45.856907897Z',
+        installed_integration_id: '73f156dc-e7aa-47b4-9dda-0ef741205c31',
+        integration: {
+          id: '046042e2-5732-48ef-9313-0a93778ea8b1',
+          catalog_id: 'travel0-action',
+          url_slug: 'travel0-sms',
+          partner_id: 'bea44019-d08d-47cd-b4f9-30074ca2ab69',
+          name: 'Travel0',
+          logo: 'https://cdn.auth0.com/travel0-logo.png',
+          updated_at: '2022-05-03T15:05:45.684007768Z',
+          created_at: '2021-08-24T20:49:30.446854653Z',
+          feature_type: 'action',
+          current_release: {
+            id: '',
+            semver: {},
+          },
+          all_changes_deployed: false,
+        },
+      };
+
+      const auth0 = {
+        actions: {
+          getAll: () => Promise.resolve([marketplaceAction]),
+          delete: () => {
+            wasDeleteCalled = true;
+          },
+        },
+        pool,
+      };
+
+      const handler = new actions.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [{ actions: [] }]);
+
+      expect(wasDeleteCalled).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
## ✏️ Changes

Currently, the Auth0 Management API does not have endpoints for managing Marketplace actions. These actions are different enough that they cannot be managed through the regular set of actions endpoints. 

If a tenant has a marketplace-installed action configured, the Deploy CLI will not be able to negotiate the set of change properly, and an error will be incurred. I

Ideally, the Deploy CLI would be able to manage these special types of actions, but without sufficient API functionality, the next best thing is to ignore them as to prevent runtime errors. The first is omitting marketplace actions from being written to configuration files. Secondly, if marketplace actions exist on remote but absent from configuration, the Deploy CLI will recognize these actions and prevent a deletion from occurring.

## 🔗 References

> Include at least one link to an explanation + requirements for this change, and more if at all possible. Typically this is a Jira/GitHub Issue, but could also be links to Zendesk tickets, RFCs, rollout plan or Slack conversations (for Slack conversations, make sure you provide a summary of the conversation under “Changes”).

## 🎯 Testing

> Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why.
> - Make sure you add unit and integration tests.
> - If this is on a hot path, add load or performance tests
> - Especially for dependency updates we also need to make sure that there is no impact on performance.

✅🚫 This change has unit test coverage

✅🚫 This change has integration test coverage

✅🚫 This change has been tested for performance
