### PR TITLE
Fix: Client grants test

### DIFF
--- a/test/context/directory/clientGrants.test.js
+++ b/test/context/directory/clientGrants.test.js
@@ -108,7 +108,7 @@ describe('#directory context clientGrants', () => {
     context.assets.clientGrants = [
       { audience: 'https://test.myapp.com/api/v1', client_id: 'My M2M', scope: ['update:account'] },
     ];
-    //local/testData/directory/clientGrantsDump'
+    // local/testData/directory/clientGrantsDump'
     await handler.dump(context);
     const clientGrantsFolder = path.join(dir, constants.CLIENTS_GRANTS_DIRECTORY);
 

--- a/test/context/directory/clientGrants.test.js
+++ b/test/context/directory/clientGrants.test.js
@@ -108,7 +108,7 @@ describe('#directory context clientGrants', () => {
     context.assets.clientGrants = [
       { audience: 'https://test.myapp.com/api/v1', client_id: 'My M2M', scope: ['update:account'] },
     ];
-    // local/testData/directory/clientGrantsDump'
+
     await handler.dump(context);
     const clientGrantsFolder = path.join(dir, constants.CLIENTS_GRANTS_DIRECTORY);
 

--- a/test/context/directory/clientGrants.test.js
+++ b/test/context/directory/clientGrants.test.js
@@ -108,12 +108,13 @@ describe('#directory context clientGrants', () => {
     context.assets.clientGrants = [
       { audience: 'https://test.myapp.com/api/v1', client_id: 'My M2M', scope: ['update:account'] },
     ];
-
+    //local/testData/directory/clientGrantsDump'
     await handler.dump(context);
     const clientGrantsFolder = path.join(dir, constants.CLIENTS_GRANTS_DIRECTORY);
-    expect(
-      loadJSON(path.join(clientGrantsFolder, 'My M2M (https---test.myapp.com-api-v1).json'))
-    ).to.deep.equal(context.assets.clientGrants[0]);
+
+    expect(loadJSON(path.join(clientGrantsFolder, 'My M2M.json'))).to.deep.equal(
+      context.assets.clientGrants[0]
+    );
   });
 
   it('should dump client grants sanitized', async () => {
@@ -127,8 +128,8 @@ describe('#directory context clientGrants', () => {
 
     await handler.dump(context);
     const clientGrantsFolder = path.join(dir, constants.CLIENTS_GRANTS_DIRECTORY);
-    expect(
-      loadJSON(path.join(clientGrantsFolder, 'My M2M (https---test.myapp.com-api-v1).json'))
-    ).to.deep.equal(context.assets.clientGrants[0]);
+    expect(loadJSON(path.join(clientGrantsFolder, 'My M2M.json'))).to.deep.equal(
+      context.assets.clientGrants[0]
+    );
   });
 });


### PR DESCRIPTION
### 🔧 Changes

In #684 we removed the tenant-specific audience name from dumped client grant filenames. However, we did not also adequately adjust the tests. Problematically, these tests were failing in the [Circle CI PR checks](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1979/workflows/5588b594-2bf9-4dee-9861-ac990fb304a2/jobs/4839) but for some reason didn't return a non-zero exit code. Definitely a huge problem but something to fix in a following PR.

This PR fixes our tests to ensure that our testing suite passes.

### 📚 References

Source of breaking tests: #684, see also [failing tests in CI](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1979/workflows/5588b594-2bf9-4dee-9861-ac990fb304a2/jobs/4839).

### 🔬 Testing

Tests pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
