### PR TITLE
DXCDT-241: Fix loading action code file between different operating systems

### DIFF
--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -14,19 +14,23 @@ type ParsedActions = ParsedAsset<'actions', Asset[]>;
 
 function parse(context: DirectoryContext): ParsedActions {
   const actionsFolder = path.join(context.filePath, constants.ACTIONS_DIRECTORY);
+
   if (!existsMustBeDir(actionsFolder)) return { actions: null }; // Skip
+
   const files = getFiles(actionsFolder, ['.json']);
   const actions = files.map((file) => {
     const action = { ...loadJSON(file, context.mappings) };
     const actionFolder = path.join(constants.ACTIONS_DIRECTORY, `${action.name}`);
+
     if (action.code) {
-      action.code = context.loadFile(action.code, actionFolder);
+      const toUnixPath = somePath => somePath.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
+      action.code = context.loadFile(toUnixPath(action.code), actionFolder);
     }
+
     return action;
   });
-  return {
-    actions,
-  };
+
+  return { actions };
 }
 
 function mapSecrets(secrets) {

--- a/test/context/directory/actions.test.js
+++ b/test/context/directory/actions.test.js
@@ -36,6 +36,33 @@ const actionFiles = {
   },
 };
 
+const actionFilesWin32 = {
+  [constants.ACTIONS_DIRECTORY]: {
+    'code.js':
+      '/** @type {PostLoginAction} */ module.exports = async (event, context) => { console.log(@@replace@@); return {}; };',
+    'action-one.json': `{
+      "name": "action-one",
+      "code": "local\\\\testData\\\\directory\\\\test1\\\\actions\\\\code.js",
+      "runtime": "node12",
+      "dependencies": [
+        {
+          "name": "lodash",
+          "version": "4.17.20"
+        }
+      ],
+      "secrets": [],
+      "status": "built",
+      "supported_triggers": [
+        {
+          "id": "post-login",
+          "version": "v1"
+        }
+      ],
+      "deployed": true
+    }`,
+  },
+};
+
 const actionsTarget = [
   {
     name: 'action-one',
@@ -60,9 +87,21 @@ const actionsTarget = [
 ];
 
 describe('#directory context actions', () => {
-  it('should process actions', async () => {
+  it('should process actions from unix systems', async () => {
     const repoDir = path.join(testDataDir, 'directory', 'test1');
     createDir(repoDir, actionFiles);
+    const config = {
+      AUTH0_INPUT_FILE: repoDir,
+      AUTH0_KEYWORD_REPLACE_MAPPINGS: { replace: 'test-action' },
+    };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+    expect(context.assets.actions).to.deep.equal(actionsTarget);
+  });
+
+  it('should process actions from windows systems', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'test1');
+    createDir(repoDir, actionFilesWin32);
     const config = {
       AUTH0_INPUT_FILE: repoDir,
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { replace: 'test-action' },


### PR DESCRIPTION
## ✏️ Changes

The path separator on windows is `\` but on unix based system `/` and while dumping actions, when the code points to a file, the file's relative path is stored within the code field. This field is calculated based on the separator of the current operating system. 

Ideally we would store the path to the `code.js` file in an agnostic way independent of the platform used, however to not introduce a breaking change we opted in this PR to make the parsing of actions a bit smarter and convert whatever path is in the code field to a unix based path. 

To note that unix notation on relative paths will also work correctly on windows.  

## 🔗 References

- A good read to dive deeper into the topic: https://2ality.com/2022/07/nodejs-path.html#relative-platform-independent-paths. 

## 🎯 Testing

I booted up a virtual machine with windows and followed exactly the reproduction steps as pointed out in #378.

Interestingly enough, when exporting as yaml the path is already in unix notation. 

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance
