### PR TITLE
DXCDT-372: Traverse assets tree for preservable fields

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -12,3 +12,33 @@ export const shouldFieldBePreserved = (
     return !hasArrayMarker && !hasStringMarker;
   });
 };
+
+export const getPreservableFieldsFromAssets = (
+  asset: any,
+  keywordMappings: KeywordMappings
+): string[] => {
+  if (typeof asset === 'string') {
+    if (shouldFieldBePreserved(asset, keywordMappings)) {
+      return [asset];
+    }
+    return [];
+  }
+  if (Array.isArray(asset)) {
+    return asset
+      .map((arrayItem) => {
+        return getPreservableFieldsFromAssets(arrayItem, keywordMappings);
+      })
+      .flat();
+  }
+  if (typeof asset === 'object') {
+    return Object.keys(asset)
+      .map((key: string): string[] => {
+        const value = asset[key];
+
+        if (value === undefined || value === null) return [];
+        return getPreservableFieldsFromAssets(value, keywordMappings);
+      })
+      .flat();
+  }
+  return [];
+};

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,0 +1,14 @@
+import { KeywordMappings } from './types';
+import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
+
+export const shouldFieldBePreserved = (
+  string: string,
+  keywordMappings: KeywordMappings
+): boolean => {
+  return !Object.keys(keywordMappings).every((keyword) => {
+    const hasArrayMarker = keywordReplaceArrayRegExp(keyword).test(string);
+    const hasStringMarker = keywordReplaceStringRegExp(keyword).test(string);
+
+    return !hasArrayMarker && !hasStringMarker;
+  });
+};

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -6,13 +6,22 @@ import log from '../logger';
 import { Asset, Assets, CalculatedChanges, KeywordMappings } from '../types';
 import constants from './constants';
 
+export const keywordReplaceArrayRegExp = (key) => {
+  const pattern = `@@${key}@@`;
+  const patternWithQuotes = `"${pattern}"`;
+
+  return new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
+};
+
+export const keywordReplaceStringRegExp = (key) => {
+  return new RegExp(`##${key}##`, 'g');
+};
+
 export function keywordArrayReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
     // Matching against two sets of patterns because a developer may provide their array replacement keyword with or without wrapping quotes. It is not obvious to the developer which to do depending if they're operating in YAML or JSON.
-    const pattern = `@@${key}@@`;
-    const patternWithQuotes = `"${pattern}"`;
+    const regex = keywordReplaceArrayRegExp(key);
 
-    const regex = new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
     input = input.replace(regex, JSON.stringify(mappings[key]));
   });
   return input;
@@ -20,7 +29,7 @@ export function keywordArrayReplace(input: string, mappings: KeywordMappings): s
 
 export function keywordStringReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
-    const regex = new RegExp(`##${key}##`, 'g');
+    const regex = keywordReplaceStringRegExp(key);
     // @ts-ignore TODO: come back and distinguish strings vs array replacement.
     input = input.replace(regex, mappings[key]);
   });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { shouldFieldBePreserved } from '../src/keywordPreservation';
+
+describe('#Keyword Preservation', () => {
+  describe('shouldFieldBePreserved', () => {
+    it('should return false when field does not contain keyword markers', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this is a field without a keyword marker', keywordMappings)).to
+        .be.false;
+      expect(shouldFieldBePreserved('this field has an invalid @keyword@ marker', keywordMappings))
+        .to.be.false;
+    });
+
+    it('should return false when field contain keyword markers but are absent in keyword mappings', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this field has a @@FOO@@ marker', keywordMappings)).to.be
+        .false;
+    });
+
+    it('should return true when field contain keyword markers that exist in keyword mappings', () => {
+      const keywordMappings = {
+        FOO: 'foo keyword',
+        BAR: 'bar keyword',
+        ARRAY: ['foo', 'bar'],
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('this field has a ##FOO## marker', keywordMappings)).to.be.true;
+      expect(
+        shouldFieldBePreserved('this field has both a ##FOO## and ##BAR## marker', keywordMappings)
+      ).to.be.true;
+    });
+  });
+});

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -62,6 +62,8 @@ describe('#Keyword Preservation', () => {
             },
           ],
           arrayReplace: '@@ARRAY_REPLACE_KEYWORD@@',
+          nullField: null,
+          undefinedField: undefined,
         },
         {
           KEYWORD: 'Travel0',

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { shouldFieldBePreserved } from '../src/keywordPreservation';
+import { shouldFieldBePreserved, getPreservableFieldsFromAssets } from '../src/keywordPreservation';
 
 describe('#Keyword Preservation', () => {
   describe('shouldFieldBePreserved', () => {
@@ -36,6 +36,44 @@ describe('#Keyword Preservation', () => {
       expect(
         shouldFieldBePreserved('this field has both a ##FOO## and ##BAR## marker', keywordMappings)
       ).to.be.true;
+    });
+  });
+
+  describe('getPreservableFieldsFromAssets', () => {
+    it('should retrieve all preservable fields from assets tree', () => {
+      const fieldsToPreserve = getPreservableFieldsFromAssets(
+        {
+          object: {
+            friendly_name: 'Friendly name ##KEYWORD##',
+            notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
+            number: 5,
+            boolean: true,
+            nested: {
+              nestedProperty: 'Nested property ##KEYWORD##',
+            },
+          },
+          array: [
+            {
+              nestedArray: ['Nested array value 1 ##KEYWORD##', 'Nested array value 2 ##KEYWORD##'],
+              notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
+              nested: {
+                nestedProperty: 'Another nested array property ##KEYWORD##',
+              },
+            },
+          ],
+        },
+        {
+          KEYWORD: 'Travel0',
+        }
+      );
+
+      expect(fieldsToPreserve).to.have.members([
+        'Friendly name ##KEYWORD##',
+        'Nested property ##KEYWORD##',
+        'Nested array value 1 ##KEYWORD##',
+        'Nested array value 2 ##KEYWORD##',
+        'Another nested array property ##KEYWORD##',
+      ]);
     });
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -61,9 +61,11 @@ describe('#Keyword Preservation', () => {
               },
             },
           ],
+          arrayReplace: '@@ARRAY_REPLACE_KEYWORD@@',
         },
         {
           KEYWORD: 'Travel0',
+          ARRAY_REPLACE_KEYWORD: ['this value', 'that value'],
         }
       );
 
@@ -73,6 +75,7 @@ describe('#Keyword Preservation', () => {
         'Nested array value 1 ##KEYWORD##',
         'Nested array value 2 ##KEYWORD##',
         'Another nested array property ##KEYWORD##',
+        '@@ARRAY_REPLACE_KEYWORD@@',
       ]);
     });
   });


### PR DESCRIPTION
### 🔧 Changes

Part two of keyword preservation implementation by building off of #738. This PR introduces the ability to recursively traverse an arbitrary JSON structure and look for [preservable properties](https://github.com/auth0/auth0-cli/pulls/738). The recursion here is necessary because the assets tree is an amalgamation of all the different Auth0 resource types which contain their own arbitrary data structures which may differ on a tenant-by-tenant basis. 

Notably, this utility of this function is limited because it only produces a list of the field _values_ to preserve which may help us understand _what_ to preserve but it doesn't provide any guidance on where or how to preserve. The concept of "addresses" will be added in a follow-up PR which will improve the usefulness of this function, but wasn't added to keep this PR simple.

### 📚 References

Related Issues:

https://github.com/auth0/auth0-deploy-cli/issues/328
https://github.com/auth0/auth0-deploy-cli/issues/688


### 🔬 Testing

Added a single unit test that tests a variety of scenarios.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
