### PR TITLE
DXCDT-358: Client grants with API name when exporting with directory format

### DIFF
--- a/src/context/directory/handlers/clientGrants.ts
+++ b/src/context/directory/handlers/clientGrants.ts
@@ -12,9 +12,10 @@ import {
 } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { ClientGrant } from '../../../tools/auth0/handlers/clientGrants';
 
-type ParsedClientGrants = ParsedAsset<'clientGrants', Asset[]>;
+type ParsedClientGrants = ParsedAsset<'clientGrants', ClientGrant[]>;
 
 function parse(context: DirectoryContext): ParsedClientGrants {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
@@ -39,15 +40,29 @@ async function dump(context: DirectoryContext): Promise<void> {
   const grantsFolder = path.join(context.filePath, constants.CLIENTS_GRANTS_DIRECTORY);
   fs.ensureDirSync(grantsFolder);
 
+  const allResourceServers = await context.mgmtClient.resourceServers.getAll({
+    paginate: true,
+  });
+
   // Convert client_id to the client name for readability
-  clientGrants.forEach((grant: Asset) => {
+  clientGrants.forEach((grant: ClientGrant) => {
     const dumpGrant = { ...grant };
 
     if (context.assets.clientsOrig) {
       dumpGrant.client_id = convertClientIdToName(dumpGrant.client_id, context.assets.clientsOrig);
     }
 
-    const name = sanitize(`${dumpGrant.client_id}`);
+    const apiName = (() => {
+      const associatedAPI = allResourceServers.find((resourceServer) => {
+        return resourceServer.identifier === grant.audience;
+      });
+
+      if (associatedAPI === undefined) return grant.audience;
+
+      return associatedAPI.name;
+    })();
+
+    const name = sanitize(`${dumpGrant.client_id}-${apiName}`);
     const grantFile = path.join(grantsFolder, `${name}.json`);
 
     dumpJSON(grantFile, dumpGrant);

--- a/src/context/directory/handlers/resourceServers.ts
+++ b/src/context/directory/handlers/resourceServers.ts
@@ -4,9 +4,10 @@ import { constants } from '../../../tools';
 import { getFiles, existsMustBeDir, dumpJSON, loadJSON, sanitize } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { ResourceServer } from '../../../tools/auth0/handlers/resourceServers';
 
-type ParsedResourceServers = ParsedAsset<'resourceServers', Asset[]>;
+type ParsedResourceServers = ParsedAsset<'resourceServers', ResourceServer[]>;
 
 function parse(context: DirectoryContext): ParsedResourceServers {
   const resourceServersFolder = path.join(context.filePath, constants.RESOURCE_SERVERS_DIRECTORY);

--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -1,9 +1,10 @@
 import { convertClientIdToName } from '../../../utils';
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { ClientGrant } from '../../../tools/auth0/handlers/clientGrants';
 
-type ParsedClientGrants = ParsedAsset<'clientGrants', Asset[]>;
+type ParsedClientGrants = ParsedAsset<'clientGrants', ClientGrant[]>;
 
 async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
   const { clientGrants } = context.assets;

--- a/src/context/yaml/handlers/resourceServers.ts
+++ b/src/context/yaml/handlers/resourceServers.ts
@@ -1,8 +1,9 @@
 import { YAMLHandler } from '.';
 import YAMLContext from '..';
-import { Asset, ParsedAsset } from '../../../types';
+import { ParsedAsset } from '../../../types';
+import { ResourceServer } from '../../../tools/auth0/handlers/resourceServers';
 
-type ParsedResourceServers = ParsedAsset<'resourceServers', Asset[]>;
+type ParsedResourceServers = ParsedAsset<'resourceServers', ResourceServer[]>;
 
 async function dumpAndParse(context: YAMLContext): Promise<ParsedResourceServers> {
   const { resourceServers } = context.assets;

--- a/src/tools/auth0/handlers/clientGrants.ts
+++ b/src/tools/auth0/handlers/clientGrants.ts
@@ -20,8 +20,14 @@ export const schema = {
   },
 };
 
+export type ClientGrant = {
+  client_id: string;
+  audience: string;
+  scope: string[];
+};
+
 export default class ClientGrantsHandler extends DefaultHandler {
-  existing: Asset[] | null;
+  existing: ClientGrant[] | null;
 
   constructor(config: DefaultAPIHandler) {
     super({
@@ -38,7 +44,7 @@ export default class ClientGrantsHandler extends DefaultHandler {
     return super.objString({ id: item.id, client_id: item.client_id, audience: item.audience });
   }
 
-  async getType(): Promise<Asset> {
+  async getType(): Promise<ClientGrant[]> {
     if (this.existing) {
       return this.existing;
     }

--- a/src/tools/auth0/handlers/resourceServers.ts
+++ b/src/tools/auth0/handlers/resourceServers.ts
@@ -3,7 +3,7 @@ import ValidationError from '../../validationError';
 import constants from '../../constants';
 import DefaultHandler from './default';
 import { calculateChanges } from '../../calculateChanges';
-import { Asset, Assets, CalculatedChanges } from '../../../types';
+import { Assets, CalculatedChanges } from '../../../types';
 
 export const excludeSchema = {
   type: 'array',
@@ -34,8 +34,14 @@ export const schema = {
   },
 };
 
+export type ResourceServer = {
+  id: string;
+  name: string;
+  identifier: string;
+  scopes?: { description: string; value: string }[];
+};
 export default class ResourceServersHandler extends DefaultHandler {
-  existing: Asset[];
+  existing: ResourceServer[];
 
   constructor(options: DefaultHandler) {
     super({
@@ -49,7 +55,7 @@ export default class ResourceServersHandler extends DefaultHandler {
     return super.objString({ name: resourceServer.name, identifier: resourceServer.identifier });
   }
 
-  async getType(): Promise<Asset[]> {
+  async getType(): Promise<ResourceServer[]> {
     if (this.existing) return this.existing;
     const resourceServers = await this.client.resourceServers.getAll({
       paginate: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ import { Tenant } from './tools/auth0/handlers/tenant';
 import { Theme } from './tools/auth0/handlers/themes';
 import { Page } from './tools/auth0/handlers/pages';
 import { LogStream } from './tools/auth0/handlers/logStreams';
+import { ClientGrant } from './tools/auth0/handlers/clientGrants';
+import { ResourceServer } from './tools/auth0/handlers/resourceServers';
 
 type SharedPaginationParams = {
   checkpoint?: boolean;
@@ -80,7 +82,12 @@ export type BaseAuth0APIClient = {
     deleteTheme: (arg0: { id: string }) => Promise<void>;
   };
   clients: APIClientBaseFunctions;
-  clientGrants: APIClientBaseFunctions;
+  clientGrants: {
+    getAll: (arg0: SharedPaginationParams) => Promise<ClientGrant[]>;
+    create: (arg0: { id: string }) => Promise<ClientGrant>;
+    update: (arg0: {}, arg1: Partial<ClientGrant>) => Promise<ClientGrant>;
+    delete: (arg0: Asset) => Promise<void>;
+  };
   connections: APIClientBaseFunctions & {
     get: (arg0: Asset) => Promise<Asset>;
     getAll: (arg0: PagePaginationParams | CheckpointPaginationParams) => Promise<Asset[]>;
@@ -148,7 +155,12 @@ export type BaseAuth0APIClient = {
     getSettings: () => Promise<PromptSettings>;
     updateSettings: (arg0: {}, arg1: Partial<PromptSettings>) => Promise<void>;
   };
-  resourceServers: APIClientBaseFunctions;
+  resourceServers: {
+    getAll: (arg0: SharedPaginationParams) => Promise<ResourceServer[]>;
+    create: (arg0: { id: string }) => Promise<ResourceServer>;
+    update: (arg0: {}, arg1: Partial<ResourceServer>) => Promise<ResourceServer>;
+    delete: (arg0: Asset) => Promise<void>;
+  };
   roles: APIClientBaseFunctions & {
     permissions: APIClientBaseFunctions & {
       delete: (arg0: { id: string }, arg1: { permissions: Asset[] }) => Promise<void>;
@@ -221,7 +233,7 @@ export type Assets = Partial<{
       })
     | null;
   clients: Asset[] | null;
-  clientGrants: Asset[] | null;
+  clientGrants: ClientGrant[] | null;
   connections: Asset[] | null;
   customDomains: Asset[] | null;
   databases: Asset[] | null;
@@ -243,7 +255,7 @@ export type Assets = Partial<{
   organizations: Asset[] | null;
   pages: Page[] | null;
   prompts: Prompts | null;
-  resourceServers: Asset[] | null;
+  resourceServers: ResourceServer[] | null;
   roles: Asset[] | null;
   rules: Asset[] | null;
   rulesConfigs: Asset[] | null;

--- a/test/context/directory/clientGrants.test.js
+++ b/test/context/directory/clientGrants.test.js
@@ -13,15 +13,24 @@ describe('#directory context clientGrants', () => {
   it('should process clientGrants', async () => {
     const files = {
       [constants.CLIENTS_GRANTS_DIRECTORY]: {
-        'test.json': `
-          {
-           "client_id": "auth0-webhooks",
-           "audience": "https://test.auth0.com/api/v2/",
-           "scope": [
-              "read:logs"
-           ],
-           "var": @@var@@
-          }`,
+        'Primary M2M-Auth0 Management API.json': `
+        {
+          "audience": "https://travel0.us.auth0.com/api/v2",
+          "client_id": "Primary M2M",
+          "scope": ["read:users"]
+        }`,
+        'Primary M2M-Payments Service.json': `
+        {
+          "audience": "https://payments.travel0.com/api",
+          "client_id": "Primary M2M",
+          "scope": ["update:card", "create:card", "delete:card"]
+        }`,
+        'some-arbitrary-filename.json': `
+        {
+          "audience": "https://payments.travel0.com/api",
+          "client_id": "Secondary M2M",
+          "scope": ["update:card", "create:card", "delete:card"]
+        }`,
       },
     };
 
@@ -35,16 +44,24 @@ describe('#directory context clientGrants', () => {
     const context = new Context(config, mockMgmtClient());
     await context.load();
 
-    const target = [
+    expect(context.assets.clientGrants).to.deep.equal([
       {
-        audience: 'https://test.auth0.com/api/v2/',
-        client_id: 'auth0-webhooks',
-        scope: ['read:logs'],
-        var: 'something',
+        audience: 'https://travel0.us.auth0.com/api/v2',
+        client_id: 'Primary M2M',
+        scope: ['read:users'],
       },
-    ];
 
-    expect(context.assets.clientGrants).to.deep.equal(target);
+      {
+        audience: 'https://payments.travel0.com/api',
+        client_id: 'Primary M2M',
+        scope: ['update:card', 'create:card', 'delete:card'],
+      },
+      {
+        audience: 'https://payments.travel0.com/api',
+        client_id: 'Secondary M2M',
+        scope: ['update:card', 'create:card', 'delete:card'],
+      },
+    ]);
   });
 
   it('should ignore unknown file', async () => {
@@ -108,20 +125,18 @@ describe('#directory context clientGrants', () => {
       {
         ...mockMgmtClient(),
         resourceServers: {
-          getAll: () => {
-            return [
-              {
-                id: 'resource-server-1',
-                name: 'Payments Service',
-                identifier: 'https://payments.travel0.com/api',
-              },
-              {
-                id: 'resource-server-2',
-                name: 'Auth0 Management API',
-                identifier: 'https://travel0.us.auth0.com/api/v2',
-              },
-            ];
-          },
+          getAll: () => [
+            {
+              id: 'resource-server-1',
+              name: 'Payments Service',
+              identifier: 'https://payments.travel0.com/api',
+            },
+            {
+              id: 'resource-server-2',
+              name: 'Auth0 Management API',
+              identifier: 'https://travel0.us.auth0.com/api/v2',
+            },
+          ],
         },
       }
     );
@@ -130,7 +145,7 @@ describe('#directory context clientGrants', () => {
       {
         audience: 'https://travel0.us.auth0.com/api/v2',
         client_id: 'Primary M2M',
-        scope: ['update:account'],
+        scope: ['read:users'],
       },
       {
         audience: 'https://payments.travel0.com/api',


### PR DESCRIPTION
### 🔧 Changes

In #684 we removed a client grant's audience from the filename when exporting with directory mode. This was removed because audiences (ex: `https://example-prod.us.auth0.com/api/v2/`) are environment-specific values and violate the tenant-agnostic nature of this tool. That is, it would be jarring for a developer if it appeared that their development client grants were being propagated to production. However there can be multiple client grants associated to a single client, in these cases the client grants for a single client were getting overwritten. This was reported as a bug with #722.

The proposed fix in this PR is to perform a lookup of the audience and match it to the human-friendly API name. The uniqueness of the name will prevent overrides and the API name is tenant-agnostic so it solves the original issue.

The import remains unaffected because the name of the file does not matter, no data is sourced from it.

### 📚 References

Relate Github issue: #722
Original Github issue: #459

### 🔬 Testing

Extended the current test cases to introduce the scenario of multiple client grants for a single client. 

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
