### PR TITLE
DXCDT-237: Fixing undefined HTML page template writing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "a0deploy": "lib/index.js"
       },
       "devDependencies": {
+        "@types/fs-extra": "^9.0.13",
         "@types/lodash": "^4.14.185",
         "@types/mocha": "^9.1.0",
         "@types/nconf": "^0.10.3",
@@ -895,6 +896,15 @@
       "integrity": "sha512-TyPLQaF6w8UlWdv4gj8i46B+INBVzURBNRahCozCSXfsK2VTlL1wNyTlMKw817VHygBtlcl5jfnPadlydr06Yw==",
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/json5": {
@@ -7383,6 +7393,15 @@
       "integrity": "sha512-TyPLQaF6w8UlWdv4gj8i46B+INBVzURBNRahCozCSXfsK2VTlL1wNyTlMKw817VHygBtlcl5jfnPadlydr06Yw==",
       "requires": {
         "@types/express": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/json5": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.14.185",
     "@types/mocha": "^9.1.0",
     "@types/nconf": "^0.10.3",

--- a/src/context/directory/handlers/databases.ts
+++ b/src/context/directory/handlers/databases.ts
@@ -125,13 +125,14 @@ async function dump(context: DirectoryContext): Promise<void> {
         // customScripts option only written if there are scripts
         ...(database.options.customScripts && {
           customScripts: Object.entries(database.options.customScripts)
-            //@ts-ignore
+            //@ts-ignore because we'll fix this in subsequent PR
             .sort(sortCustomScripts)
             .reduce((scripts, [name, script]) => {
               // Dump custom script to file
               const scriptName = sanitize(`${name}.js`);
               const scriptFile = path.join(dbFolder, scriptName);
               log.info(`Writing ${scriptFile}`);
+              //@ts-ignore because we'll fix this in subsequent PR
               fs.writeFileSync(scriptFile, script);
               scripts[name] = `./${scriptName}`;
               return scripts;

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -71,7 +71,7 @@ async function dump(context: DirectoryContext): Promise<void> {
     if (page.html !== undefined) {
       const htmlFile = path.join(pagesFolder, `${page.name}.html`);
       log.info(`Writing ${htmlFile}`);
-      fs.writeFileSync(htmlFile || '', page.html);
+      fs.writeFileSync(htmlFile, page.html);
       metadata.html = `./${page.name}.html`;
     }
 

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -6,9 +6,10 @@ import log from '../../../logger';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { Page } from '../../../tools/auth0/handlers/pages';
 
-type ParsedPages = ParsedAsset<'pages', Asset[]>;
+type ParsedPages = ParsedAsset<'pages', Page[]>;
 
 function parse(context: DirectoryContext): ParsedPages {
   const pagesFolder = path.join(context.filePath, constants.PAGES_DIRECTORY);
@@ -29,7 +30,7 @@ function parse(context: DirectoryContext): ParsedPages {
     return acc;
   }, {});
 
-  const pages = Object.keys(sorted).flatMap((key): Asset[] => {
+  const pages = Object.keys(sorted).flatMap((key): Page[] => {
     const { meta, html } = sorted[key];
     if (!meta) {
       log.warn(`Skipping pages file ${html} as missing the corresponding '.json' file`);

--- a/src/context/directory/handlers/pages.ts
+++ b/src/context/directory/handlers/pages.ts
@@ -60,24 +60,21 @@ function parse(context: DirectoryContext): ParsedPages {
 async function dump(context: DirectoryContext): Promise<void> {
   const pages = context.assets.pages;
 
-  if (!pages) return; // Skip, nothing to dump
+  if (!pages) return;
 
-  // Create Pages folder
   const pagesFolder = path.join(context.filePath, constants.PAGES_DIRECTORY);
   fs.ensureDirSync(pagesFolder);
 
   pages.forEach((page) => {
-    var metadata = { ...page };
+    const metadata = { ...page };
 
-    if (page.name !== 'error_page' || page.html !== undefined) {
-      // Dump template html to file
+    if (page.html !== undefined) {
       const htmlFile = path.join(pagesFolder, `${page.name}.html`);
       log.info(`Writing ${htmlFile}`);
       fs.writeFileSync(htmlFile || '', page.html);
       metadata.html = `./${page.name}.html`;
     }
 
-    // Dump page metadata
     const pageFile = path.join(pagesFolder, `${page.name}.json`);
     dumpJSON(pageFile, metadata);
   });

--- a/src/context/yaml/handlers/databases.ts
+++ b/src/context/yaml/handlers/databases.ts
@@ -58,6 +58,7 @@ async function dump(context: YAMLContext): Promise<ParsedDatabases> {
           // customScripts option only written if there are scripts
           ...(database.options.customScripts && {
             customScripts: Object.entries(database.options.customScripts)
+              //@ts-ignore because we'll fix this in subsequent PR
               .sort(sortCustomScripts)
               .reduce((scripts, [name, script]) => {
                 // Create Database folder
@@ -69,6 +70,7 @@ async function dump(context: YAMLContext): Promise<ParsedDatabases> {
                 const scriptName = sanitize(name);
                 const scriptFile = path.join(dbFolder, `${scriptName}.js`);
                 log.info(`Writing ${scriptFile}`);
+                //@ts-ignore because we'll fix this in subsequent PR
                 fs.writeFileSync(scriptFile, script);
                 scripts[name] = `./databases/${dbName}/${scriptName}.js`;
                 return scripts;

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -41,7 +41,7 @@ async function dump(context: YAMLContext): Promise<ParsedPages> {
 
     const htmlFile = path.join(pagesFolder, `${page.name}.html`);
     log.info(`Writing ${htmlFile}`);
-    fs.writeFileSync(htmlFile, page.html || '');
+    fs.writeFileSync(htmlFile, page.html);
     return {
       ...page,
       html: `./pages/${page.name}.html`,

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -36,11 +36,10 @@ async function dump(context: YAMLContext): Promise<ParsedPages> {
   fs.ensureDirSync(pagesFolder);
 
   pages = pages.map((page) => {
-    if (page.name === 'error_page' && page.html === undefined) {
+    if (page.html === undefined) {
       return page;
     }
 
-    // Dump html to file
     const htmlFile = path.join(pagesFolder, `${page.name}.html`);
     log.info(`Writing ${htmlFile}`);
     fs.writeFileSync(htmlFile, page.html || '');

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -4,9 +4,10 @@ import fs from 'fs-extra';
 import log from '../../../logger';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { Page } from '../../../tools/auth0/handlers/pages';
 
-type ParsedPages = ParsedAsset<'pages', Asset[]>;
+type ParsedPages = ParsedAsset<'pages', Page[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedPages> {
   // Load the HTML file for each page

--- a/src/context/yaml/handlers/pages.ts
+++ b/src/context/yaml/handlers/pages.ts
@@ -31,7 +31,6 @@ async function dump(context: YAMLContext): Promise<ParsedPages> {
     return { pages: null };
   }
 
-  // Create Pages folder
   const pagesFolder = path.join(context.basePath, 'pages');
   fs.ensureDirSync(pagesFolder);
 

--- a/src/tools/auth0/handlers/pages.ts
+++ b/src/tools/auth0/handlers/pages.ts
@@ -12,6 +12,14 @@ export const pageNameMap = {
   error_page: 'error_page',
 };
 
+export type Page = {
+  show_log_link?: boolean;
+  name: string;
+  enabled?: boolean;
+  html?: string;
+  url?: string;
+};
+
 // With this schema, we can only validate property types but not valid properties on per type basis
 export const schema = {
   type: 'array',

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import {
 } from './tools/auth0/handlers/prompts';
 import { Tenant } from './tools/auth0/handlers/tenant';
 import { Theme } from './tools/auth0/handlers/themes';
+import { Page } from './tools/auth0/handlers/pages';
 
 type SharedPaginationParams = {
   checkpoint?: boolean;
@@ -232,7 +233,7 @@ export type Assets = Partial<{
   logStreams: Asset[] | null;
   migrations: Asset[] | null;
   organizations: Asset[] | null;
-  pages: Asset[] | null;
+  pages: Page[] | null;
   prompts: Prompts | null;
   resourceServers: Asset[] | null;
   roles: Asset[] | null;

--- a/test/context/directory/pages.test.js
+++ b/test/context/directory/pages.test.js
@@ -112,11 +112,11 @@ describe('#directory context pages', () => {
 
     context.assets.pages = [
       { html: htmlValidation, name: 'login' },
-      { html: htmlValidation, name: 'password_reset' },
-      { enabled: false, html: htmlValidation, name: 'guardian_multifactor' },
+      { enabled: false, html: htmlValidation, name: 'password_reset' },
+      { name: 'guardian_multifactor' }, //No `html` property defined
       {
         name: 'error_page',
-        url: errorPageUrl,
+        url: errorPageUrl, // URL defined instead of `html` property
         show_log_link: false,
       },
     ];
@@ -136,19 +136,17 @@ describe('#directory context pages', () => {
     expect(loadJSON(path.join(pagesFolder, 'password_reset.json'))).to.deep.equal({
       html: './password_reset.html',
       name: 'password_reset',
+      enabled: false,
     });
     expect(fs.readFileSync(path.join(pagesFolder, 'password_reset.html'), 'utf8')).to.deep.equal(
       htmlValidation
     );
 
     expect(loadJSON(path.join(pagesFolder, 'guardian_multifactor.json'))).to.deep.equal({
-      html: './guardian_multifactor.html',
       name: 'guardian_multifactor',
-      enabled: false,
     });
-    expect(
-      fs.readFileSync(path.join(pagesFolder, 'guardian_multifactor.html'), 'utf8')
-    ).to.deep.equal(htmlValidation);
+    // eslint-disable-next-line no-unused-expressions
+    expect(fs.existsSync(path.join(pagesFolder, 'guardian_multifactor.html'), 'utf8')).to.be.false; // Should not dump template with no HTML
 
     expect(loadJSON(path.join(pagesFolder, 'error_page.json'))).to.deep.equal({
       name: 'error_page',

--- a/test/context/directory/pages.test.js
+++ b/test/context/directory/pages.test.js
@@ -115,7 +115,6 @@ describe('#directory context pages', () => {
       { html: htmlValidation, name: 'password_reset' },
       { enabled: false, html: htmlValidation, name: 'guardian_multifactor' },
       {
-        html: htmlValidation,
         name: 'error_page',
         url: errorPageUrl,
         show_log_link: false,
@@ -152,14 +151,12 @@ describe('#directory context pages', () => {
     ).to.deep.equal(htmlValidation);
 
     expect(loadJSON(path.join(pagesFolder, 'error_page.json'))).to.deep.equal({
-      html: './error_page.html',
       name: 'error_page',
       url: errorPageUrl,
       show_log_link: false,
     });
-    expect(fs.readFileSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.deep.equal(
-      htmlValidation
-    );
+    // eslint-disable-next-line no-unused-expressions
+    expect(fs.existsSync(path.join(pagesFolder, 'error_page.html'), 'utf8')).to.be.false; // Should not dump template with no HTML
   });
 
   it('should dump empty error page even if HTML is not set', async () => {

--- a/test/context/directory/pages.test.js
+++ b/test/context/directory/pages.test.js
@@ -113,7 +113,7 @@ describe('#directory context pages', () => {
     context.assets.pages = [
       { html: htmlValidation, name: 'login' },
       { enabled: false, html: htmlValidation, name: 'password_reset' },
-      { name: 'guardian_multifactor' }, //No `html` property defined
+      { name: 'guardian_multifactor' }, // No `html` property defined
       {
         name: 'error_page',
         url: errorPageUrl, // URL defined instead of `html` property

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -145,22 +145,20 @@ describe('#YAML context pages', () => {
     );
 
     context.assets.pages = [
-      { html: undefined, name: 'login' }, // HTML property is not defined here
+      { name: 'login' }, // HTML property is not defined here
     ];
 
     const dumped = await handler.dump(context);
     expect(dumped).to.deep.equal({
       pages: [
         {
-          html: './pages/login.html',
           name: 'login',
         },
       ],
     });
 
     const pagesFolder = path.join(dir, 'pages');
-    expect(fs.readFileSync(path.join(pagesFolder, 'login.html'), 'utf8')).to.deep.equal('');
-    expect(fs.readdirSync(pagesFolder).length).to.equal(1);
+    expect(fs.readdirSync(pagesFolder).length).to.equal(0);
   });
 
   it('should dump error_page with html undefined', async () => {


### PR DESCRIPTION
### 🔧 Changes

Under certain conditions, the `html` property of template page (error page, MFA guardian, login, etc) will be undefined. The Deploy CLI will simply attempt to write that value and will incur the following error:

```sh
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
```

This can be observed in the Github issues #654 and #365. Previously, this situation occurred because the logic attempted to predict the existence of properties based on the page type alone. Instead, this PR will largely disregard the page type and just observe the existence of `html` property. If it does, write it to disk, otherwise continue.

To help this process, I added a `Page` type that models the uncertainty of the page template properties. Further, I added the `@types/fs-extra` package which will emit a compilation error if a potentially undefined value may be written to a file. 

### 📚 References

Related Github issue: #654, #365

### 🔬 Testing

Added tests for one or more page templates lacking the `html` property.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
