### PR TITLE
DXCDT-252: Enable deletion of email provider (2/2)

### DIFF
--- a/docs/excluding-from-management.md
+++ b/docs/excluding-from-management.md
@@ -66,14 +66,17 @@ roles: # roles configuration is not omitted
 
 ### Empty
 
-Resource configuration that is explicitly defined as empty. For set-based configurations like hooks, organizations and actions, setting these configurations to an empty set expresses an intentional emptying of those resources. In practice, this would signal a deletion, so long as the [`AUTH0_ALLOW_DELETE` deletion configuration property](configuring-the-deploy-cli.md#AUTH0_ALLOW_DELETE) is enabled. For non-set-based resource configuration like tenant and branding, the concept of emptiness does not apply, will not trigger any deletions or removals.
+Resource configuration that is explicitly defined as empty. For set-based configurations like hooks, organizations and actions, setting these configurations to an empty set expresses an intentional emptying of those resources. In practice, this would signal a deletion, so long as the [`AUTH0_ALLOW_DELETE` deletion configuration property](configuring-the-deploy-cli.md#AUTH0_ALLOW_DELETE) is enabled.
+
+For non-set-based resource configuration like tenant, email provider and branding, the expected behavior when applying an explicitly empty configuration value will depend on the resource. The `tenant`, `branding`, `attackProtection`, and `guardianPhoneFactorSelectedProvider` resources cannot be deleted whereas the `emailProvider` resource can be deleted.
 
 #### Example of emptiness
 
 ```yaml
 hooks: [] # Empty hooks
 connections: [] # Empty connections
-tenant: {} # Effectively a no-op, emptiness does not apply to non-set resource config
+tenant: {} # Effectively a no-op, cannot delete tenant
+emailProvider: {} # Will delete email provider
 ```
 
 ---

--- a/src/tools/auth0/handlers/emailProvider.ts
+++ b/src/tools/auth0/handlers/emailProvider.ts
@@ -34,9 +34,11 @@ export default class EmailProviderHandler extends DefaultHandler {
 
     let existing = await this.getType();
 
-    if (Object.keys(emailProvider).length === 0 && this.config('AUTH0_ALLOW_DELETE') === true) {
-      await this.client.emailProvider.delete();
-      this.didDelete(existing);
+    if (Object.keys(emailProvider).length === 0) {
+      if (this.config('AUTH0_ALLOW_DELETE') === true) {
+        await this.client.emailProvider.delete();
+        this.didDelete(existing);
+      }
       return;
     }
 

--- a/src/tools/auth0/handlers/emailProvider.ts
+++ b/src/tools/auth0/handlers/emailProvider.ts
@@ -1,5 +1,5 @@
 import DefaultHandler from './default';
-import { Asset, Assets, CalculatedChanges } from '../../../types';
+import { Asset, Assets } from '../../../types';
 
 export const schema = { type: 'object' };
 
@@ -30,34 +30,35 @@ export default class EmailProviderHandler extends DefaultHandler {
   async processChanges(assets: Assets): Promise<void> {
     const { emailProvider } = assets;
 
-    // Do nothing if not set
     if (!emailProvider) return;
 
-    if (Object.keys(emailProvider).length > 0) {
-      let existing = await this.getType();
+    let existing = await this.getType();
 
-      // Check for existing Email Provider
-      if (existing.name) {
-        if (existing.name !== emailProvider.name) {
-          // Delete the current provider as it's different
-          await this.client.emailProvider.delete();
-          this.didDelete(existing);
-          existing = {};
-        }
-      }
+    if (Object.keys(emailProvider).length === 0 && this.config('AUTH0_ALLOW_DELETE') === true) {
+      await this.client.emailProvider.delete();
+      this.didDelete(existing);
+      return;
+    }
 
-      // Now configure or update depending if it is configured already
-      if (existing.name) {
-        const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
-        const updated = await this.client.emailProvider.update(provider, emailProvider);
-        this.updated += 1;
-        this.didUpdate(updated);
-      } else {
-        const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
-        const created = await this.client.emailProvider.configure(provider, emailProvider);
-        this.created += 1;
-        this.didCreate(created);
+    if (existing.name) {
+      if (existing.name !== emailProvider.name) {
+        // Delete the current provider as it's different
+        await this.client.emailProvider.delete();
+        this.didDelete(existing);
+        existing = {};
       }
+    }
+
+    if (existing.name) {
+      const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
+      const updated = await this.client.emailProvider.update(provider, emailProvider);
+      this.updated += 1;
+      this.didUpdate(updated);
+    } else {
+      const provider = { name: emailProvider.name, enabled: emailProvider.enabled };
+      const created = await this.client.emailProvider.configure(provider, emailProvider);
+      this.created += 1;
+      this.didCreate(created);
     }
   }
 }

--- a/test/e2e/e2e-utils.ts
+++ b/test/e2e/e2e-utils.ts
@@ -7,12 +7,15 @@ export function decodeBuffer(recordingResponse: Definition['response']) {
   try {
     const isArray = Array.isArray(recordingResponse);
     if (!isArray) return recordingResponse; // Some Auth0 Management API endpoints aren't gzipped, we can tell this if they are an array or not
+    if (recordingResponse.length === 0) return []; // Empty arrays can be piped through as-is too
 
     const decoded = Buffer.from(recordingResponse.join(''), 'hex');
     const unzipped = zlib.gunzipSync(decoded).toString('utf-8');
     return JSON.parse(unzipped);
   } catch (err) {
-    throw new Error(`Error decoding nock hex:\n${err}`);
+    throw new Error(
+      `Error decoding nock response, likely when decoding the response buffer:\n${err}\nRecording response: ${recordingResponse}`
+    );
   }
 }
 

--- a/test/e2e/e2e_recordings.md
+++ b/test/e2e/e2e_recordings.md
@@ -1,0 +1,33 @@
+# How to manage E2E testing recordings
+
+## Re-recording
+
+Ensure `AUTH0_E2E_TENANT_DOMAIN`, `AUTH0_E2E_CLIENT_ID`, `AUTH0_E2E_CLIENT_SECRET` env vars are set.
+
+Then delete the recording file that you are attempting to re-record. Example: `rm test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json`
+
+Finally, run the following command:
+
+```shell
+AUTH0_HTTP_RECORDINGS="record" npx ts-mocha --timeout=120000 -p tsconfig.json test/e2e/e2e.test.ts -g="<SPECIFIC_TEST_TO_TARGET>"
+```
+
+**Example:**
+
+```shell
+AUTH0_HTTP_RECORDINGS="record" npx ts-mocha --timeout=120000 -p tsconfig.json test/e2e/e2e.test.ts -g="AUTH0_ALLOW_DELETE is true"
+```
+
+## Running Tests w/ Recordings
+
+**Run for all:**
+
+```shell
+AUTH0_HTTP_RECORDINGS="lockdown" npm run test:e2e:node-module
+```
+
+**Run a specific test:**
+
+```shell
+AUTH0_HTTP_RECORDINGS="lockdown" npx ts-mocha --timeout=120000 -p tsconfig.json test/e2e/e2e.test.ts -g="should deploy while deleting resources if AUTH0_ALLOW_DELETE is true"
+```

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -6,19 +6,10 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 0,
             "start": 0,
             "limit": 100,
-            "rules": [
-                {
-                    "id": "rul_CZeKvuRVAFUXroeI",
-                    "enabled": true,
-                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
-                    "name": "my-rule",
-                    "order": 2,
-                    "stage": "login_success"
-                }
-            ]
+            "rules": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -30,36 +21,28 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 0,
             "start": 0,
             "limit": 100,
-            "rules": [
-                {
-                    "id": "rul_CZeKvuRVAFUXroeI",
-                    "enabled": true,
-                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
-                    "name": "my-rule",
-                    "order": 2,
-                    "stage": "login_success"
-                }
-            ]
+            "rules": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/rules/rul_CZeKvuRVAFUXroeI",
+        "method": "POST",
+        "path": "/api/v2/rules",
         "body": {
             "name": "my-rule",
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
+            "stage": "login_success",
             "enabled": true,
             "order": 2
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "rul_CZeKvuRVAFUXroeI",
+            "id": "rul_3LlpfTOiEZLdojv1",
             "enabled": true,
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
             "name": "my-rule",
@@ -743,76 +726,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -829,7 +832,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 9,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -899,7 +902,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "THIzPn7nUNYxPIQsOfqDMaPY3b1JdXGX",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -912,368 +915,6 @@
                         "implicit",
                         "refresh_token",
                         "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
                     ],
                     "custom_login_page_on": true
                 }
@@ -1285,7 +926,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+        "path": "/api/v2/clients/THIzPn7nUNYxPIQsOfqDMaPY3b1JdXGX",
         "body": {},
         "status": 204,
         "response": "",
@@ -1294,8 +935,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "API Explorer Application",
             "allowed_clients": [],
@@ -1312,7 +953,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1335,7 +977,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1365,14 +1007,16 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1393,487 +1037,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-        "body": {
-            "name": "Quickstarts API (Test Application)",
-            "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-        "body": {
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
-        "body": {
-            "name": "Test SPA",
-            "allowed_clients": [],
-            "allowed_logout_urls": [
-                "http://localhost:3000"
-            ],
-            "app_type": "spa",
-            "callbacks": [
-                "http://localhost:3000"
-            ],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "expiring",
-                "leeway": 0,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "infinite_token_lifetime": false,
-                "infinite_idle_token_lifetime": false,
-                "rotation_type": "rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "none",
-            "web_origins": [
-                "http://localhost:3000"
-            ]
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Test SPA",
-            "allowed_clients": [],
-            "allowed_logout_urls": [
-                "http://localhost:3000"
-            ],
-            "callbacks": [
-                "http://localhost:3000"
-            ],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "expiring",
-                "leeway": 0,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "infinite_token_lifetime": false,
-                "infinite_idle_token_lifetime": false,
-                "rotation_type": "rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "none",
-            "app_type": "spa",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token"
-            ],
-            "web_origins": [
-                "http://localhost:3000"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-        "body": {
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -1895,7 +1060,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1919,7 +1085,7 @@
             "token_endpoint_auth_method": "client_secret_post",
             "web_origins": []
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1950,15 +1116,17 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
             "allowed_origins": [],
-            "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+            "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1983,22 +1151,516 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
-        "body": "",
-        "status": 200,
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Quickstarts API (Test Application)",
+            "app_type": "non_interactive",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
         "response": {
-            "name": "mandrill",
-            "credentials": {},
-            "default_from_address": "auth0-user@auth0.com",
-            "enabled": false
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Test SPA",
+            "allowed_clients": [],
+            "allowed_logout_urls": [
+                "http://localhost:3000"
+            ],
+            "app_type": "spa",
+            "callbacks": [
+                "http://localhost:3000"
+            ],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "expiring",
+                "leeway": 0,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "infinite_token_lifetime": false,
+                "infinite_idle_token_lifetime": false,
+                "rotation_type": "rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "none",
+            "web_origins": [
+                "http://localhost:3000"
+            ]
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Test SPA",
+            "allowed_clients": [],
+            "allowed_logout_urls": [
+                "http://localhost:3000"
+            ],
+            "callbacks": [
+                "http://localhost:3000"
+            ],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "expiring",
+                "leeway": 0,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "infinite_token_lifetime": false,
+                "infinite_idle_token_lifetime": false,
+                "rotation_type": "rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "none",
+            "app_type": "spa",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token"
+            ],
+            "web_origins": [
+                "http://localhost:3000"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "There is not a configured email provider",
+            "errorCode": "inexistent_email_provider"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
         "path": "/api/v2/emails/provider?enabled=false&name=mandrill",
         "body": {
             "name": "mandrill",
@@ -2008,7 +1670,7 @@
             "default_from_address": "auth0-user@auth0.com",
             "enabled": false
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "name": "mandrill",
             "credentials": {},
@@ -2028,62 +1690,6 @@
         "status": 200,
         "response": {
             "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2119,7 +1725,63 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": true
+        },
+        "status": 200,
+        "response": {
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
         },
@@ -2185,6 +1847,41 @@
             "universal_login_experience": "new",
             "identifier_first": true
         },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/log-streams?paginate=false",
+        "body": "",
+        "status": 200,
+        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -2264,88 +1961,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/log-streams?paginate=false",
-        "body": "",
-        "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000006221",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
-                },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ]
-            }
-        ],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000006221",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -2386,18 +2003,22 @@
                     "name": "auth.token_exchange.fail"
                 }
             ],
-            "status": "active"
+            "sink": {
+                "awsAccountId": "123456789012",
+                "awsRegion": "us-east-2"
+            },
+            "type": "eventbridge"
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000006221",
+            "id": "lst_0000000000007930",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b991d69a-cc44-4338-a2e9-d03efc651b0f/auth0.logs"
             },
             "filters": [
                 {
@@ -2496,49 +2117,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -2571,7 +2149,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2625,7 +2203,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2643,6 +2221,89 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -2682,7 +2343,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2696,98 +2357,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2833,7 +2402,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2851,6 +2420,58 @@
                     ],
                     "web_origins": [
                         "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
                     ],
                     "custom_login_page_on": true
                 },
@@ -2896,60 +2517,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_RnK0arVAFCqDuQxp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2981,60 +2554,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_RnK0arVAFCqDuQxp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3062,80 +2587,25 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_TCTd3NlTfu8widbC",
+        "path": "/api/v2/connections/con_RnK0arVAFCqDuQxp",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-07-29T15:31:51.623Z"
+            "deleted_at": "2022-12-23T22:12:30.181Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_Vtsb73LK2IOecB11",
-        "body": "",
-        "status": 200,
-        "response": {
-            "id": "con_Vtsb73LK2IOecB11",
-            "options": {
-                "mfa": {
-                    "active": true,
-                    "return_enroll_settings": true
-                },
-                "import_mode": false,
-                "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                },
-                "disable_signup": false,
-                "passwordPolicy": "low",
-                "password_history": {
-                    "size": 5,
-                    "enable": false
-                },
-                "strategy_version": 2,
-                "requires_username": true,
-                "password_dictionary": {
-                    "enable": true,
-                    "dictionary": []
-                },
-                "brute_force_protection": true,
-                "password_no_personal_info": {
-                    "enable": true
-                },
-                "password_complexity_options": {
-                    "min_length": 8
-                },
-                "enabledDatabaseCustomization": true
-            },
-            "strategy": "auth0",
-            "name": "boo-baz-db-connection-test",
-            "is_domain_connection": false,
-            "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-            ],
-            "realms": [
-                "boo-baz-db-connection-test"
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/connections/con_Vtsb73LK2IOecB11",
+        "method": "POST",
+        "path": "/api/v2/connections",
         "body": {
+            "name": "boo-baz-db-connection-test",
+            "strategy": "auth0",
             "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3177,25 +2647,25 @@
                 "boo-baz-db-connection-test"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "con_Vtsb73LK2IOecB11",
+            "id": "con_rUXzAOVRUgHFvHTF",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
+                "passwordPolicy": "low",
                 "import_mode": false,
                 "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
                 },
                 "disable_signup": false,
-                "passwordPolicy": "low",
                 "password_history": {
                     "size": 5,
                     "enable": false
@@ -3219,8 +2689,8 @@
             "name": "boo-baz-db-connection-test",
             "is_domain_connection": false,
             "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -3284,49 +2754,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -3359,7 +2786,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3413,7 +2840,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3431,6 +2858,89 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -3470,7 +2980,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3484,98 +2994,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3621,7 +3039,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3639,6 +3057,58 @@
                     ],
                     "web_origins": [
                         "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
                     ],
                     "custom_login_page_on": true
                 },
@@ -3684,12 +3154,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_rUXzAOVRUgHFvHTF",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3732,29 +3202,8 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_VqEWDbU3psp0T0TD",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
                     ]
                 }
             ]
@@ -3769,12 +3218,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_rUXzAOVRUgHFvHTF",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3817,29 +3266,8 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_VqEWDbU3psp0T0TD",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
                     ]
                 }
             ]
@@ -3849,12 +3277,14 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/connections/con_VqEWDbU3psp0T0TD",
+        "method": "POST",
+        "path": "/api/v2/connections",
         "body": {
+            "name": "google-oauth2",
+            "strategy": "google-oauth2",
             "enabled_clients": [
-                "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3866,9 +3296,9 @@
                 "profile": true
             }
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "con_VqEWDbU3psp0T0TD",
+            "id": "con_XLWbXl5xalZlLPmu",
             "options": {
                 "email": true,
                 "scope": [
@@ -3881,8 +3311,8 @@
             "name": "google-oauth2",
             "is_domain_connection": false,
             "enabled_clients": [
-                "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO"
             ],
             "realms": [
                 "google-oauth2"
@@ -4000,49 +3430,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -4075,7 +3462,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4129,7 +3516,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4147,6 +3534,89 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -4186,7 +3656,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4200,98 +3670,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4337,7 +3715,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4355,6 +3733,58 @@
                     ],
                     "web_origins": [
                         "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
                     ],
                     "custom_login_page_on": true
                 },
@@ -4400,7 +3830,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "client_grants": [
@@ -4541,280 +3971,6 @@
                         "read:organization_invitations",
                         "delete:organization_invitations"
                     ]
-                },
-                {
-                    "id": "cgr_r2ghlZPm4B5VAUbP",
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
-                },
-                {
-                    "id": "cgr_ybuyiJ6ov15TDJyE",
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
                 }
             ]
         },
@@ -4823,9 +3979,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_r2ghlZPm4B5VAUbP",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -4959,10 +4117,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_r2ghlZPm4B5VAUbP",
-            "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+            "id": "cgr_wwoVFzkzvqUZTE1i",
+            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5102,9 +4260,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_ybuyiJ6ov15TDJyE",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -5238,10 +4398,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_ybuyiJ6ov15TDJyE",
-            "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+            "id": "cgr_lspk4neTGuXvfcBJ",
+            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5386,43 +4546,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "roles": [
-                {
-                    "id": "rol_yadEKRjs1mhMWTzQ",
-                    "name": "Admin",
-                    "description": "Can read and write things"
-                },
-                {
-                    "id": "rol_fDrBFzOWx5SiJo32",
-                    "name": "Reader",
-                    "description": "Can only read things"
-                },
-                {
-                    "id": "rol_YHX0bBjDw1OKrIVB",
-                    "name": "read_only",
-                    "description": "Read Only"
-                },
-                {
-                    "id": "rol_k6IsMYUJQhlQtN6J",
-                    "name": "read_osnly",
-                    "description": "Readz Only"
-                }
-            ],
-            "start": 0,
-            "limit": 100,
-            "total": 4
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
+            "roles": [],
             "start": 0,
             "limit": 100,
             "total": 0
@@ -5432,60 +4556,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "Admin",
             "description": "Can read and write things"
         },
         "status": 200,
         "response": {
-            "id": "rol_yadEKRjs1mhMWTzQ",
+            "id": "rol_tsvg41q3jEXMHS5h",
             "name": "Admin",
             "description": "Can read and write things"
         },
@@ -5494,32 +4573,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB",
-        "body": {
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_YHX0bBjDw1OKrIVB",
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_fDrBFzOWx5SiJo32",
+            "id": "rol_lEmzu22SgcP4U0s7",
             "name": "Reader",
             "description": "Can only read things"
         },
@@ -5528,15 +4590,32 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J",
+        "method": "POST",
+        "path": "/api/v2/roles",
+        "body": {
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_4ADnAjlDwR6Y5Un8",
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_k6IsMYUJQhlQtN6J",
+            "id": "rol_k33F9UXOS24kZev3",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -5550,56 +4629,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:21.868184183Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node16",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node16",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2022-07-29T15:31:22.444672116Z",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2022-07-29T15:31:22.444672116Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z",
-                        "runtime": "node16",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -5607,8 +4637,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/actions/actions/33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+        "method": "POST",
+        "path": "/api/v2/actions/actions",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -5622,9 +4652,9 @@
                 }
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+            "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -5632,43 +4662,14 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2022-07-29T14:53:28.697788039Z",
-            "updated_at": "2022-07-29T15:31:55.264160919Z",
+            "created_at": "2022-12-23T22:12:32.752916764Z",
+            "updated_at": "2022-12-23T22:12:32.774919739Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node16",
             "status": "pending",
             "secrets": [],
-            "current_version": {
-                "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "runtime": "node16",
-                "status": "BUILT",
-                "number": 2,
-                "build_time": "2022-07-29T15:31:22.444672116Z",
-                "created_at": "2022-07-29T15:31:22.300547590Z",
-                "updated_at": "2022-07-29T15:31:22.446232527Z"
-            },
-            "deployed_version": {
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "dependencies": [],
-                "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                "deployed": true,
-                "number": 2,
-                "built_at": "2022-07-29T15:31:22.444672116Z",
-                "secrets": [],
-                "status": "built",
-                "created_at": "2022-07-29T15:31:22.300547590Z",
-                "updated_at": "2022-07-29T15:31:22.446232527Z",
-                "runtime": "node16",
-                "supported_triggers": [
-                    {
-                        "id": "post-login",
-                        "version": "v2"
-                    }
-                ]
-            },
-            "all_changes_deployed": true
+            "all_changes_deployed": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5682,7 +4683,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -5690,43 +4691,14 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:55.264160919Z",
+                    "created_at": "2022-12-23T22:12:32.752916764Z",
+                    "updated_at": "2022-12-23T22:12:32.774919739Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
-                    "current_version": {
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node16",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2022-07-29T15:31:22.444672116Z",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2022-07-29T15:31:22.444672116Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z",
-                        "runtime": "node16",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
+                    "all_changes_deployed": false
                 }
             ],
             "total": 1,
@@ -5738,19 +4710,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/33c963a5-bcd8-46a6-86ac-20d4a41c13ad/deploy",
+        "path": "/api/v2/actions/actions/2571978b-8443-42bd-84e1-3a59350ca63f/deploy",
         "body": {},
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "94eb1867-248d-4f3b-8394-d8b21ee84f69",
+            "id": "bd128428-ab85-4f81-90a5-118785021e05",
             "deployed": false,
-            "number": 3,
+            "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2022-07-29T15:31:55.740222369Z",
-            "updated_at": "2022-07-29T15:31:55.740222369Z",
+            "created_at": "2022-12-23T22:12:33.116351669Z",
+            "updated_at": "2022-12-23T22:12:33.116351669Z",
             "runtime": "node16",
             "supported_triggers": [
                 {
@@ -5759,7 +4731,7 @@
                 }
             ],
             "action": {
-                "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -5767,8 +4739,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2022-07-29T14:53:28.697788039Z",
-                "updated_at": "2022-07-29T15:31:55.256066843Z",
+                "created_at": "2022-12-23T22:12:32.752916764Z",
+                "updated_at": "2022-12-23T22:12:32.752916764Z",
                 "all_changes_deployed": false
             }
         },
@@ -5782,27 +4754,10 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_UbEQO06JATYNqOSu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    }
-                },
-                {
-                    "id": "org_NKqJCufgliq6yM1o",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                }
-            ],
+            "organizations": [],
             "start": 0,
             "limit": 50,
-            "total": 2
+            "total": 0
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5814,45 +4769,8 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_UbEQO06JATYNqOSu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    }
-                },
-                {
-                    "id": "org_NKqJCufgliq6yM1o",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                }
-            ]
+            "organizations": []
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu/enabled_connections",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o/enabled_connections",
-        "body": "",
-        "status": 200,
-        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -5868,7 +4786,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_rUXzAOVRUgHFvHTF",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5911,12 +4829,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XLWbXl5xalZlLPmu",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5932,8 +4850,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                        "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO"
                     ]
                 }
             ]
@@ -5943,25 +4861,27 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
+            "name": "org2",
             "display_name": "Organization2"
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "org_NKqJCufgliq6yM1o",
+            "name": "org2",
             "display_name": "Organization2",
-            "name": "org2"
+            "id": "org_NRLHyFDZX47A5zQh"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
+            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
@@ -5970,17 +4890,17 @@
             },
             "display_name": "Organization"
         },
-        "status": 200,
+        "status": 201,
         "response": {
+            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
                     "primary": "#57ddff"
                 }
             },
-            "id": "org_UbEQO06JATYNqOSu",
             "display_name": "Organization",
-            "name": "org1"
+            "id": "org_xvQyLVGDOlwSti2P"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6172,7 +5092,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_CZeKvuRVAFUXroeI",
+                    "id": "rul_3LlpfTOiEZLdojv1",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -6196,7 +5116,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_CZeKvuRVAFUXroeI",
+                    "id": "rul_3LlpfTOiEZLdojv1",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -6211,7 +5131,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/rules/rul_CZeKvuRVAFUXroeI",
+        "path": "/api/v2/rules/rul_3LlpfTOiEZLdojv1",
         "body": {},
         "status": 204,
         "response": "",
@@ -6722,76 +5642,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -6856,49 +5796,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -6931,7 +5828,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6985,7 +5882,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7003,6 +5900,89 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -7042,7 +6022,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7056,98 +6036,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -7193,7 +6081,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7213,6 +6101,58 @@
                         "http://localhost:3000"
                     ],
                     "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -7222,7 +6162,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+        "path": "/api/v2/clients/1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
         "body": {},
         "status": 204,
         "response": "",
@@ -7232,7 +6172,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+        "path": "/api/v2/clients/fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
         "body": {},
         "status": 204,
         "response": "",
@@ -7242,7 +6182,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+        "path": "/api/v2/clients/fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
         "body": {},
         "status": 204,
         "response": "",
@@ -7252,7 +6192,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+        "path": "/api/v2/clients/aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
         "body": {},
         "status": 204,
         "response": "",
@@ -7262,7 +6202,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+        "path": "/api/v2/clients/ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
         "body": {},
         "status": 204,
         "response": "",
@@ -7272,7 +6212,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
+        "path": "/api/v2/clients/PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
         "body": {},
         "status": 204,
         "response": "",
@@ -7282,7 +6222,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+        "path": "/api/v2/clients/Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
         "body": {},
         "status": 204,
         "response": "",
@@ -7352,7 +6292,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk",
+            "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -7373,15 +6313,26 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
+        "method": "GET",
+        "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
+        "body": "",
         "status": 200,
         "response": {
+            "name": "mandrill",
+            "credentials": {},
+            "default_from_address": "auth0-user@auth0.com",
             "enabled": false
         },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "DELETE",
+        "path": "/api/v2/emails/provider",
+        "body": {},
+        "status": 204,
+        "response": "",
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -7389,20 +6340,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -7430,7 +6367,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/duo",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -7458,7 +6409,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -7472,7 +6423,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -7539,6 +6504,59 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -7582,68 +6600,20 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/log-streams?paginate=false",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000006221",
+                "id": "lst_0000000000007930",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b991d69a-cc44-4338-a2e9-d03efc651b0f/auth0.logs"
                 },
                 "filters": [
                     {
@@ -7691,7 +6661,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000006221",
+        "path": "/api/v2/log-streams/lst_0000000000007930",
         "body": {},
         "status": 204,
         "response": "",
@@ -7775,7 +6745,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk",
+                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7838,7 +6808,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_rUXzAOVRUgHFvHTF",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7899,7 +6869,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_rUXzAOVRUgHFvHTF",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7951,11 +6921,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_Vtsb73LK2IOecB11",
+        "path": "/api/v2/connections/con_rUXzAOVRUgHFvHTF",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-07-29T15:32:05.407Z"
+            "deleted_at": "2022-12-23T22:12:41.468Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7969,7 +6939,7 @@
             "strategy": "auth0",
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
             ],
             "is_domain_connection": false,
             "options": {
@@ -7987,7 +6957,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_IBGde4qHQvXHQdlV",
+            "id": "con_01XuzDgMqPqIFgWH",
             "options": {
                 "mfa": {
                     "active": true,
@@ -8002,7 +6972,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -8088,7 +7058,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk",
+                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8151,7 +7121,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XLWbXl5xalZlLPmu",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8169,7 +7139,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_IBGde4qHQvXHQdlV",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8187,7 +7157,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
                     ]
                 }
             ]
@@ -8207,7 +7177,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XLWbXl5xalZlLPmu",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8225,7 +7195,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_IBGde4qHQvXHQdlV",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8243,7 +7213,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
                     ]
                 }
             ]
@@ -8254,11 +7224,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_VqEWDbU3psp0T0TD",
+        "path": "/api/v2/connections/con_XLWbXl5xalZlLPmu",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-07-29T15:32:06.310Z"
+            "deleted_at": "2022-12-23T22:12:42.302Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8340,7 +7310,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk",
+                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8554,22 +7524,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_yadEKRjs1mhMWTzQ",
+                    "id": "rol_tsvg41q3jEXMHS5h",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_fDrBFzOWx5SiJo32",
+                    "id": "rol_lEmzu22SgcP4U0s7",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_YHX0bBjDw1OKrIVB",
+                    "id": "rol_4ADnAjlDwR6Y5Un8",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_k6IsMYUJQhlQtN6J",
+                    "id": "rol_k33F9UXOS24kZev3",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -8584,7 +7554,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_tsvg41q3jEXMHS5h/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -8599,7 +7569,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_lEmzu22SgcP4U0s7/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -8614,7 +7584,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_4ADnAjlDwR6Y5Un8/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -8629,7 +7599,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_k33F9UXOS24kZev3/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -8644,7 +7614,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB",
+        "path": "/api/v2/roles/rol_tsvg41q3jEXMHS5h",
         "body": {},
         "status": 200,
         "response": {},
@@ -8654,7 +7624,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32",
+        "path": "/api/v2/roles/rol_lEmzu22SgcP4U0s7",
         "body": {},
         "status": 200,
         "response": {},
@@ -8664,7 +7634,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ",
+        "path": "/api/v2/roles/rol_4ADnAjlDwR6Y5Un8",
         "body": {},
         "status": 200,
         "response": {},
@@ -8674,7 +7644,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J",
+        "path": "/api/v2/roles/rol_k33F9UXOS24kZev3",
         "body": {},
         "status": 200,
         "response": {},
@@ -8690,7 +7660,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -8698,34 +7668,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:55.264160919Z",
+                    "created_at": "2022-12-23T22:12:32.752916764Z",
+                    "updated_at": "2022-12-23T22:12:32.774919739Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "94eb1867-248d-4f3b-8394-d8b21ee84f69",
+                        "id": "bd128428-ab85-4f81-90a5-118785021e05",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
-                        "number": 3,
-                        "build_time": "2022-07-29T15:31:55.873842899Z",
-                        "created_at": "2022-07-29T15:31:55.740222369Z",
-                        "updated_at": "2022-07-29T15:31:55.876044637Z"
+                        "number": 1,
+                        "build_time": "2022-12-23T22:12:33.191362503Z",
+                        "created_at": "2022-12-23T22:12:33.116351669Z",
+                        "updated_at": "2022-12-23T22:12:33.191716636Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "94eb1867-248d-4f3b-8394-d8b21ee84f69",
+                        "id": "bd128428-ab85-4f81-90a5-118785021e05",
                         "deployed": true,
-                        "number": 3,
-                        "built_at": "2022-07-29T15:31:55.873842899Z",
+                        "number": 1,
+                        "built_at": "2022-12-23T22:12:33.191362503Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2022-07-29T15:31:55.740222369Z",
-                        "updated_at": "2022-07-29T15:31:55.876044637Z",
+                        "created_at": "2022-12-23T22:12:33.116351669Z",
+                        "updated_at": "2022-12-23T22:12:33.191716636Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -8746,7 +7716,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/33c963a5-bcd8-46a6-86ac-20d4a41c13ad?force=true",
+        "path": "/api/v2/actions/actions/2571978b-8443-42bd-84e1-3a59350ca63f?force=true",
         "body": {},
         "status": 204,
         "response": "",
@@ -8775,7 +7745,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_xvQyLVGDOlwSti2P",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -8786,7 +7756,7 @@
                     }
                 },
                 {
-                    "id": "org_NKqJCufgliq6yM1o",
+                    "id": "org_NRLHyFDZX47A5zQh",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -8807,7 +7777,12 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_NRLHyFDZX47A5zQh",
+                    "name": "org2",
+                    "display_name": "Organization2"
+                },
+                {
+                    "id": "org_xvQyLVGDOlwSti2P",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -8816,11 +7791,6 @@
                             "primary": "#57ddff"
                         }
                     }
-                },
-                {
-                    "id": "org_NKqJCufgliq6yM1o",
-                    "name": "org2",
-                    "display_name": "Organization2"
                 }
             ]
         },
@@ -8830,7 +7800,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu/enabled_connections",
+        "path": "/api/v2/organizations/org_NRLHyFDZX47A5zQh/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -8840,7 +7810,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o/enabled_connections",
+        "path": "/api/v2/organizations/org_xvQyLVGDOlwSti2P/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -8859,7 +7829,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_IBGde4qHQvXHQdlV",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8877,7 +7847,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
                     ]
                 }
             ]
@@ -8888,7 +7858,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o",
+        "path": "/api/v2/organizations/org_xvQyLVGDOlwSti2P",
         "body": {},
         "status": 204,
         "response": "",
@@ -8898,7 +7868,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu",
+        "path": "/api/v2/organizations/org_NRLHyFDZX47A5zQh",
         "body": {},
         "status": 204,
         "response": "",
@@ -9682,76 +8652,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -9838,7 +8828,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk",
+                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9871,7 +8861,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_IBGde4qHQvXHQdlV",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9889,7 +8879,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
                     ]
                 }
             ]
@@ -9909,7 +8899,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_IBGde4qHQvXHQdlV",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9927,7 +8917,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "doHTOWI2eVPoOv6YJj01kW6LX5EtnDDk"
+                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
                     ]
                 }
             ]
@@ -10010,57 +9000,12 @@
         "method": "GET",
         "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
         "body": "",
-        "status": 200,
-        "response": {
-            "name": "mandrill",
-            "credentials": {},
-            "default_from_address": "auth0-user@auth0.com",
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
         "status": 404,
         "response": {
             "statusCode": 404,
             "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
+            "message": "There is not a configured email provider",
+            "errorCode": "inexistent_email_provider"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10086,52 +9031,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -10165,7 +9065,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
         "response": {
@@ -10181,6 +9081,96 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -10596,216 +9586,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/organizations/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-email/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/invitation/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
@@ -10836,7 +9616,217 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/invitation/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-email/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/organizations/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/common/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -10850,7 +9840,9 @@
         "body": "",
         "status": 200,
         "response": {
-            "flags": {}
+            "flags": {
+                "role_users_offset_pagination_over_thousand": true
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10888,6 +9880,17 @@
                 },
                 {
                     "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -10903,14 +9906,13 @@
                     ]
                 },
                 {
-                    "id": "post-login",
-                    "version": "v2",
+                    "id": "credentials-exchange",
+                    "version": "v1",
                     "status": "DEPRECATED",
                     "runtimes": [
-                        "node12",
-                        "node16"
+                        "node12"
                     ],
-                    "default_runtime": "node16",
+                    "default_runtime": "node12",
                     "compatible_triggers": []
                 },
                 {
@@ -10925,13 +9927,14 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "credentials-exchange",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "id": "pre-user-registration",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
-                        "node12"
+                        "node12",
+                        "node16"
                     ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node16",
                     "compatible_triggers": []
                 },
                 {
@@ -10945,28 +9948,6 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "pre-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "post-user-registration",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -10974,6 +9955,17 @@
                         "node12"
                     ],
                     "default_runtime": "node12",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-user-registration",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
                     "compatible_triggers": []
                 },
                 {
@@ -10999,6 +9991,15 @@
                 },
                 {
                     "id": "send-phone-message",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12"
+                    ],
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "send-phone-message",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -11006,15 +10007,6 @@
                         "node16"
                     ],
                     "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "send-phone-message",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12"
-                    ],
                     "compatible_triggers": []
                 }
             ]
@@ -11130,33 +10122,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "admin_notification",
-                "block"
-            ],
-            "allowlist": [],
-            "stage": {
-                "pre-login": {
-                    "max_attempts": 100,
-                    "rate": 864000
-                },
-                "pre-user-registration": {
-                    "max_attempts": 50,
-                    "rate": 1200
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/attack-protection/brute-force-protection",
         "body": "",
         "status": 200,
@@ -11183,7 +10148,39 @@
             "enabled": false,
             "shields": [],
             "admin_notification_frequency": [],
-            "method": "standard"
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "admin_notification",
+                "block"
+            ],
+            "allowlist": [],
+            "stage": {
+                "pre-login": {
+                    "max_attempts": 100,
+                    "rate": 864000
+                },
+                "pre-user-registration": {
+                    "max_attempts": 50,
+                    "rate": 1200
+                }
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false


### PR DESCRIPTION
### 🔧 Changes

#653 highlighted that email provider cannot be deleted by this tool when setting the configuration as an empty object. Resource deletion is a first-class feature of this tool and an inability to delete is considered a bug. This PR implements that deletions functionality.

This PR is a draft only because it depends on #672 being released for some duration to offer adequate time to warn folks about this fix. Eventually, that warning will be removed and replaced with this PR.

### 📚 References

Original Github issue: #653 
Part 1 PR: #672 

### 🔬 Testing

Added test for empty-object configuration and subsequent deletion.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
