### PR TITLE
Unmark sandbox_version as readonly

### DIFF
--- a/src/readonly.ts
+++ b/src/readonly.ts
@@ -8,7 +8,6 @@ const readOnlyFields: Partial<Record<AssetTypes, string[]>> = {
   connections: ['provisioning_ticket_url', 'realms'],
   databases: ['options.configuration'],
   tenant: [
-    'sandbox_version',
     'sandbox_versions_available',
     'flags.allow_changing_enable_sso',
     'flags.enable_sso',

--- a/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
@@ -4135,7 +4135,8 @@
                 "universal_login": true,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false
-            }
+            },
+            "sandbox_version": "12"
         },
         "status": 200,
         "response": {


### PR DESCRIPTION

### 🔧 Changes

Previously, there was a issue about sandbox_version Import. https://github.com/auth0/auth0-deploy-cli/issues/69 
So mark sandbox_version to readonly, and remove sandbox_version in export.

Now seems to have been resolved that issue. Fix so that sandbox_version is exported again.


### 📚 References
Fix: https://github.com/auth0/auth0-deploy-cli/issues/682

### 🔬 Testing

Following steps
1. Check the Node.js runtime version in tenant advanced settings
2. Export settings with a0deploy
3. Check to appears `sandbox_version` in tenant.json
4. Compare 1 and 3 step's Node version


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
