### PR TITLE
DXCDT-292: Handling undefined tenant languages

### DIFF
--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -188,9 +188,10 @@ export default class PromptsHandler extends DefaultHandler {
   async getCustomTextSettings(): Promise<AllPromptsByLanguage> {
     const supportedLanguages = await this.client.tenant
       .getSettings()
-      .then(({ enabled_locales }) => enabled_locales);
-
-    if (supportedLanguages === undefined) return {}; // In rare cases, private cloud tenants may not have `enabled_locales` defined
+      .then(({ enabled_locales }) => {
+        if (enabled_locales === undefined) return []; // In rare cases, private cloud tenants may not have `enabled_locales` defined
+        return enabled_locales;
+      });
 
     const data = await Promise.all(
       supportedLanguages

--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -190,6 +190,8 @@ export default class PromptsHandler extends DefaultHandler {
       .getSettings()
       .then(({ enabled_locales }) => enabled_locales);
 
+    if (supportedLanguages === undefined) return {}; // In rare cases, private cloud tenants may not have `enabled_locales` defined
+
     const data = await Promise.all(
       supportedLanguages
         .map((language) => {

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -9,7 +9,7 @@ export const schema = {
   type: 'object',
 };
 
-export type Tenant = Asset & { enabled_locales: Language[]; flags: { [key: string]: boolean } };
+export type Tenant = Asset & { enabled_locales?: Language[]; flags: { [key: string]: boolean } };
 
 const blockPageKeys = [
   ...Object.keys(pageNameMap),

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -166,5 +166,26 @@ describe('#prompts handler', () => {
       expect(didCallUpdateCustomText).to.equal(true);
       expect(numberOfUpdateCustomTextCalls).to.equal(3);
     });
+
+    it('should not fail if tenant languages undefined', async () => {
+      const auth0 = {
+        tenant: {
+          getSettings: () =>
+            Promise.resolve({
+              enabled_locales: undefined,
+            }),
+        },
+        prompts: {
+          getSettings: () => mockPromptsSettings,
+        },
+      };
+
+      const handler = new promptsHandler({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({
+        ...mockPromptsSettings,
+        customText: {}, // Custom text empty
+      });
+    });
   });
 });


### PR DESCRIPTION
### 🔧 Changes

There are rare cases where Private Cloud tenants may not have tenant languages defined through the `enabled_locales` property. Usually, this property lists a non-empty array of languages which feeds into the prompts handler to dictate which prompts to return. However, when it is undefined, it will cause a runtime error. This PR prevents the runtime error and effectively ignores prompts from being dumped; custom text prompts can still be imported as appropriate.

### 📚 References

Original service desk ticket:

>The customer reported that the CLI is failing when retrieving prompts data from Auth0 with the following error upon export in the directory structure: "Problem running command export during stage load when processing type prompts. Cannot read property 'map' of undefined" This is happening only on this tenant and not on any other tenant from them so it may be a configuration issue. 

### 🔬 Testing

Added unit test.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
