### PR TITLE
Adding `shouldFieldBePreserved` function

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,0 +1,14 @@
+import { KeywordMappings } from './types';
+import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
+
+export const shouldFieldBePreserved = (
+  string: string,
+  keywordMappings: KeywordMappings
+): boolean => {
+  return !Object.keys(keywordMappings).every((keyword) => {
+    const hasArrayMarker = keywordReplaceArrayRegExp(keyword).test(string);
+    const hasStringMarker = keywordReplaceStringRegExp(keyword).test(string);
+
+    return !hasArrayMarker && !hasStringMarker;
+  });
+};

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -6,13 +6,22 @@ import log from '../logger';
 import { Asset, Assets, CalculatedChanges, KeywordMappings } from '../types';
 import constants from './constants';
 
+export const keywordReplaceArrayRegExp = (key) => {
+  const pattern = `@@${key}@@`;
+  const patternWithQuotes = `"${pattern}"`;
+
+  return new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
+};
+
+export const keywordReplaceStringRegExp = (key) => {
+  return new RegExp(`##${key}##`, 'g');
+};
+
 export function keywordArrayReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
     // Matching against two sets of patterns because a developer may provide their array replacement keyword with or without wrapping quotes. It is not obvious to the developer which to do depending if they're operating in YAML or JSON.
-    const pattern = `@@${key}@@`;
-    const patternWithQuotes = `"${pattern}"`;
+    const regex = keywordReplaceArrayRegExp(key);
 
-    const regex = new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
     input = input.replace(regex, JSON.stringify(mappings[key]));
   });
   return input;
@@ -20,7 +29,7 @@ export function keywordArrayReplace(input: string, mappings: KeywordMappings): s
 
 export function keywordStringReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
-    const regex = new RegExp(`##${key}##`, 'g');
+    const regex = keywordReplaceStringRegExp(key);
     // @ts-ignore TODO: come back and distinguish strings vs array replacement.
     input = input.replace(regex, mappings[key]);
   });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { shouldFieldBePreserved } from '../src/keywordPreservation';
+
+describe('#Keyword Preservation', () => {
+  describe('shouldFieldBePreserved', () => {
+    it('should return false when field does not contain keyword markers', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this is a field without a keyword marker', keywordMappings)).to
+        .be.false;
+      expect(shouldFieldBePreserved('this field has an invalid @keyword@ marker', keywordMappings))
+        .to.be.false;
+    });
+
+    it('should return false when field contain keyword markers but are absent in keyword mappings', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this field has a @@FOO@@ marker', keywordMappings)).to.be
+        .false;
+    });
+
+    it('should return true when field contain keyword markers that exist in keyword mappings', () => {
+      const keywordMappings = {
+        FOO: 'foo keyword',
+        BAR: 'bar keyword',
+        ARRAY: ['foo', 'bar'],
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('this field has a ##FOO## marker', keywordMappings)).to.be.true;
+      expect(
+        shouldFieldBePreserved('this field has both a ##FOO## and ##BAR## marker', keywordMappings)
+      ).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
### 🔧 Changes

The first part of many to implement a fix for #328.  At the most basic level, we need to identify which fields to preserve before can actually preserve them. 

This function doesn't serve much function in its current form, but it will be used by higher-order functions to compose the keyword preservation functionality. 

This PR starts to lay the foundation for the keyword preservation code in both the `keywordPreservation.ts` file as well as the accompanying test file.

### 📚 References

Related Issues:
- #328 
- #688 

### 🔬 Testing

Many unit tests included to cover a wide-range of situations.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
