### PR TITLE
Returning all branding settings for YAML branding handler

### DIFF
--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -19,14 +19,6 @@ type ParsedBranding = ParsedAsset<
 >;
 
 async function parse(context: YAMLContext): Promise<ParsedBranding> {
-  // Load the HTML file for each page
-  if (!context.assets.branding)
-    return {
-      branding: {
-        templates: [],
-      },
-    };
-
   if (!context.assets.branding) return { branding: null };
 
   const {
@@ -56,11 +48,11 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedBranding> {
-  const { branding } = context.assets;
+  if (!context.assets.branding) return { branding: null };
 
-  if (!branding) return { branding: null };
+  const { templates: templateConfig, ...branding } = context.assets.branding;
 
-  let templates = branding.templates || [];
+  let templates = templateConfig || [];
 
   // create templates folder
   if (templates.length) {
@@ -91,7 +83,7 @@ async function dump(context: YAMLContext): Promise<ParsedBranding> {
     });
   }
 
-  return { branding: { templates } };
+  return { branding: { templates, ...branding } };
 }
 
 const brandingHandler: YAMLHandler<ParsedBranding> = {

--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -69,14 +69,12 @@ export default class BrandingHandler extends DefaultHandler {
   }
 
   async processChanges(assets: Assets) {
-    const { branding } = assets;
-
     // quit early if there's no branding to process.
-    if (!branding) return;
+    if (!assets.branding) return;
 
     // remove templates, we only want top level branding settings for this API call
-    const brandingSettings = { ...branding };
-    delete brandingSettings.templates;
+    const { templates, ...brandingSettings } = assets.branding;
+
     // Do nothing if not set
     if (brandingSettings && Object.keys(brandingSettings).length) {
       await this.client.branding.updateSettings({}, brandingSettings);
@@ -85,8 +83,8 @@ export default class BrandingHandler extends DefaultHandler {
     }
 
     // handle templates
-    if (branding.templates && branding.templates.length) {
-      const unknownTemplates = branding.templates
+    if (templates && templates.length) {
+      const unknownTemplates = templates
         .filter((t) => !constants.SUPPORTED_BRANDING_TEMPLATES.includes(t.template))
         .map((t) => t.template);
       if (unknownTemplates.length) {
@@ -98,7 +96,7 @@ export default class BrandingHandler extends DefaultHandler {
         );
       }
 
-      const templateDefinition = branding.templates.find(
+      const templateDefinition = templates.find(
         (t) => t.template === constants.UNIVERSAL_LOGIN_TEMPLATE
       );
       if (templateDefinition && templateDefinition.body) {
@@ -107,7 +105,7 @@ export default class BrandingHandler extends DefaultHandler {
           { template: templateDefinition.body }
         );
         this.updated += 1;
-        this.didUpdate(branding.templates);
+        this.didUpdate(templates);
       }
     }
   }

--- a/test/context/yaml/branding.test.js
+++ b/test/context/yaml/branding.test.js
@@ -20,6 +20,10 @@ describe('#YAML context branding templates', () => {
 
     const yaml = `
     branding:
+      colors:
+        page_background: '#0f5a1b'
+        primary: '#0f5a1b'
+      logo_url: https://mycompany.org/logo-5.png
       templates:
         - template: universal_login
           body: universalLogin.html
@@ -30,13 +34,19 @@ describe('#YAML context branding templates', () => {
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
     await context.load();
-    expect(context.assets.branding).to.be.an('object');
-    expect(context.assets.branding.templates).to.deep.equal([
-      {
-        template: 'universal_login',
-        body: htmlTransformed,
+    expect(context.assets.branding).to.deep.equal({
+      colors: {
+        page_background: '#0f5a1b',
+        primary: '#0f5a1b',
       },
-    ]);
+      logo_url: 'https://mycompany.org/logo-5.png',
+      templates: [
+        {
+          template: 'universal_login',
+          body: htmlTransformed,
+        },
+      ],
+    });
   });
 
   it('should dump branding settings, including templates', async () => {
@@ -48,6 +58,11 @@ describe('#YAML context branding templates', () => {
     );
 
     context.assets.branding = {
+      colors: {
+        page_background: '#0f5a1b',
+        primary: '#0f5a1b',
+      },
+      logo_url: 'https://mycompany.org/logo-5.png',
       templates: [
         {
           template: 'universal_login',
@@ -59,6 +74,11 @@ describe('#YAML context branding templates', () => {
     const dumped = await handler.dump(context);
     expect(dumped).to.deep.equal({
       branding: {
+        colors: {
+          page_background: '#0f5a1b',
+          primary: '#0f5a1b',
+        },
+        logo_url: 'https://mycompany.org/logo-5.png',
         templates: [
           {
             template: 'universal_login',


### PR DESCRIPTION
## ✏️ Changes

In response to #648, which highlighted that there was missing branding configurations when using the YAML format. For example, when exporting branding settings in recent versions, there is a clear disprepancy in exported config:

**YAML:**
```
branding:
  templates: []
```

**Directory:**
```
{
  "colors": {
    "primary": "#f55e05",
    "page_background": "#000000"
  },
  "logo_url": "<url>"
}
```

This PR addresses the missing branding properties when using the YAML format. 

## 🔗 References

Original issue: #648 

## 🎯 Testing

One of the reasons this made it's way into production is because the existing test for the branding YAML handler _only_ checked for template-related configuration, completely ignoring all other possible branding settings. This PR introduces more comprehensive testing to assert that all branding config gets dumped.