### PR TITLE
Fix: CircleCI check should fail if unit tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "ts-mocha -p tsconfig.json --recursive 'test/**/*.test*' --exclude 'test/e2e/*' --timeout 5000",
     "test:e2e:node-module": "ts-mocha -p tsconfig.json --recursive 'test/e2e/*.test*' --timeout 120000",
     "test:e2e:cli": "sh ./test/e2e/e2e-cli.sh",
-    "test:coverage": "nyc npm run test; nyc report --reporter=lcov",
+    "test:coverage": "nyc npm run test && nyc report --reporter=lcov",
     "build": "rimraf ./lib && npx tsc",
     "dev": "npx tsc --watch",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
### 🔧 Changes

Currently, our unit test suite is failing but gets marked as a pass in CircleCi. The `npm run test:coverage` is a composition of two commands, running unit tests and generating test coverage. These two commands are joined by a semicolon (`;`) which means that the exit code of the first command is essentially ignored in favor of the test coverage command, which rarely exits with a non-zero code. Instead, these commands should be joined with `&&` to signal an error if either two of the commands returns a non-zero exit code. [Example of tests failing in CI but passing the stage.](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1979/workflows/5588b594-2bf9-4dee-9861-ac990fb304a2/jobs/4839?invite=true#step-106-1875)

### 📚 References

[Example](https://app.circleci.com/pipelines/github/auth0/auth0-deploy-cli/1979/workflows/5588b594-2bf9-4dee-9861-ac990fb304a2/jobs/4839?invite=true#step-106-1875)

### 🔬 Testing

Running `npm run test:coverage` followed by `echo $?` to verify the exit code of the resulting change.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
