### PR TITLE
DXCDT-251: Trigger binding tests

### DIFF
--- a/test/tools/auth0/handlers/triggers.tests.js
+++ b/test/tools/auth0/handlers/triggers.tests.js
@@ -92,7 +92,7 @@ describe('#triggers handler', () => {
               'send-phone-message',
             ]).to.include(trigger_id); // eslint-disable-line camelcase
             expect(bindings).to.be.an('array').that.is.empty; // eslint-disable-line no-unused-expressions
-            timesUpdateTriggerBindingsCalled = timesUpdateTriggerBindingsCalled + 1;
+            timesUpdateTriggerBindingsCalled += 1;
             return Promise.resolve([]);
           },
         },
@@ -160,7 +160,7 @@ describe('#triggers handler', () => {
           updateTriggerBindings: ({ trigger_id }, { bindings }) => {
             expect(trigger_id).to.equal('post-login');
             expect(bindings).to.deep.equal(updatePayload);
-            timesUpdateTriggerBindingsCalled = timesUpdateTriggerBindingsCalled + 1;
+            timesUpdateTriggerBindingsCalled += 1;
             return Promise.resolve(updatePayload);
           },
         },

--- a/test/tools/auth0/handlers/triggers.tests.js
+++ b/test/tools/auth0/handlers/triggers.tests.js
@@ -26,7 +26,7 @@ describe('#triggers handler', () => {
       const handler = new triggers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = {
-        'post-login': [{ action_name: 'action-one', display_name: 'dysplay-name' }],
+        'post-login': [{ action_name: 'action-one', display_name: 'display-name' }],
         'credentials-exchange': [],
         'pre-user-registration': [],
         'post-user-registration': [],
@@ -41,7 +41,7 @@ describe('#triggers handler', () => {
   describe('#triggers process', () => {
     it('should bind a trigger', async () => {
       const triggersBindings = {
-        'post-login': [{ action_name: 'action-one', display_name: 'dysplay-name' }],
+        'post-login': [{ action_name: 'action-one', display_name: 'display-name' }],
         'credentials-exchange': [],
         'pre-user-registration': [],
         'post-user-registration': [],
@@ -62,6 +62,127 @@ describe('#triggers handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [{ triggers: triggersBindings }]);
+    });
+
+    it('should unbind triggers', async () => {
+      let timesUpdateTriggerBindingsCalled = 0;
+
+      const existingTriggerBindings = {
+        'post-login': [{ action_name: 'action-one', display_name: 'email-user' }],
+        'credentials-exchange': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
+        'pre-user-registration': [
+          { action_name: 'action-three', display_name: 'slack-integration' },
+        ],
+        'post-user-registration': [{ action_name: 'action-one', display_name: 'email-user' }],
+        'post-change-password': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
+        'send-phone-message': [{ action_name: 'action-three', display_name: 'slack-integration' }],
+      };
+
+      const auth0 = {
+        actions: {
+          getAllTriggers: () => Promise.resolve(existingTriggerBindings),
+          // eslint-disable-next-line camelcase
+          updateTriggerBindings: ({ trigger_id }, { bindings }) => {
+            expect([
+              'post-login',
+              'credentials-exchange',
+              'pre-user-registration',
+              'post-user-registration',
+              'post-change-password',
+              'send-phone-message',
+            ]).to.include(trigger_id); // eslint-disable-line camelcase
+            expect(bindings).to.be.an('array').that.is.empty; // eslint-disable-line no-unused-expressions
+            timesUpdateTriggerBindingsCalled = timesUpdateTriggerBindingsCalled + 1;
+            return Promise.resolve([]);
+          },
+        },
+        pool,
+        getAllCalled: false,
+      };
+
+      const handler = new triggers.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          triggers: {
+            'post-login': [],
+            'credentials-exchange': [],
+            'pre-user-registration': [],
+            'post-user-registration': [],
+            'post-change-password': [],
+            'send-phone-message': [],
+          },
+        },
+      ]);
+
+      expect(timesUpdateTriggerBindingsCalled).to.equal(6);
+    });
+
+    it('should not update triggers omitted from configuration', async () => {
+      let timesUpdateTriggerBindingsCalled = 0;
+
+      const existingTriggerBindings = {
+        'post-login': [
+          { action_name: 'action-one', display_name: 'email-user' },
+          { action_name: 'action-two', display_name: 'log-to-logger' },
+        ],
+        'credentials-exchange': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
+        'pre-user-registration': [
+          { action_name: 'action-three', display_name: 'slack-integration' },
+        ],
+        'post-user-registration': [{ action_name: 'action-one', display_name: 'email-user' }],
+        'post-change-password': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
+        'send-phone-message': [{ action_name: 'action-three', display_name: 'slack-integration' }],
+      };
+
+      const updatePayload = [
+        {
+          display_name: 'log-to-logger',
+          ref: {
+            type: 'action_name',
+            value: 'action-two',
+          },
+        },
+        {
+          display_name: 'slack-integration',
+          ref: {
+            type: 'action_name',
+            value: 'action-three',
+          },
+        },
+      ];
+
+      const auth0 = {
+        actions: {
+          getAllTriggers: () => Promise.resolve(existingTriggerBindings),
+          // eslint-disable-next-line camelcase
+          updateTriggerBindings: ({ trigger_id }, { bindings }) => {
+            expect(trigger_id).to.equal('post-login');
+            expect(bindings).to.deep.equal(updatePayload);
+            timesUpdateTriggerBindingsCalled = timesUpdateTriggerBindingsCalled + 1;
+            return Promise.resolve(updatePayload);
+          },
+        },
+        pool,
+        getAllCalled: false,
+      };
+
+      const handler = new triggers.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          triggers: {
+            'post-login': [
+              { action_name: 'action-two', display_name: 'log-to-logger' },
+              { action_name: 'action-three', display_name: 'slack-integration' },
+            ], // All other triggers omitted
+          },
+        },
+      ]);
+
+      expect(timesUpdateTriggerBindingsCalled).to.equal(1);
     });
 
     it('should get all triggers', async () => {


### PR DESCRIPTION
### 🔧 Changes

This PR is in response to #623 which brought into question wether or not assigning explicitly-empty trigger bindings would actually unbind actions from a trigger. It turns out that is does, however, I did not find that there was adequate testing for this. So added are two new testing cases:

- Explicitly setting all trigger bindings to empty
- Omitting all but one trigger binding from configuration

### 📚 References

Original issue: #623 

### 🔬 Testing

This PR only includes testing updates.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
