### PR TITLE
Set sourceMap to true in tsconfig to allow for debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "./src",
     "allowJs": true,
     "outDir": "./lib",
+    "sourceMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": false,


### PR DESCRIPTION
## ✏️ Changes

Enabled `sourceMap` in `tsconfig.json` so we can debug the application with VSCODE for example. 


## 🔗 References

https://www.typescriptlang.org/tsconfig#sourceMap


>Enables the generation of [sourcemap files](https://developer.mozilla.org/docs/Tools/Debugger/How_to/Use_a_source_map). These files allow debuggers and other tools to display the original TypeScript source code when actually working with the emitted JavaScript files. Source map files are emitted as .js.map (or .jsx.map) files next to the corresponding .js output file.

## 🎯 Testing

![image](https://user-images.githubusercontent.com/28300158/195566125-1ddc0d54-57bc-4026-ac8d-99fe8a01d476.png)

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
