### PR TITLE
DXCDT-282: Support suspended log streams

### DIFF
--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -19,7 +19,7 @@ Example **config.json** file:
 }
 ```
 
-> ⚠️ **NOTE:** Hard-coding credentials is not recommended, and risks secret leakage should this file ever be committed to a public version control system. Instead, passing credentials as [environment variables](#Environment variables) is considered best practice.
+> ⚠️ **NOTE:** Hard-coding credentials is not recommended, and risks secret leakage should this file ever be committed to a public version control system. Instead, passing credentials as [environment variables](#environment-variables) is considered best practice.
 
 ### Environment variables
 

--- a/src/tools/auth0/handlers/logStreams.ts
+++ b/src/tools/auth0/handlers/logStreams.ts
@@ -54,15 +54,12 @@ export default class LogStreamsHandler extends DefaultAPIHandler {
       return this.existing;
     }
 
-    const logStreams = await this.client.logStreams
-      .getAll({ paginate: false })
-      .then((logStreams) => {
-        console.log(logStreams);
-        return logStreams.map((logStream) => {
-          if (logStream.status === 'suspended') delete logStream.status;
-          return logStream;
-        });
-      });
+    const logStreams = await this.client.logStreams.getAll({ paginate: false }).then((logStreams) =>
+      logStreams.map((logStream) => {
+        if (logStream.status === 'suspended') delete logStream.status;
+        return logStream;
+      })
+    );
 
     this.existing = logStreams;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import {
 import { Tenant } from './tools/auth0/handlers/tenant';
 import { Theme } from './tools/auth0/handlers/themes';
 import { Page } from './tools/auth0/handlers/pages';
+import { LogStream } from './tools/auth0/handlers/logStreams';
 
 type SharedPaginationParams = {
   checkpoint?: boolean;
@@ -116,7 +117,12 @@ export type BaseAuth0APIClient = {
     getSecrets: (arg0: { id: string }) => Promise<Promise<Asset[]>>;
     addSecrets: (arg0: {}, arg1: Asset) => Promise<void>;
   };
-  logStreams: APIClientBaseFunctions;
+  logStreams: {
+    getAll: (arg0: SharedPaginationParams) => Promise<LogStream[]>;
+    create: (arg0: { id: string }) => Promise<LogStream>;
+    update: (arg0: {}, arg1: Partial<LogStream>) => Promise<LogStream>;
+    delete: (arg0: Asset) => Promise<void>;
+  };
   migrations: APIClientBaseFunctions & {
     getMigrations: () => Promise<{ flags: Asset[] }>;
     updateMigrations: (arg0: { flags: Asset[] }) => Promise<void>;
@@ -232,7 +238,7 @@ export type Assets = Partial<{
     policies: Asset[]; //TODO: eliminate this intermediate level for consistency
   } | null;
   hooks: Asset[] | null;
-  logStreams: Asset[] | null;
+  logStreams: LogStream[] | null;
   migrations: Asset[] | null;
   organizations: Asset[] | null;
   pages: Page[] | null;

--- a/test/e2e/e2e_recordings.md
+++ b/test/e2e/e2e_recordings.md
@@ -18,6 +18,11 @@ AUTH0_HTTP_RECORDINGS="record" npx ts-mocha --timeout=120000 -p tsconfig.json te
 AUTH0_HTTP_RECORDINGS="record" npx ts-mocha --timeout=120000 -p tsconfig.json test/e2e/e2e.test.ts -g="AUTH0_ALLOW_DELETE is true"
 ```
 
+### Common Errors When Re-Recording
+
+- `access_denied: {"error":"access_denied","error_description":"Unauthorized"}` - The client ID/secret pair provided through `AUTH0_E2E_CLIENT_ID` and `AUTH0_E2E_CLIENT_SECRET` respectively is not valid, double-check their correct values
+- `APIError: Nock: Disallowed net connect for "auth0-deploy-cli-e2e.us.auth0.com:443/oauth/token"` - Recordings already exist for this test, will need to remove the correlating recordings file and try again. Re-recording the entire file is necessary even if HTTP request changes are additive.
+
 ## Running Tests w/ Recordings
 
 **Run for all:**

--- a/test/e2e/e2e_recordings.md
+++ b/test/e2e/e2e_recordings.md
@@ -20,7 +20,7 @@ AUTH0_HTTP_RECORDINGS="record" npx ts-mocha --timeout=120000 -p tsconfig.json te
 
 ### Common Errors When Re-Recording
 
-- `access_denied: {"error":"access_denied","error_description":"Unauthorized"}` - The client ID/secret pair provided through `AUTH0_E2E_CLIENT_ID` and `AUTH0_E2E_CLIENT_SECRET` respectively is not valid, double-check their correct values
+- `access_denied: {"error":"access_denied","error_description":"Unauthorized"}` - The client ID/secret pair provided through `AUTH0_E2E_CLIENT_ID` and `AUTH0_E2E_CLIENT_SECRET` respectively is not valid, double-check their correct values.
 - `APIError: Nock: Disallowed net connect for "auth0-deploy-cli-e2e.us.auth0.com:443/oauth/token"` - Recordings already exist for this test, will need to remove the correlating recordings file and try again. Re-recording the entire file is necessary even if HTTP request changes are additive.
 
 ## Running Tests w/ Recordings

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -42,7 +42,7 @@
         },
         "status": 201,
         "response": {
-            "id": "rul_3LlpfTOiEZLdojv1",
+            "id": "rul_o96lM3TC9Cbi9LlL",
             "enabled": true,
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
             "name": "my-rule",
@@ -109,7 +109,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -153,7 +154,8 @@
                 "rotation_type": "non-rotating"
             },
             "owners": [
-                "mr|samlp|okta|will.vedder@auth0.com"
+                "mr|samlp|okta|will.vedder@auth0.com",
+                "mr|google-oauth2|102002633619863830825"
             ],
             "custom_login_page": "<html>TEST123</html>\n",
             "signing_keys": [
@@ -902,7 +904,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "THIzPn7nUNYxPIQsOfqDMaPY3b1JdXGX",
+                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -926,112 +928,10 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/THIzPn7nUNYxPIQsOfqDMaPY3b1JdXGX",
+        "path": "/api/v2/clients/eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
         "body": {},
         "status": 204,
         "response": "",
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -1126,7 +1026,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+            "client_id": "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1154,6 +1054,108 @@
         "method": "POST",
         "path": "/api/v2/clients",
         "body": {
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
             "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
             "client_metadata": {
@@ -1215,7 +1217,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+            "client_id": "0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1293,7 +1295,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+            "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1398,7 +1400,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+            "client_id": "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1412,6 +1414,108 @@
                 "authorization_code",
                 "implicit",
                 "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
                 "client_credentials"
             ],
             "custom_login_page_on": true
@@ -1517,7 +1621,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+            "client_id": "MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1535,108 +1639,6 @@
             ],
             "web_origins": [
                 "http://localhost:3000"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
             ],
             "custom_login_page_on": true
         },
@@ -1683,76 +1685,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
@@ -1781,7 +1713,77 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": true
+        },
+        "status": 200,
+        "response": {
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/duo",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -1852,31 +1854,6 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/log-streams?paginate=false",
         "body": "",
@@ -1934,6 +1911,31 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
         "path": "/api/v2/attack-protection/brute-force-protection",
         "body": {
             "enabled": true,
@@ -1955,6 +1957,32 @@
             "mode": "count_per_identifier_and_ip",
             "allowlist": [],
             "max_attempts": 66
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
+        "body": {
+            "name": "Suspended DD Log Stream",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            },
+            "type": "datadog"
+        },
+        "status": 200,
+        "response": {
+            "id": "lst_0000000000008172",
+            "name": "Suspended DD Log Stream",
+            "type": "datadog",
+            "status": "active",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2011,14 +2039,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000007930",
+            "id": "lst_0000000000008173",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b991d69a-cc44-4338-a2e9-d03efc651b0f/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-f4a53afc-5b5a-4c8e-8d36-695862fbb9db/auth0.logs"
             },
             "filters": [
                 {
@@ -2117,6 +2145,49 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -2149,7 +2220,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+                    "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2203,7 +2274,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                    "client_id": "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2221,49 +2292,6 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -2291,7 +2319,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2343,7 +2371,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+                    "client_id": "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2402,7 +2430,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+                    "client_id": "MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2459,7 +2487,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "client_id": "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2491,7 +2519,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -2522,7 +2551,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_RnK0arVAFCqDuQxp",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2559,7 +2588,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_RnK0arVAFCqDuQxp",
+                    "id": "con_01XuzDgMqPqIFgWH",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2587,11 +2616,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_RnK0arVAFCqDuQxp",
+        "path": "/api/v2/connections/con_01XuzDgMqPqIFgWH",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-12-23T22:12:30.181Z"
+            "deleted_at": "2023-01-27T13:16:57.397Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2604,8 +2633,8 @@
             "name": "boo-baz-db-connection-test",
             "strategy": "auth0",
             "enabled_clients": [
-                "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
-                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
+                "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5"
             ],
             "is_domain_connection": false,
             "options": {
@@ -2649,7 +2678,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_rUXzAOVRUgHFvHTF",
+            "id": "con_IJh2Pq5t62vGi8MW",
             "options": {
                 "mfa": {
                     "active": true,
@@ -2689,8 +2718,8 @@
             "name": "boo-baz-db-connection-test",
             "is_domain_connection": false,
             "enabled_clients": [
-                "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
-                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                "ro5s4bv1l8KHgffegm23gkY6bR33fLk4"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -2754,6 +2783,49 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -2786,7 +2858,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+                    "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2840,7 +2912,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                    "client_id": "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2858,49 +2930,6 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -2928,7 +2957,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2980,7 +3009,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+                    "client_id": "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3039,7 +3068,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+                    "client_id": "MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3096,7 +3125,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "client_id": "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3128,7 +3157,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -3159,7 +3189,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_rUXzAOVRUgHFvHTF",
+                    "id": "con_IJh2Pq5t62vGi8MW",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3202,8 +3232,8 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
-                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                        "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                        "ro5s4bv1l8KHgffegm23gkY6bR33fLk4"
                     ]
                 }
             ]
@@ -3223,7 +3253,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_rUXzAOVRUgHFvHTF",
+                    "id": "con_IJh2Pq5t62vGi8MW",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3266,8 +3296,8 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
-                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                        "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                        "ro5s4bv1l8KHgffegm23gkY6bR33fLk4"
                     ]
                 }
             ]
@@ -3283,8 +3313,8 @@
             "name": "google-oauth2",
             "strategy": "google-oauth2",
             "enabled_clients": [
-                "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
-                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
+                "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3298,7 +3328,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_XLWbXl5xalZlLPmu",
+            "id": "con_4wmKttcZ269Ntr4Z",
             "options": {
                 "email": true,
                 "scope": [
@@ -3311,8 +3341,8 @@
             "name": "google-oauth2",
             "is_domain_connection": false,
             "enabled_clients": [
-                "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
-                "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO"
+                "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g"
             ],
             "realms": [
                 "google-oauth2"
@@ -3430,6 +3460,49 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -3462,7 +3535,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+                    "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3516,7 +3589,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                    "client_id": "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3534,49 +3607,6 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -3604,7 +3634,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3656,7 +3686,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+                    "client_id": "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3715,7 +3745,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+                    "client_id": "MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3772,7 +3802,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "client_id": "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3804,7 +3834,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -3982,7 +4013,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+            "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4119,8 +4150,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_wwoVFzkzvqUZTE1i",
-            "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+            "id": "cgr_CROL8ythj0BEstu8",
+            "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4263,7 +4294,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+            "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4400,8 +4431,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_lspk4neTGuXvfcBJ",
-            "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+            "id": "cgr_PFbqpwNeCaJiWIiw",
+            "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4559,14 +4590,14 @@
         "method": "POST",
         "path": "/api/v2/roles",
         "body": {
-            "name": "Admin",
-            "description": "Can read and write things"
+            "name": "Reader",
+            "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_tsvg41q3jEXMHS5h",
-            "name": "Admin",
-            "description": "Can read and write things"
+            "id": "rol_ZR53q29hybOu2g3D",
+            "name": "Reader",
+            "description": "Can only read things"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4576,14 +4607,14 @@
         "method": "POST",
         "path": "/api/v2/roles",
         "body": {
-            "name": "Reader",
-            "description": "Can only read things"
+            "name": "Admin",
+            "description": "Can read and write things"
         },
         "status": 200,
         "response": {
-            "id": "rol_lEmzu22SgcP4U0s7",
-            "name": "Reader",
-            "description": "Can only read things"
+            "id": "rol_byDRrjQCxlZlwraf",
+            "name": "Admin",
+            "description": "Can read and write things"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4598,7 +4629,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_4ADnAjlDwR6Y5Un8",
+            "id": "rol_ZyjvexLo98aOnYNk",
             "name": "read_only",
             "description": "Read Only"
         },
@@ -4615,7 +4646,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_k33F9UXOS24kZev3",
+            "id": "rol_C4IRe9QRC5MW7d1U",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -4654,7 +4685,7 @@
         },
         "status": 201,
         "response": {
-            "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
+            "id": "59929690-3de5-4da8-a5dd-1d5bb4b79418",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -4662,8 +4693,8 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2022-12-23T22:12:32.752916764Z",
-            "updated_at": "2022-12-23T22:12:32.774919739Z",
+            "created_at": "2023-01-27T13:17:00.026008383Z",
+            "updated_at": "2023-01-27T13:17:00.045302057Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node16",
@@ -4683,7 +4714,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
+                    "id": "59929690-3de5-4da8-a5dd-1d5bb4b79418",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4691,8 +4722,8 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-12-23T22:12:32.752916764Z",
-                    "updated_at": "2022-12-23T22:12:32.774919739Z",
+                    "created_at": "2023-01-27T13:17:00.026008383Z",
+                    "updated_at": "2023-01-27T13:17:00.045302057Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
@@ -4710,19 +4741,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/2571978b-8443-42bd-84e1-3a59350ca63f/deploy",
+        "path": "/api/v2/actions/actions/59929690-3de5-4da8-a5dd-1d5bb4b79418/deploy",
         "body": {},
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "bd128428-ab85-4f81-90a5-118785021e05",
+            "id": "4e9af404-e2d6-4c05-a46f-aa2a4677e154",
             "deployed": false,
             "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2022-12-23T22:12:33.116351669Z",
-            "updated_at": "2022-12-23T22:12:33.116351669Z",
+            "created_at": "2023-01-27T13:17:00.427152404Z",
+            "updated_at": "2023-01-27T13:17:00.427152404Z",
             "runtime": "node16",
             "supported_triggers": [
                 {
@@ -4731,7 +4762,7 @@
                 }
             ],
             "action": {
-                "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
+                "id": "59929690-3de5-4da8-a5dd-1d5bb4b79418",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -4739,8 +4770,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2022-12-23T22:12:32.752916764Z",
-                "updated_at": "2022-12-23T22:12:32.752916764Z",
+                "created_at": "2023-01-27T13:17:00.026008383Z",
+                "updated_at": "2023-01-27T13:17:00.026008383Z",
                 "all_changes_deployed": false
             }
         },
@@ -4786,7 +4817,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_rUXzAOVRUgHFvHTF",
+                    "id": "con_IJh2Pq5t62vGi8MW",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4829,12 +4860,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
-                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT"
+                        "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                        "ro5s4bv1l8KHgffegm23gkY6bR33fLk4"
                     ]
                 },
                 {
-                    "id": "con_XLWbXl5xalZlLPmu",
+                    "id": "con_4wmKttcZ269Ntr4Z",
                     "options": {
                         "email": true,
                         "scope": [
@@ -4850,28 +4881,11 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
-                        "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO"
+                        "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
+                        "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g"
                     ]
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
-        "body": {
-            "name": "org2",
-            "display_name": "Organization2"
-        },
-        "status": 201,
-        "response": {
-            "name": "org2",
-            "display_name": "Organization2",
-            "id": "org_NRLHyFDZX47A5zQh"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4900,7 +4914,24 @@
                 }
             },
             "display_name": "Organization",
-            "id": "org_xvQyLVGDOlwSti2P"
+            "id": "org_HutkXrNP9q4G56Cn"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/organizations",
+        "body": {
+            "name": "org2",
+            "display_name": "Organization2"
+        },
+        "status": 201,
+        "response": {
+            "name": "org2",
+            "display_name": "Organization2",
+            "id": "org_deydQfr14mLiDNJy"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5092,7 +5123,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_3LlpfTOiEZLdojv1",
+                    "id": "rul_o96lM3TC9Cbi9LlL",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -5116,7 +5147,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_3LlpfTOiEZLdojv1",
+                    "id": "rul_o96lM3TC9Cbi9LlL",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -5131,7 +5162,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/rules/rul_3LlpfTOiEZLdojv1",
+        "path": "/api/v2/rules/rul_o96lM3TC9Cbi9LlL",
         "body": {},
         "status": 204,
         "response": "",
@@ -5796,6 +5827,49 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "API Explorer Application",
                     "allowed_clients": [],
                     "callbacks": [],
@@ -5828,7 +5902,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+                    "client_id": "xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5882,7 +5956,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+                    "client_id": "ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5900,49 +5974,6 @@
                         "client_credentials"
                     ],
                     "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
                     "custom_login_page_on": true
                 },
                 {
@@ -5970,7 +6001,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+                    "client_id": "AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6022,7 +6053,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+                    "client_id": "i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6081,7 +6112,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+                    "client_id": "MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6138,7 +6169,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+                    "client_id": "S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6162,7 +6193,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/1RlXsTabv1NXp3PROSwbdUog7ySrsNDY",
+        "path": "/api/v2/clients/xwWI3KFE5jQFXQFlxaxRurCP7yx7kSt5",
         "body": {},
         "status": 204,
         "response": "",
@@ -6172,7 +6203,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/fjBS3NdgFPvH5r50pIu9bQT1OGA5MkUw",
+        "path": "/api/v2/clients/0TKcxHgtd5vC6bGs5bSYMTyvVwxOvJGj",
         "body": {},
         "status": 204,
         "response": "",
@@ -6182,7 +6213,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/fDbsHBBACpbzBZVrsDbI74MfgfMyCHtI",
+        "path": "/api/v2/clients/ro5s4bv1l8KHgffegm23gkY6bR33fLk4",
         "body": {},
         "status": 204,
         "response": "",
@@ -6192,7 +6223,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/aHIxpr238DFXJ0tLu5xSmCgaK3UcxJlj",
+        "path": "/api/v2/clients/AhbktZ5OzMeMW4NhPIB7lmCwxVbaP8qP",
         "body": {},
         "status": 204,
         "response": "",
@@ -6202,7 +6233,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ghVwx91Zy88Xw2hRCUrFuxLjoKsuN4AO",
+        "path": "/api/v2/clients/i4CJzj4YnsomC8gJCO0ZJl8LVRhAX71g",
         "body": {},
         "status": 204,
         "response": "",
@@ -6212,7 +6243,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/PMxBlN7zIV0UhCjAiklaOICOIDwD2uhC",
+        "path": "/api/v2/clients/MEg4PQza4b2amNWlqjBsVfP65GXsnh0X",
         "body": {},
         "status": 204,
         "response": "",
@@ -6222,7 +6253,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/Gd3qu5CDrZY8xZBoXnugqsm0LFysIJrT",
+        "path": "/api/v2/clients/S3GLsspoAa64UtPuqEoA2ngqiGWxZRk5",
         "body": {},
         "status": 204,
         "response": "",
@@ -6292,7 +6323,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
+            "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -6339,77 +6370,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/duo",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -6438,6 +6399,76 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -6504,59 +6535,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -6606,14 +6584,24 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000007930",
+                "id": "lst_0000000000008172",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000008173",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b991d69a-cc44-4338-a2e9-d03efc651b0f/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-f4a53afc-5b5a-4c8e-8d36-695862fbb9db/auth0.logs"
                 },
                 "filters": [
                     {
@@ -6660,8 +6648,71 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000007930",
+        "path": "/api/v2/log-streams/lst_0000000000008172",
+        "body": {},
+        "status": 204,
+        "response": "",
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "DELETE",
+        "path": "/api/v2/log-streams/lst_0000000000008173",
         "body": {},
         "status": 204,
         "response": "",
@@ -6745,7 +6796,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6777,7 +6828,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -6808,7 +6860,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_rUXzAOVRUgHFvHTF",
+                    "id": "con_IJh2Pq5t62vGi8MW",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6869,7 +6921,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_rUXzAOVRUgHFvHTF",
+                    "id": "con_IJh2Pq5t62vGi8MW",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6921,11 +6973,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_rUXzAOVRUgHFvHTF",
+        "path": "/api/v2/connections/con_IJh2Pq5t62vGi8MW",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-12-23T22:12:41.468Z"
+            "deleted_at": "2023-01-27T13:17:08.867Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6939,7 +6991,7 @@
             "strategy": "auth0",
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
             ],
             "is_domain_connection": false,
             "options": {
@@ -6957,7 +7009,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_01XuzDgMqPqIFgWH",
+            "id": "con_vKGKyyDISDZMInSa",
             "options": {
                 "mfa": {
                     "active": true,
@@ -6972,7 +7024,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -7058,7 +7110,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7090,7 +7142,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -7121,7 +7174,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_XLWbXl5xalZlLPmu",
+                    "id": "con_4wmKttcZ269Ntr4Z",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7139,7 +7192,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_01XuzDgMqPqIFgWH",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7157,7 +7210,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -7177,7 +7230,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_XLWbXl5xalZlLPmu",
+                    "id": "con_4wmKttcZ269Ntr4Z",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7195,7 +7248,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_01XuzDgMqPqIFgWH",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7213,7 +7266,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -7224,11 +7277,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_XLWbXl5xalZlLPmu",
+        "path": "/api/v2/connections/con_4wmKttcZ269Ntr4Z",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2022-12-23T22:12:42.302Z"
+            "deleted_at": "2023-01-27T13:17:09.599Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7310,7 +7363,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7342,7 +7395,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -7524,22 +7578,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_tsvg41q3jEXMHS5h",
+                    "id": "rol_byDRrjQCxlZlwraf",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_lEmzu22SgcP4U0s7",
+                    "id": "rol_ZR53q29hybOu2g3D",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_4ADnAjlDwR6Y5Un8",
+                    "id": "rol_ZyjvexLo98aOnYNk",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_k33F9UXOS24kZev3",
+                    "id": "rol_C4IRe9QRC5MW7d1U",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -7554,7 +7608,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_tsvg41q3jEXMHS5h/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_byDRrjQCxlZlwraf/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7569,7 +7623,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_lEmzu22SgcP4U0s7/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_ZR53q29hybOu2g3D/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7584,7 +7638,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_4ADnAjlDwR6Y5Un8/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_ZyjvexLo98aOnYNk/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7599,7 +7653,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_k33F9UXOS24kZev3/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_C4IRe9QRC5MW7d1U/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7614,7 +7668,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_tsvg41q3jEXMHS5h",
+        "path": "/api/v2/roles/rol_byDRrjQCxlZlwraf",
         "body": {},
         "status": 200,
         "response": {},
@@ -7624,7 +7678,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_lEmzu22SgcP4U0s7",
+        "path": "/api/v2/roles/rol_ZR53q29hybOu2g3D",
         "body": {},
         "status": 200,
         "response": {},
@@ -7634,7 +7688,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_4ADnAjlDwR6Y5Un8",
+        "path": "/api/v2/roles/rol_ZyjvexLo98aOnYNk",
         "body": {},
         "status": 200,
         "response": {},
@@ -7644,7 +7698,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_k33F9UXOS24kZev3",
+        "path": "/api/v2/roles/rol_C4IRe9QRC5MW7d1U",
         "body": {},
         "status": 200,
         "response": {},
@@ -7660,7 +7714,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "2571978b-8443-42bd-84e1-3a59350ca63f",
+                    "id": "59929690-3de5-4da8-a5dd-1d5bb4b79418",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -7668,34 +7722,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-12-23T22:12:32.752916764Z",
-                    "updated_at": "2022-12-23T22:12:32.774919739Z",
+                    "created_at": "2023-01-27T13:17:00.026008383Z",
+                    "updated_at": "2023-01-27T13:17:00.045302057Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "bd128428-ab85-4f81-90a5-118785021e05",
+                        "id": "4e9af404-e2d6-4c05-a46f-aa2a4677e154",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2022-12-23T22:12:33.191362503Z",
-                        "created_at": "2022-12-23T22:12:33.116351669Z",
-                        "updated_at": "2022-12-23T22:12:33.191716636Z"
+                        "build_time": "2023-01-27T13:17:00.515093284Z",
+                        "created_at": "2023-01-27T13:17:00.427152404Z",
+                        "updated_at": "2023-01-27T13:17:00.515445308Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "bd128428-ab85-4f81-90a5-118785021e05",
+                        "id": "4e9af404-e2d6-4c05-a46f-aa2a4677e154",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2022-12-23T22:12:33.191362503Z",
+                        "built_at": "2023-01-27T13:17:00.515093284Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2022-12-23T22:12:33.116351669Z",
-                        "updated_at": "2022-12-23T22:12:33.191716636Z",
+                        "created_at": "2023-01-27T13:17:00.427152404Z",
+                        "updated_at": "2023-01-27T13:17:00.515445308Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -7716,7 +7770,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/2571978b-8443-42bd-84e1-3a59350ca63f?force=true",
+        "path": "/api/v2/actions/actions/59929690-3de5-4da8-a5dd-1d5bb4b79418?force=true",
         "body": {},
         "status": 204,
         "response": "",
@@ -7745,7 +7799,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_xvQyLVGDOlwSti2P",
+                    "id": "org_HutkXrNP9q4G56Cn",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -7756,7 +7810,7 @@
                     }
                 },
                 {
-                    "id": "org_NRLHyFDZX47A5zQh",
+                    "id": "org_deydQfr14mLiDNJy",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -7777,12 +7831,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_NRLHyFDZX47A5zQh",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                },
-                {
-                    "id": "org_xvQyLVGDOlwSti2P",
+                    "id": "org_HutkXrNP9q4G56Cn",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -7791,6 +7840,11 @@
                             "primary": "#57ddff"
                         }
                     }
+                },
+                {
+                    "id": "org_deydQfr14mLiDNJy",
+                    "name": "org2",
+                    "display_name": "Organization2"
                 }
             ]
         },
@@ -7800,7 +7854,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_NRLHyFDZX47A5zQh/enabled_connections",
+        "path": "/api/v2/organizations/org_HutkXrNP9q4G56Cn/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -7810,7 +7864,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_xvQyLVGDOlwSti2P/enabled_connections",
+        "path": "/api/v2/organizations/org_deydQfr14mLiDNJy/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -7829,7 +7883,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_01XuzDgMqPqIFgWH",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7847,7 +7901,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -7858,7 +7912,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_xvQyLVGDOlwSti2P",
+        "path": "/api/v2/organizations/org_deydQfr14mLiDNJy",
         "body": {},
         "status": 204,
         "response": "",
@@ -7868,7 +7922,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_NRLHyFDZX47A5zQh",
+        "path": "/api/v2/organizations/org_HutkXrNP9q4G56Cn",
         "body": {},
         "status": 204,
         "response": "",
@@ -8089,7 +8143,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -8828,7 +8883,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8861,7 +8916,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_01XuzDgMqPqIFgWH",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8879,7 +8934,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -8899,7 +8954,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_01XuzDgMqPqIFgWH",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8917,7 +8972,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "eq46U0O1VN4x6n9NM7Ab4HxMUqHveECD"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -9013,59 +9068,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -9095,7 +9098,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -9140,7 +9143,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
+        "path": "/api/v2/email-templates/user_invitation",
         "body": "",
         "status": 404,
         "response": {
@@ -9148,6 +9151,25 @@
             "error": "Not Found",
             "message": "The template does not exist.",
             "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9170,7 +9192,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
+        "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
         "response": {
@@ -9178,6 +9200,39 @@
             "error": "Not Found",
             "message": "The template does not exist.",
             "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9390,6 +9445,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
@@ -9399,16 +9464,6 @@
             "from": "from bar",
             "messaging_service_sid": "foo"
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
-        "body": "",
-        "status": 200,
-        "response": {},
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -9586,36 +9641,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/consent/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
@@ -9626,137 +9651,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/invitation/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-email/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9786,6 +9681,36 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/consent/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
@@ -9796,7 +9721,27 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/common/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9826,7 +9771,117 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/invitation/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-email/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9880,17 +9935,6 @@
                 },
                 {
                     "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -9904,6 +9948,17 @@
                             "version": "v2"
                         }
                     ]
+                },
+                {
+                    "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
                 },
                 {
                     "id": "credentials-exchange",
@@ -10122,25 +10177,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
@@ -10181,6 +10217,25 @@
                     "rate": 1200
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false

--- a/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
+++ b/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
@@ -6,19 +6,10 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 0,
             "start": 0,
             "limit": 100,
-            "rules": [
-                {
-                    "id": "rul_CZeKvuRVAFUXroeI",
-                    "enabled": true,
-                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}",
-                    "name": "my-rule",
-                    "order": 2,
-                    "stage": "login_success"
-                }
-            ]
+            "rules": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -30,36 +21,28 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 0,
             "start": 0,
             "limit": 100,
-            "rules": [
-                {
-                    "id": "rul_CZeKvuRVAFUXroeI",
-                    "enabled": true,
-                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}",
-                    "name": "my-rule",
-                    "order": 2,
-                    "stage": "login_success"
-                }
-            ]
+            "rules": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/rules/rul_CZeKvuRVAFUXroeI",
+        "method": "POST",
+        "path": "/api/v2/rules",
         "body": {
             "name": "my-rule",
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
+            "stage": "login_success",
             "enabled": true,
             "order": 2
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "rul_CZeKvuRVAFUXroeI",
+            "id": "rul_wyztfxV95OGrjEAB",
             "enabled": true,
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
             "name": "my-rule",
@@ -126,9 +109,10 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
-                    "custom_login_page": "<html>TEST123</html>",
+                    "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -170,7 +154,8 @@
                 "rotation_type": "non-rotating"
             },
             "owners": [
-                "mr|samlp|okta|will.vedder@auth0.com"
+                "mr|samlp|okta|will.vedder@auth0.com",
+                "mr|google-oauth2|102002633619863830825"
             ],
             "custom_login_page": "<html>TEST123</html>\n",
             "signing_keys": [
@@ -743,76 +728,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -829,7 +834,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 9,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -899,7 +904,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -912,368 +917,6 @@
                         "implicit",
                         "refresh_token",
                         "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
                     ],
                     "custom_login_page_on": true
                 }
@@ -1284,8 +927,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "API Explorer Application",
             "allowed_clients": [],
@@ -1302,7 +945,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1325,7 +969,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1355,14 +999,16 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+            "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1383,89 +1029,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-        "body": {
-            "name": "Quickstarts API (Test Application)",
-            "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -1487,7 +1052,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1511,7 +1077,7 @@
             "token_endpoint_auth_method": "client_secret_post",
             "web_origins": []
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1542,15 +1108,17 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
             "allowed_origins": [],
-            "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+            "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1575,8 +1143,170 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Quickstarts API (Test Application)",
+            "app_type": "non_interactive",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "The Default App",
             "allowed_clients": [],
@@ -1595,7 +1325,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1619,7 +1350,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1650,14 +1381,16 @@
             },
             "sso": false,
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+            "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1680,11 +1413,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
-            "name": "Terraform Provider",
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
             "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
             "cross_origin_auth": false,
             "custom_login_page_on": true,
             "grant_types": [
@@ -1694,7 +1431,16 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
             },
             "oidc_conformant": true,
             "refresh_token": {
@@ -1709,14 +1455,25 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
             "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
             "cross_origin_auth": false,
             "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
             "oidc_conformant": true,
             "refresh_token": {
                 "expiration_type": "non-expiring",
@@ -1728,14 +1485,16 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+            "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1743,6 +1502,7 @@
                 "lifetime_in_seconds": 36000,
                 "secret_encoded": false
             },
+            "client_aliases": [],
             "token_endpoint_auth_method": "client_secret_post",
             "app_type": "non_interactive",
             "grant_types": [
@@ -1755,8 +1515,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -1780,7 +1540,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -1806,7 +1567,7 @@
                 "http://localhost:3000"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1841,14 +1602,16 @@
                 "rotation_type": "rotating"
             },
             "sso_disabled": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+            "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1874,121 +1637,22 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-        "body": {
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
         "body": "",
-        "status": 200,
+        "status": 404,
         "response": {
-            "name": "mandrill",
-            "credentials": {},
-            "default_from_address": "auth0-user@auth0.com",
-            "enabled": false
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "There is not a configured email provider",
+            "errorCode": "inexistent_email_provider"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
+        "method": "POST",
         "path": "/api/v2/emails/provider?enabled=false&name=mandrill",
         "body": {
             "name": "mandrill",
@@ -1998,7 +1662,7 @@
             "default_from_address": "auth0-user@auth0.com",
             "enabled": false
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "name": "mandrill",
             "credentials": {},
@@ -2011,7 +1675,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -2025,27 +1689,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
-            "enabled": false
+            "enabled": true
         },
         "status": 200,
         "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2081,20 +1731,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
@@ -2109,7 +1745,35 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -2184,57 +1848,32 @@
         "path": "/api/v2/log-streams?paginate=false",
         "body": "",
         "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000006221",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
-                },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ]
+        "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
             }
-        ],
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -2287,26 +1926,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/brute-force-protection",
         "body": {
             "enabled": true,
@@ -2334,8 +1953,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000006221",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
+        "body": {
+            "name": "Suspended DD Log Stream",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            },
+            "type": "datadog"
+        },
+        "status": 200,
+        "response": {
+            "id": "lst_0000000000008174",
+            "name": "Suspended DD Log Stream",
+            "type": "datadog",
+            "status": "active",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -2376,18 +2021,22 @@
                     "name": "auth.token_exchange.fail"
                 }
             ],
-            "status": "active"
+            "sink": {
+                "awsAccountId": "123456789012",
+                "awsRegion": "us-east-2"
+            },
+            "type": "eventbridge"
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000006221",
+            "id": "lst_0000000000008175",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-eeaf2545-d189-4917-a958-35b7dd9d13e2/auth0.logs"
             },
             "filters": [
                 {
@@ -2508,7 +2157,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2522,6 +2171,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -2552,7 +2259,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2603,7 +2310,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2623,21 +2330,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -2656,8 +2351,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2665,16 +2359,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -2714,7 +2403,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2728,98 +2417,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2865,7 +2462,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2888,6 +2485,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -2902,7 +2551,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -2928,60 +2578,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2999,7 +2601,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -3014,60 +2616,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3085,7 +2639,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -3095,69 +2649,14 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_Vtsb73LK2IOecB11",
-        "body": "",
-        "status": 200,
-        "response": {
-            "id": "con_Vtsb73LK2IOecB11",
-            "options": {
-                "mfa": {
-                    "active": true,
-                    "return_enroll_settings": true
-                },
-                "import_mode": false,
-                "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                },
-                "disable_signup": false,
-                "passwordPolicy": "low",
-                "password_history": {
-                    "size": 5,
-                    "enable": false
-                },
-                "strategy_version": 2,
-                "requires_username": true,
-                "password_dictionary": {
-                    "enable": true,
-                    "dictionary": []
-                },
-                "brute_force_protection": true,
-                "password_no_personal_info": {
-                    "enable": true
-                },
-                "password_complexity_options": {
-                    "min_length": 8
-                },
-                "enabledDatabaseCustomization": true
-            },
-            "strategy": "auth0",
-            "name": "boo-baz-db-connection-test",
-            "is_domain_connection": false,
-            "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-            ],
-            "realms": [
-                "boo-baz-db-connection-test"
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/connections/con_Vtsb73LK2IOecB11",
+        "method": "POST",
+        "path": "/api/v2/connections",
         "body": {
+            "name": "boo-baz-db-connection-test",
+            "strategy": "auth0",
             "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3199,25 +2698,25 @@
                 "boo-baz-db-connection-test"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "con_Vtsb73LK2IOecB11",
+            "id": "con_6rdZLHrGBvNFSF8U",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
+                "passwordPolicy": "low",
                 "import_mode": false,
                 "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
                 },
                 "disable_signup": false,
-                "passwordPolicy": "low",
                 "password_history": {
                     "size": 5,
                     "enable": false
@@ -3241,8 +2740,8 @@
             "name": "boo-baz-db-connection-test",
             "is_domain_connection": false,
             "enabled_clients": [
-                "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -3328,7 +2827,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3342,6 +2841,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -3372,7 +2929,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3423,7 +2980,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3443,21 +3000,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -3476,8 +3021,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3485,16 +3029,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -3534,7 +3073,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3548,98 +3087,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3685,7 +3132,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3708,6 +3155,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -3722,7 +3221,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -3748,12 +3248,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3796,33 +3296,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3840,7 +3319,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -3855,12 +3334,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3903,33 +3382,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
-                    ]
-                },
-                {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3947,7 +3405,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -3957,12 +3415,14 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/connections/con_VqEWDbU3psp0T0TD",
+        "method": "POST",
+        "path": "/api/v2/connections",
         "body": {
+            "name": "google-oauth2",
+            "strategy": "google-oauth2",
             "enabled_clients": [
-                "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
+                "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3974,9 +3434,9 @@
                 "profile": true
             }
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "con_VqEWDbU3psp0T0TD",
+            "id": "con_XF2IeVZmdqN5MzHN",
             "options": {
                 "email": true,
                 "scope": [
@@ -3989,38 +3449,12 @@
             "name": "google-oauth2",
             "is_domain_connection": false,
             "enabled_clients": [
-                "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
             ],
             "realms": [
                 "google-oauth2"
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "enabled": true,
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000
-        },
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4049,6 +3483,32 @@
             "syntax": "liquid",
             "urlLifetimeInSeconds": 3600,
             "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "enabled": true,
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000
+        },
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4130,7 +3590,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4144,6 +3604,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -4174,7 +3692,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4225,7 +3743,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4245,21 +3763,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -4278,8 +3784,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4287,16 +3792,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -4336,7 +3836,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4350,98 +3850,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4487,7 +3895,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4510,6 +3918,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -4524,7 +3984,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -4550,7 +4011,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 1,
             "start": 0,
             "limit": 100,
             "client_grants": [
@@ -4691,280 +4152,6 @@
                         "read:organization_invitations",
                         "delete:organization_invitations"
                     ]
-                },
-                {
-                    "id": "cgr_r2ghlZPm4B5VAUbP",
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
-                },
-                {
-                    "id": "cgr_ybuyiJ6ov15TDJyE",
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
                 }
             ]
         },
@@ -4973,9 +4160,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_ybuyiJ6ov15TDJyE",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -5109,10 +4298,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_ybuyiJ6ov15TDJyE",
-            "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+            "id": "cgr_2lE4NL6nwOBZWY9k",
+            "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5252,9 +4441,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_r2ghlZPm4B5VAUbP",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -5388,10 +4579,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_r2ghlZPm4B5VAUbP",
-            "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+            "id": "cgr_zF9xXPmO64MKrqyu",
+            "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5536,43 +4727,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "roles": [
-                {
-                    "id": "rol_yadEKRjs1mhMWTzQ",
-                    "name": "Admin",
-                    "description": "Can read and write things"
-                },
-                {
-                    "id": "rol_fDrBFzOWx5SiJo32",
-                    "name": "Reader",
-                    "description": "Can only read things"
-                },
-                {
-                    "id": "rol_YHX0bBjDw1OKrIVB",
-                    "name": "read_only",
-                    "description": "Read Only"
-                },
-                {
-                    "id": "rol_k6IsMYUJQhlQtN6J",
-                    "name": "read_osnly",
-                    "description": "Readz Only"
-                }
-            ],
-            "start": 0,
-            "limit": 100,
-            "total": 4
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
+            "roles": [],
             "start": 0,
             "limit": 100,
             "total": 0
@@ -5582,94 +4737,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J/permissions?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB",
-        "body": {
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_YHX0bBjDw1OKrIVB",
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ",
-        "body": {
-            "name": "Admin",
-            "description": "Can read and write things"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_yadEKRjs1mhMWTzQ",
-            "name": "Admin",
-            "description": "Can read and write things"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_fDrBFzOWx5SiJo32",
+            "id": "rol_5dRdRg4d9VuibVDh",
             "name": "Reader",
             "description": "Can only read things"
         },
@@ -5678,15 +4754,49 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J",
+        "method": "POST",
+        "path": "/api/v2/roles",
+        "body": {
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_SACktg7qrEBTpAkh",
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/roles",
+        "body": {
+            "name": "Admin",
+            "description": "Can read and write things"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_E8FYyc4yRytSemJV",
+            "name": "Admin",
+            "description": "Can read and write things"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_k6IsMYUJQhlQtN6J",
+            "id": "rol_zHXK9tGyLi4fvBil",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -5700,56 +4810,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T14:53:28.708733693Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node16",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node16",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2022-07-29T14:53:29.163813776Z",
-                        "created_at": "2022-07-29T14:53:29.080848403Z",
-                        "updated_at": "2022-07-29T14:53:29.164451306Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2022-07-29T14:53:29.163813776Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2022-07-29T14:53:29.080848403Z",
-                        "updated_at": "2022-07-29T14:53:29.164451306Z",
-                        "runtime": "node16",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -5757,8 +4818,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/actions/actions/33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+        "method": "POST",
+        "path": "/api/v2/actions/actions",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -5772,9 +4833,9 @@
                 }
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+            "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -5782,43 +4843,14 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2022-07-29T14:53:28.697788039Z",
-            "updated_at": "2022-07-29T15:31:21.868184183Z",
+            "created_at": "2023-01-27T13:22:16.579099437Z",
+            "updated_at": "2023-01-27T13:22:16.587984016Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node16",
             "status": "pending",
             "secrets": [],
-            "current_version": {
-                "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "runtime": "node16",
-                "status": "BUILT",
-                "number": 1,
-                "build_time": "2022-07-29T14:53:29.163813776Z",
-                "created_at": "2022-07-29T14:53:29.080848403Z",
-                "updated_at": "2022-07-29T14:53:29.164451306Z"
-            },
-            "deployed_version": {
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "dependencies": [],
-                "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                "deployed": true,
-                "number": 1,
-                "built_at": "2022-07-29T14:53:29.163813776Z",
-                "secrets": [],
-                "status": "built",
-                "created_at": "2022-07-29T14:53:29.080848403Z",
-                "updated_at": "2022-07-29T14:53:29.164451306Z",
-                "runtime": "node16",
-                "supported_triggers": [
-                    {
-                        "id": "post-login",
-                        "version": "v2"
-                    }
-                ]
-            },
-            "all_changes_deployed": true
+            "all_changes_deployed": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5832,7 +4864,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -5840,43 +4872,14 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:21.868184183Z",
+                    "created_at": "2023-01-27T13:22:16.579099437Z",
+                    "updated_at": "2023-01-27T13:22:16.587984016Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
-                    "current_version": {
-                        "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node16",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2022-07-29T14:53:29.163813776Z",
-                        "created_at": "2022-07-29T14:53:29.080848403Z",
-                        "updated_at": "2022-07-29T14:53:29.164451306Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "bb0970ca-a2b1-4f75-a7f4-2e0db1fad578",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2022-07-29T14:53:29.163813776Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2022-07-29T14:53:29.080848403Z",
-                        "updated_at": "2022-07-29T14:53:29.164451306Z",
-                        "runtime": "node16",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
+                    "all_changes_deployed": false
                 }
             ],
             "total": 1,
@@ -5888,19 +4891,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/33c963a5-bcd8-46a6-86ac-20d4a41c13ad/deploy",
+        "path": "/api/v2/actions/actions/5992c6f4-daae-4079-9aa6-f4111823c6be/deploy",
         "body": {},
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+            "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
             "deployed": false,
-            "number": 2,
+            "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2022-07-29T15:31:22.300547590Z",
-            "updated_at": "2022-07-29T15:31:22.300547590Z",
+            "created_at": "2023-01-27T13:22:16.918712794Z",
+            "updated_at": "2023-01-27T13:22:16.918712794Z",
             "runtime": "node16",
             "supported_triggers": [
                 {
@@ -5909,7 +4912,7 @@
                 }
             ],
             "action": {
-                "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -5917,8 +4920,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2022-07-29T14:53:28.697788039Z",
-                "updated_at": "2022-07-29T15:31:21.860726521Z",
+                "created_at": "2023-01-27T13:22:16.579099437Z",
+                "updated_at": "2023-01-27T13:22:16.579099437Z",
                 "all_changes_deployed": false
             }
         },
@@ -5932,27 +4935,10 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_UbEQO06JATYNqOSu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    }
-                },
-                {
-                    "id": "org_NKqJCufgliq6yM1o",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                }
-            ],
+            "organizations": [],
             "start": 0,
             "limit": 50,
-            "total": 2
+            "total": 0
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5964,45 +4950,8 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_UbEQO06JATYNqOSu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    }
-                },
-                {
-                    "id": "org_NKqJCufgliq6yM1o",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                }
-            ]
+            "organizations": []
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu/enabled_connections",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o/enabled_connections",
-        "body": "",
-        "status": 200,
-        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -6018,7 +4967,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6061,12 +5010,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XF2IeVZmdqN5MzHN",
                     "options": {
                         "email": true,
                         "scope": [
@@ -6082,12 +5031,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6105,7 +5054,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -6115,9 +5064,10 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
+            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
@@ -6126,33 +5076,34 @@
             },
             "display_name": "Organization"
         },
-        "status": 200,
+        "status": 201,
         "response": {
+            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
                     "primary": "#57ddff"
                 }
             },
-            "id": "org_UbEQO06JATYNqOSu",
             "display_name": "Organization",
-            "name": "org1"
+            "id": "org_fIFox2I32Pb2i7a0"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
+            "name": "org2",
             "display_name": "Organization2"
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "org_NKqJCufgliq6yM1o",
+            "name": "org2",
             "display_name": "Organization2",
-            "name": "org2"
+            "id": "org_JOPN2fgtRT7bjM6X"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6344,7 +5295,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_CZeKvuRVAFUXroeI",
+                    "id": "rul_wyztfxV95OGrjEAB",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -6368,7 +5319,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_CZeKvuRVAFUXroeI",
+                    "id": "rul_wyztfxV95OGrjEAB",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -6884,76 +5835,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -7040,7 +6011,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7054,6 +6025,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -7084,7 +6113,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7135,7 +6164,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7155,21 +6184,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -7188,8 +6205,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7197,16 +6213,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -7246,7 +6257,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7260,98 +6271,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -7397,7 +6316,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7417,6 +6336,58 @@
                         "http://localhost:3000"
                     ],
                     "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -7426,7 +6397,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+        "path": "/api/v2/clients/c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -7483,7 +6454,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+            "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -7504,8 +6475,37 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
+        "body": "",
+        "status": 200,
+        "response": {
+            "name": "mandrill",
+            "credentials": {},
+            "default_from_address": "auth0-user@auth0.com",
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -7520,6 +6520,20 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/duo",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -7561,7 +6575,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -7576,34 +6590,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -7669,68 +6655,30 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/log-streams?paginate=false",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000006221",
+                "id": "lst_0000000000008174",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000008175",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-eeaf2545-d189-4917-a958-35b7dd9d13e2/auth0.logs"
                 },
                 "filters": [
                     {
@@ -7821,6 +6769,59 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/clients?include_totals=true&page=0&per_page=100",
         "body": "",
@@ -7896,7 +6897,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7910,6 +6911,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -7940,7 +6999,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7991,7 +7050,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8011,21 +7070,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8044,8 +7091,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8053,16 +7099,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -8102,7 +7143,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8116,98 +7157,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8253,7 +7202,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8276,6 +7225,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -8290,7 +7291,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -8321,7 +7323,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8364,12 +7366,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8387,7 +7389,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -8407,7 +7409,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8450,12 +7452,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8473,7 +7475,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -8484,11 +7486,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_TCTd3NlTfu8widbC",
+        "path": "/api/v2/connections/con_vKGKyyDISDZMInSa",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_TCTd3NlTfu8widbC",
+            "id": "con_vKGKyyDISDZMInSa",
             "options": {
                 "mfa": {
                     "active": true,
@@ -8503,7 +7505,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -8515,11 +7517,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_TCTd3NlTfu8widbC",
+        "path": "/api/v2/connections/con_vKGKyyDISDZMInSa",
         "body": {
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
             ],
             "is_domain_connection": false,
             "options": {
@@ -8537,7 +7539,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_TCTd3NlTfu8widbC",
+            "id": "con_vKGKyyDISDZMInSa",
             "options": {
                 "mfa": {
                     "active": true,
@@ -8552,7 +7554,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -8638,7 +7640,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8652,6 +7654,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -8682,7 +7742,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8733,7 +7793,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8753,21 +7813,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8786,8 +7834,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8795,16 +7842,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -8844,7 +7886,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8858,98 +7900,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8995,7 +7945,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9018,6 +7968,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -9032,7 +8034,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -9063,7 +8066,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9106,12 +8109,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XF2IeVZmdqN5MzHN",
                     "options": {
                         "email": true,
                         "scope": [
@@ -9127,12 +8130,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9150,7 +8153,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -9170,7 +8173,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9213,12 +8216,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XF2IeVZmdqN5MzHN",
                     "options": {
                         "email": true,
                         "scope": [
@@ -9234,12 +8237,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9257,7 +8260,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -9342,7 +8345,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9356,6 +8359,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -9386,7 +8447,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9437,7 +8498,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9457,21 +8518,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -9490,8 +8539,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9499,16 +8547,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -9548,7 +8591,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9562,98 +8605,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -9699,7 +8650,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9722,6 +8673,58 @@
                 },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
                     "global": true,
                     "callbacks": [],
                     "is_first_party": true,
@@ -9736,7 +8739,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -9766,6 +8770,143 @@
             "start": 0,
             "limit": 100,
             "client_grants": [
+                {
+                    "id": "cgr_2lE4NL6nwOBZWY9k",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
                 {
                     "id": "cgr_iodSzvwxqm51tLZF",
                     "client_id": "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
@@ -9905,145 +9046,8 @@
                     ]
                 },
                 {
-                    "id": "cgr_r2ghlZPm4B5VAUbP",
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
-                },
-                {
-                    "id": "cgr_ybuyiJ6ov15TDJyE",
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+                    "id": "cgr_zF9xXPmO64MKrqyu",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -10192,22 +9196,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_yadEKRjs1mhMWTzQ",
+                    "id": "rol_E8FYyc4yRytSemJV",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_fDrBFzOWx5SiJo32",
+                    "id": "rol_5dRdRg4d9VuibVDh",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_YHX0bBjDw1OKrIVB",
+                    "id": "rol_SACktg7qrEBTpAkh",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_k6IsMYUJQhlQtN6J",
+                    "id": "rol_zHXK9tGyLi4fvBil",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -10222,7 +9226,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_E8FYyc4yRytSemJV/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -10237,7 +9241,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_5dRdRg4d9VuibVDh/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -10252,7 +9256,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_SACktg7qrEBTpAkh/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -10267,7 +9271,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_zHXK9tGyLi4fvBil/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -10288,7 +9292,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10296,34 +9300,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:21.868184183Z",
+                    "created_at": "2023-01-27T13:22:16.579099437Z",
+                    "updated_at": "2023-01-27T13:22:16.587984016Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2022-07-29T15:31:22.444672116Z",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z"
+                        "number": 1,
+                        "build_time": "2023-01-27T13:22:17.032504530Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2022-07-29T15:31:22.444672116Z",
+                        "number": 1,
+                        "built_at": "2023-01-27T13:22:17.032504530Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -10350,7 +9354,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10358,34 +9362,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:21.868184183Z",
+                    "created_at": "2023-01-27T13:22:16.579099437Z",
+                    "updated_at": "2023-01-27T13:22:16.587984016Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2022-07-29T15:31:22.444672116Z",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z"
+                        "number": 1,
+                        "build_time": "2023-01-27T13:22:17.032504530Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2022-07-29T15:31:22.444672116Z",
+                        "number": 1,
+                        "built_at": "2023-01-27T13:22:17.032504530Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -10412,7 +9416,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_fIFox2I32Pb2i7a0",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -10423,7 +9427,7 @@
                     }
                 },
                 {
-                    "id": "org_NKqJCufgliq6yM1o",
+                    "id": "org_JOPN2fgtRT7bjM6X",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -10444,7 +9448,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_fIFox2I32Pb2i7a0",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -10455,7 +9459,7 @@
                     }
                 },
                 {
-                    "id": "org_NKqJCufgliq6yM1o",
+                    "id": "org_JOPN2fgtRT7bjM6X",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -10467,7 +9471,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu/enabled_connections",
+        "path": "/api/v2/organizations/org_fIFox2I32Pb2i7a0/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -10477,7 +9481,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o/enabled_connections",
+        "path": "/api/v2/organizations/org_JOPN2fgtRT7bjM6X/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -10496,7 +9500,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -10539,12 +9543,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XF2IeVZmdqN5MzHN",
                     "options": {
                         "email": true,
                         "scope": [
@@ -10560,12 +9564,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -10583,7 +9587,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -10750,7 +9754,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_CZeKvuRVAFUXroeI",
+                    "id": "rul_wyztfxV95OGrjEAB",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -10814,7 +9818,8 @@
                         "rotation_type": "non-rotating"
                     },
                     "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com"
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "signing_keys": [
@@ -11377,76 +10382,96 @@
                             "value": "update:attack_protection"
                         },
                         {
+                            "description": "Read Organizations",
+                            "value": "read:organizations"
+                        },
+                        {
+                            "description": "Update Organizations",
+                            "value": "update:organizations"
+                        },
+                        {
+                            "description": "Create Organizations",
+                            "value": "create:organizations"
+                        },
+                        {
+                            "description": "Delete Organizations",
+                            "value": "delete:organizations"
+                        },
+                        {
+                            "description": "Create organization members",
+                            "value": "create:organization_members"
+                        },
+                        {
+                            "description": "Read organization members",
+                            "value": "read:organization_members"
+                        },
+                        {
+                            "description": "Delete organization members",
+                            "value": "delete:organization_members"
+                        },
+                        {
+                            "description": "Create organization connections",
+                            "value": "create:organization_connections"
+                        },
+                        {
+                            "description": "Read organization connections",
+                            "value": "read:organization_connections"
+                        },
+                        {
+                            "description": "Update organization connections",
+                            "value": "update:organization_connections"
+                        },
+                        {
+                            "description": "Delete organization connections",
+                            "value": "delete:organization_connections"
+                        },
+                        {
+                            "description": "Create organization member roles",
+                            "value": "create:organization_member_roles"
+                        },
+                        {
+                            "description": "Read organization member roles",
+                            "value": "read:organization_member_roles"
+                        },
+                        {
+                            "description": "Delete organization member roles",
+                            "value": "delete:organization_member_roles"
+                        },
+                        {
+                            "description": "Create organization invitations",
+                            "value": "create:organization_invitations"
+                        },
+                        {
+                            "description": "Read organization invitations",
+                            "value": "read:organization_invitations"
+                        },
+                        {
+                            "description": "Delete organization invitations",
+                            "value": "delete:organization_invitations"
+                        },
+                        {
                             "description": "Read organization summary",
                             "value": "read:organizations_summary"
                         },
                         {
-                            "value": "read:organizations",
-                            "description": "Read Organizations"
+                            "description": "Create Actions Log Sessions",
+                            "value": "create:actions_log_sessions"
                         },
                         {
-                            "value": "update:organizations",
-                            "description": "Update Organizations"
+                            "description": "Create Authentication Methods",
+                            "value": "create:authentication_methods"
                         },
                         {
-                            "value": "create:organizations",
-                            "description": "Create Organizations"
+                            "description": "Read Authentication Methods",
+                            "value": "read:authentication_methods"
                         },
                         {
-                            "value": "delete:organizations",
-                            "description": "Delete Organizations"
+                            "description": "Update Authentication Methods",
+                            "value": "update:authentication_methods"
                         },
                         {
-                            "value": "create:organization_members",
-                            "description": "Create organization members"
-                        },
-                        {
-                            "value": "read:organization_members",
-                            "description": "Read organization members"
-                        },
-                        {
-                            "value": "delete:organization_members",
-                            "description": "Delete organization members"
-                        },
-                        {
-                            "value": "create:organization_connections",
-                            "description": "Create organization connections"
-                        },
-                        {
-                            "value": "read:organization_connections",
-                            "description": "Read organization connections"
-                        },
-                        {
-                            "value": "update:organization_connections",
-                            "description": "Update organization connections"
-                        },
-                        {
-                            "value": "delete:organization_connections",
-                            "description": "Delete organization connections"
-                        },
-                        {
-                            "value": "create:organization_member_roles",
-                            "description": "Create organization member roles"
-                        },
-                        {
-                            "value": "read:organization_member_roles",
-                            "description": "Read organization member roles"
-                        },
-                        {
-                            "value": "delete:organization_member_roles",
-                            "description": "Delete organization member roles"
-                        },
-                        {
-                            "value": "create:organization_invitations",
-                            "description": "Create organization invitations"
-                        },
-                        {
-                            "value": "read:organization_invitations",
-                            "description": "Read organization invitations"
-                        },
-                        {
-                            "value": "delete:organization_invitations",
-                            "description": "Delete organization invitations"
+                            "description": "Delete Authentication Methods",
+                            "value": "delete:authentication_methods"
                         }
                     ],
                     "is_system": true
@@ -11533,7 +10558,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX",
+                    "client_id": "c8nvdJtD5LUgKXb5FjOrpceF33944rYB",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11547,6 +10572,64 @@
                         "refresh_token",
                         "client_credentials"
                     ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -11577,7 +10660,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "0Jd8ECcZhIIS4sYW9Z4qSz2i3rxrV63q",
+                    "client_id": "x2Bl4nQKyYH2zIZqJF9YHPe5ZekiJUjQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11628,7 +10711,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11648,21 +10731,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -11681,8 +10752,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "allowed_origins": [],
-                    "client_id": "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11690,16 +10760,11 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
-                    "web_origins": [],
                     "custom_login_page_on": true
                 },
                 {
@@ -11739,7 +10804,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
+                    "client_id": "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11753,98 +10818,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11890,7 +10863,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "mpbikzBJWwRP9nJQbbNGzdYxsC98kN5m",
+                    "client_id": "9JQOzx5b7TGmrhKkHkpeUrPf9CJ4WSQg",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11908,6 +10881,58 @@
                     ],
                     "web_origins": [
                         "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
                     ],
                     "custom_login_page_on": true
                 }
@@ -11928,7 +10953,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -11971,12 +10996,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -11994,7 +11019,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -12014,7 +11039,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_Vtsb73LK2IOecB11",
+                    "id": "con_6rdZLHrGBvNFSF8U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12057,12 +11082,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "A3SFksUhLuc4eCXmcyto0wMAfbV2QzdN",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "adeKlUfbMZ7wvXh1SIHHrmrDa7jRaAyM"
                     ]
                 },
                 {
-                    "id": "con_VqEWDbU3psp0T0TD",
+                    "id": "con_XF2IeVZmdqN5MzHN",
                     "options": {
                         "email": true,
                         "scope": [
@@ -12078,12 +11103,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "gW3JKUEirusM1ahTxbvNpeZCf3Ibqt3Z",
-                        "emN85iFnwZMZCGpa9ngws4VtslM2Nsmw"
+                        "Sv4p9dcS4PE8VNT3laIGAA8VEIMAiZO7",
+                        "YDNFRMY7PRg245q9kX5VFDE3QHGAkr3L"
                     ]
                 },
                 {
-                    "id": "con_TCTd3NlTfu8widbC",
+                    "id": "con_vKGKyyDISDZMInSa",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12101,7 +11126,7 @@
                     ],
                     "enabled_clients": [
                         "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
-                        "fGswdZhvYmClMjyBtVx4UQyOX1iTpLdX"
+                        "c8nvdJtD5LUgKXb5FjOrpceF33944rYB"
                     ]
                 }
             ]
@@ -12197,6 +11222,51 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
@@ -12212,7 +11282,85 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
         "response": {
@@ -12246,129 +11394,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/client-grants?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -12377,6 +11402,143 @@
             "start": 0,
             "limit": 100,
             "client_grants": [
+                {
+                    "id": "cgr_2lE4NL6nwOBZWY9k",
+                    "client_id": "KYBUXcugoN0kSO6EEjuUa5rL8SP8tXOb",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
                 {
                     "id": "cgr_iodSzvwxqm51tLZF",
                     "client_id": "GIW99EUCF9DFExh77WPMyTMzT8NN4J3A",
@@ -12516,145 +11678,8 @@
                     ]
                 },
                 {
-                    "id": "cgr_r2ghlZPm4B5VAUbP",
-                    "client_id": "QBODEVqWDWZa9sOlwtr5L5bHmeCyA8rX",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
-                },
-                {
-                    "id": "cgr_ybuyiJ6ov15TDJyE",
-                    "client_id": "91JbHCVGBcFXZGAsjUkTeCczTqrtnInh",
+                    "id": "cgr_zF9xXPmO64MKrqyu",
+                    "client_id": "XFYIRy547a6yJARzaGpbyV64KJp5TRCj",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -12848,6 +11873,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
@@ -12857,16 +11892,6 @@
             "from": "from bar",
             "messaging_service_sid": "foo"
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
-        "body": "",
-        "status": 200,
-        "response": {},
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -12926,22 +11951,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_yadEKRjs1mhMWTzQ",
+                    "id": "rol_E8FYyc4yRytSemJV",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_fDrBFzOWx5SiJo32",
+                    "id": "rol_5dRdRg4d9VuibVDh",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_YHX0bBjDw1OKrIVB",
+                    "id": "rol_SACktg7qrEBTpAkh",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_k6IsMYUJQhlQtN6J",
+                    "id": "rol_zHXK9tGyLi4fvBil",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -12956,7 +11981,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_yadEKRjs1mhMWTzQ/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_E8FYyc4yRytSemJV/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12971,7 +11996,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_fDrBFzOWx5SiJo32/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_5dRdRg4d9VuibVDh/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12986,7 +12011,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_YHX0bBjDw1OKrIVB/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_SACktg7qrEBTpAkh/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13001,7 +12026,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_k6IsMYUJQhlQtN6J/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_zHXK9tGyLi4fvBil/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13125,207 +12150,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/organizations/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/signup/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-email/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/consent/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/invitation/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -13345,6 +12170,76 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-email/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
@@ -13355,7 +12250,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -13375,11 +12270,143 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/consent/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/invitation/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/organizations/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/common/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/migrations",
         "body": "",
         "status": 200,
         "response": {
-            "flags": {}
+            "flags": {
+                "role_users_offset_pagination_over_thousand": true
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13393,7 +12420,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "33c963a5-bcd8-46a6-86ac-20d4a41c13ad",
+                    "id": "5992c6f4-daae-4079-9aa6-f4111823c6be",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -13401,34 +12428,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2022-07-29T14:53:28.697788039Z",
-                    "updated_at": "2022-07-29T15:31:21.868184183Z",
+                    "created_at": "2023-01-27T13:22:16.579099437Z",
+                    "updated_at": "2023-01-27T13:22:16.587984016Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2022-07-29T15:31:22.444672116Z",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z"
+                        "number": 1,
+                        "build_time": "2023-01-27T13:22:17.032504530Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "6c694496-3c11-4991-a753-1c409d8a0da7",
+                        "id": "6a39ef63-7d53-4d4e-9b19-b7138d19604c",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2022-07-29T15:31:22.444672116Z",
+                        "number": 1,
+                        "built_at": "2023-01-27T13:22:17.032504530Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2022-07-29T15:31:22.300547590Z",
-                        "updated_at": "2022-07-29T15:31:22.446232527Z",
+                        "created_at": "2023-01-27T13:22:16.918712794Z",
+                        "updated_at": "2023-01-27T13:22:17.034577338Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -13466,6 +12493,17 @@
                 },
                 {
                     "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -13481,28 +12519,6 @@
                     ]
                 },
                 {
-                    "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "credentials-exchange",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -13513,7 +12529,7 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "pre-user-registration",
+                    "id": "credentials-exchange",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -13534,6 +12550,28 @@
                     "compatible_triggers": []
                 },
                 {
+                    "id": "pre-user-registration",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-user-registration",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
+                },
+                {
                     "id": "post-user-registration",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -13544,7 +12582,7 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-user-registration",
+                    "id": "post-change-password",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -13562,17 +12600,6 @@
                         "node12"
                     ],
                     "default_runtime": "node12",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-change-password",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16"
-                    ],
-                    "default_runtime": "node16",
                     "compatible_triggers": []
                 },
                 {
@@ -13687,7 +12714,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_fIFox2I32Pb2i7a0",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -13698,7 +12725,7 @@
                     }
                 },
                 {
-                    "id": "org_NKqJCufgliq6yM1o",
+                    "id": "org_JOPN2fgtRT7bjM6X",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -13719,7 +12746,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_UbEQO06JATYNqOSu",
+                    "id": "org_fIFox2I32Pb2i7a0",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -13730,7 +12757,7 @@
                     }
                 },
                 {
-                    "id": "org_NKqJCufgliq6yM1o",
+                    "id": "org_JOPN2fgtRT7bjM6X",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -13742,7 +12769,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_UbEQO06JATYNqOSu/enabled_connections",
+        "path": "/api/v2/organizations/org_fIFox2I32Pb2i7a0/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -13752,10 +12779,30 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_NKqJCufgliq6yM1o/enabled_connections",
+        "path": "/api/v2/organizations/org_JOPN2fgtRT7bjM6X/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -13808,34 +12855,29 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/log-streams?paginate=false",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000006221",
+                "id": "lst_0000000000008174",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000008175",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-b0f3b975-aee7-4adf-8ee8-4a30f48867fb/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-eeaf2545-d189-4917-a958-35b7dd9d13e2/auth0.logs"
                 },
                 "filters": [
                     {

--- a/test/e2e/testdata/lots-of-configuration/tenant.yaml
+++ b/test/e2e/testdata/lots-of-configuration/tenant.yaml
@@ -738,3 +738,8 @@ logStreams:
         aws.partner/auth0.com/auth0-user-79f1a6de-7fc2-47de-9202-4b7b15c9d601/auth0.logs
     status: active
     type: eventbridge
+  - name: Suspended DD Log Stream
+    sink:
+      datadogApiKey: some-sensitive-api-key
+      datadogRegion: us
+    type: datadog

--- a/test/tools/auth0/handlers/logStreams.test.ts
+++ b/test/tools/auth0/handlers/logStreams.test.ts
@@ -27,17 +27,6 @@ const logStreams = [
       httpEndpoint: 'https://example.com/test',
     },
   },
-  {
-    id: 'log-stream-3',
-    name: 'Suspended Log Stream',
-    type: 'http',
-    status: 'suspended',
-    sink: {
-      httpContentFormat: 'JSONLINES',
-      httpContentType: 'application/json',
-      httpEndpoint: 'https://example.com/test',
-    },
-  },
 ];
 
 const auth0ApiClientMock = {
@@ -60,11 +49,7 @@ describe('#logStreams handler', () => {
       const handler = new logStreamsHandler({ client: auth0ApiClientMock });
       const data = await handler.load();
 
-      const expectedLogStreams = logStreams.filter((logStream) => {
-        return logStream.status !== 'suspended';
-      });
-
-      expect(data).to.deep.equal({ logStreams: expectedLogStreams });
+      expect(data).to.deep.equal({ logStreams });
     });
 
     it('should update log streams settings', async () => {
@@ -80,8 +65,10 @@ describe('#logStreams handler', () => {
               const value = logStreams.find((logStream) => {
                 return logStream.id === id;
               });
-              delete value.id;
-              delete value.type;
+              delete value.id; // Not expecting ID in PATCH payload
+              delete value.type; // Not expecting type in PATCH payload
+              //@ts-ignore because it's actually ok for status property to be omitted in PATCH payload
+              if (value?.status === 'suspended') delete value.status; // Not expecting status in PATCH payload if suspended
               return value;
             })();
 


### PR DESCRIPTION
### 🔧 Changes

Log streams were added with #495 which initially ignored log streams that were in a suspended status. This was mostly because the behavior of these log streams were slightly different and unknown. Ignoring these log streams caused a couple issues but most notably, if a target tenant has a log stream that has been suspended and applying configuration to it, the Deploy CLI will think that the suspended log stream does not exist and attempt to create a new one. With strict limits on the number of log streams, this is likely to be problematic.

This time around, the behavior of suspended log streams is better understood:

- Cannot be put log stream directly into a suspended status
- Log streams are put into a suspended state after some number of failed log deliveries
- Cannot specify any status at creation but can specify either paused or active status at update
- Cannot specify "status": "suspended" when updating an already suspended log stream
- Can update other properties of a suspended log stream, status remains suspended, will not activate

In addition to adding suspended log streams support and updating the tests, I expanded the documentation around HTTP recordings and some basic troubleshooting instructions. 

### 📚 References

- [Auth0 Log Streams](https://auth0.com/docs/customize/log-streams)

### 🔬 Testing

Added a couple of unit tests, but they're not great and mostly test the implementation. To really ensure functionality, the existing E2E tests add partial support. However, it is impossible to directly put a log stream into a suspended state, so we are not able to test this against real remote tenants.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
