### PR TITLE
DXCDT-343: More informative error when actions service returns 500

### DIFF
--- a/src/tools/auth0/handlers/actions.ts
+++ b/src/tools/auth0/handlers/actions.ts
@@ -214,6 +214,12 @@ export default class ActionHandler extends DefaultAPIHandler {
         return null;
       }
 
+      if (err.statusCode === 500 && err.message === 'An internal server error occurred') {
+        throw new Error(
+          "Cannot process actions because the actions service is currently unavailable. Retrying may result in a successful operation. Alternatively, adding 'actions' to `AUTH0_EXCLUDED` configuration property will provide ability to skip until service is restored to actions service. This is not an issue with the Deploy CLI."
+        );
+      }
+
       if (isActionsDisabled(err)) {
         log.info('Skipping actions because it is not enabled.');
         return null;


### PR DESCRIPTION
### 🔧 Changes

Over the last year, there have been several instances where the actions service returned generic 500 errors with the message "An internal server error occurred". In all cases, the failure triggered unhelpful errors in the Deploy CLI output, which required direct support. These issues were not immediately resolvable with a Deploy CLI code fix. 

To better serve our end users, we should detect these instances and provide better guidance on what the error is and a couple of possible workarounds for them to explore. The hope is to reduce the time for this issue to be resolved.

It was considered to also skip management of actions when they couldn't be retrieved, but this runs at the risk of putting customers' tenants into unwanted states. It is possible that not creating, deleting or deploying an action could result in downtime. For that reason, it is best to simply let the tool fail and allow customers to choose the workaround that best suits their situation.

### 🔬 Testing

Added unit test.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
