### PR TITLE
DXCDT-252: Adding email provider deletion warning (1/2)

### DIFF
--- a/src/tools/auth0/handlers/emailProvider.ts
+++ b/src/tools/auth0/handlers/emailProvider.ts
@@ -1,5 +1,6 @@
 import DefaultHandler from './default';
-import { Asset, Assets, CalculatedChanges } from '../../../types';
+import { Asset, Assets } from '../../../types';
+import logger from '../../../logger';
 
 export const schema = { type: 'object' };
 
@@ -30,34 +31,38 @@ export default class EmailProviderHandler extends DefaultHandler {
   async processChanges(assets: Assets): Promise<void> {
     const { emailProvider } = assets;
 
-    // Do nothing if not set
     if (!emailProvider) return;
 
-    if (Object.keys(emailProvider).length > 0) {
-      let existing = await this.getType();
+    let existing = await this.getType();
 
-      // Check for existing Email Provider
-      if (existing.name) {
-        if (existing.name !== emailProvider.name) {
-          // Delete the current provider as it's different
-          await this.client.emailProvider.delete();
-          this.didDelete(existing);
-          existing = {};
-        }
+    if (Object.keys(emailProvider).length === 0) {
+      if (this.config('AUTH0_ALLOW_DELETE') === true) {
+        logger.warn(
+          'Setting email provider to empty object will delete the provider in future versions. The current inability to delete is considered a bug. For more details see: https://github.com/auth0/auth0-deploy-cli/issues/653'
+        );
       }
+      return;
+    }
 
-      // Now configure or update depending if it is configured already
-      if (existing.name) {
-        const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
-        const updated = await this.client.emailProvider.update(provider, emailProvider);
-        this.updated += 1;
-        this.didUpdate(updated);
-      } else {
-        const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
-        const created = await this.client.emailProvider.configure(provider, emailProvider);
-        this.created += 1;
-        this.didCreate(created);
+    if (existing.name) {
+      if (existing.name !== emailProvider.name) {
+        // Delete the current provider as it's different
+        await this.client.emailProvider.delete();
+        this.didDelete(existing);
+        existing = {};
       }
+    }
+
+    if (existing.name) {
+      const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
+      const updated = await this.client.emailProvider.update(provider, emailProvider);
+      this.updated += 1;
+      this.didUpdate(updated);
+    } else {
+      const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
+      const created = await this.client.emailProvider.configure(provider, emailProvider);
+      this.created += 1;
+      this.didCreate(created);
     }
   }
 }


### PR DESCRIPTION
### 🔧 Changes

#653 highlighted that email provider cannot be deleted by this tool when setting the configuration as an empty object. Resource deletion is a first-class feature of this tool and an inability to delete is considered a bug. However, there is a small but technically possible chance that folks are passing empty configuration for email provider and not expecting a deletion. To reduce the occurrence of destructive changes, a warning will be displayed initially. After some period of time, the permanent fix to enable email provider will be released (#673) and this warning removed.

### 📚 References

Original Github issue: #653 
Part 2 PR: #673 

### 🔬 Testing

Manually tested by applying this configuration:

```yaml
emailProvider: {}
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
