### PR TITLE
DXCDT-373: Address notation for keyword preservation

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -32,6 +32,12 @@ export const getPreservableFieldsFromAssets = (
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
+        // Using the `name` field as the primary unique identifier for array items
+        // TODO: expand the available identifier fields to encompass objects that lack name
+        const hasIdentifier = arrayItem.name !== undefined;
+
+        if (!hasIdentifier) return [];
+
         return getPreservableFieldsFromAssets(
           arrayItem,
           `${address}${shouldRenderDot ? '.' : ''}[name=${arrayItem.name}]`,

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -15,18 +15,23 @@ export const shouldFieldBePreserved = (
 
 export const getPreservableFieldsFromAssets = (
   asset: any,
+  address: string,
   keywordMappings: KeywordMappings
 ): string[] => {
   if (typeof asset === 'string') {
     if (shouldFieldBePreserved(asset, keywordMappings)) {
-      return [asset];
+      return [address];
     }
     return [];
   }
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
-        return getPreservableFieldsFromAssets(arrayItem, keywordMappings);
+        return getPreservableFieldsFromAssets(
+          arrayItem,
+          `${address}.[name=${arrayItem.name}]`,
+          keywordMappings
+        );
       })
       .flat();
   }
@@ -36,7 +41,7 @@ export const getPreservableFieldsFromAssets = (
         const value = asset[key];
 
         if (value === undefined || value === null) return [];
-        return getPreservableFieldsFromAssets(value, keywordMappings);
+        return getPreservableFieldsFromAssets(value, `${address}.${key}`, keywordMappings);
       })
       .flat();
   }

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -26,12 +26,15 @@ export const getPreservableFieldsFromAssets = (
     }
     return [];
   }
+
+  const shouldRenderDot = address !== '';
+
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
         return getPreservableFieldsFromAssets(
           arrayItem,
-          `${address}.[name=${arrayItem.name}]`,
+          `${address}${shouldRenderDot ? '.' : ''}[name=${arrayItem.name}]`,
           keywordMappings
         );
       })
@@ -43,26 +46,44 @@ export const getPreservableFieldsFromAssets = (
         const value = asset[key];
 
         if (value === undefined || value === null) return [];
-        return getPreservableFieldsFromAssets(value, `${address}.${key}`, keywordMappings);
+
+        return getPreservableFieldsFromAssets(
+          value,
+          `${address}${shouldRenderDot ? '.' : ''}${key}`,
+          keywordMappings
+        );
       })
       .flat();
   }
   return [];
 };
 
+// getAssetsValueByAddress returns a value for an arbitrary data structure when
+// provided an "address" of that value. This address is similar to JS object notation
+// with the exception of identifying array items by a unique property instead of order.
+// Example:
+// Object: `{ actions: [ { name: "action-1", code: "..."}] }`
+// Address: `.actions[name=action-1].code`
 export const getAssetsValueByAddress = (address: string, assets: any): any => {
+  //Look ahead and see if the address path only contains dots (ex: `tenant.friendly_name`)
+  //if so the address is trivial and can use the dot-prop package to return the value
+
   const isTrivialAddress = address.indexOf('[') === -1;
   if (isTrivialAddress) {
     return getByDotNotation(assets, address);
   }
 
+  // It is easier to handle an address piece-by-piece by
+  // splitting on the period into separate "directions"
   const directions = address.split('.');
 
-  if (directions.length === 0) return assets;
-
+  // If the the next directions are the proprietary array syntax (ex: `[name=foo]`)
+  // then perform lookup against unique array-item property
   if (directions[0].charAt(0) === '[') {
     const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
     const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+
+    if (assets === undefined) return undefined;
 
     const target = assets.find((item: any) => {
       return item[identifier] === identifierValue;

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,5 +1,7 @@
+import { get as getByDotNotation } from 'dot-prop';
 import { KeywordMappings } from './types';
 import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
+import { add } from 'lodash';
 
 export const shouldFieldBePreserved = (
   string: string,
@@ -46,4 +48,31 @@ export const getPreservableFieldsFromAssets = (
       .flat();
   }
   return [];
+};
+
+export const getAssetsValueByAddress = (address: string, assets: any): any => {
+  const isTrivialAddress = address.indexOf('[') === -1;
+  if (isTrivialAddress) {
+    return getByDotNotation(assets, address);
+  }
+
+  const directions = address.split('.');
+
+  if (directions.length === 0) return assets;
+
+  if (directions[0].charAt(0) === '[') {
+    const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
+    const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+
+    const target = assets.find((item: any) => {
+      return item[identifier] === identifierValue;
+    });
+
+    return getAssetsValueByAddress(directions.slice(1).join('.'), target);
+  }
+
+  return getAssetsValueByAddress(
+    directions.slice(1).join('.'),
+    getByDotNotation(assets, directions[0])
+  );
 };

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { shouldFieldBePreserved, getPreservableFieldsFromAssets } from '../src/keywordPreservation';
+import {
+  shouldFieldBePreserved,
+  getPreservableFieldsFromAssets,
+  getAssetsValueByAddress,
+} from '../src/keywordPreservation';
 
 describe('#Keyword Preservation', () => {
   describe('shouldFieldBePreserved', () => {
@@ -91,5 +95,47 @@ describe('#Keyword Preservation', () => {
         '.arrayReplace',
       ]);
     });
+  });
+});
+
+describe('getAssetsValueByAddress', () => {
+  it('should find address with proprietary notation', () => {
+    const mockAssetTree = {
+      tenant: {
+        display_name: 'This is my tenant display name',
+      },
+      clients: [
+        {
+          name: 'client-1',
+          display_name: 'Some Display Name',
+        },
+        {
+          name: 'client-2',
+          display_name: 'This is the target value',
+        },
+        {
+          name: 'client-3',
+          connections: [
+            {
+              connection_name: 'connection-1',
+              display_name: 'My connection display name',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getAssetsValueByAddress('tenant.display_name', mockAssetTree)).to.equal(
+      'This is my tenant display name'
+    );
+    expect(getAssetsValueByAddress('clients.[name=client-2].display_name', mockAssetTree)).to.equal(
+      'This is the target value'
+    );
+    expect(
+      getAssetsValueByAddress(
+        'clients.[name=client-3].connections.[connection_name=connection-1].display_name',
+        mockAssetTree
+      )
+    ).to.equal('My connection display name');
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -87,19 +87,19 @@ describe('#Keyword Preservation', () => {
       );
 
       expect(fieldsToPreserve).to.have.members([
-        '.object.friendly_name',
-        '.object.nested.nestedProperty',
-        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
-        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
-        '.array.[name=array-item-1].nested.nestedProperty',
-        '.arrayReplace',
+        'object.friendly_name',
+        'object.nested.nestedProperty',
+        'array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
+        'array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
+        'array.[name=array-item-1].nested.nestedProperty',
+        'arrayReplace',
       ]);
     });
   });
 });
 
 describe('getAssetsValueByAddress', () => {
-  it('should find address with proprietary notation', () => {
+  it('should find the value of the addressed property', () => {
     const mockAssetTree = {
       tenant: {
         display_name: 'This is my tenant display name',
@@ -137,5 +137,14 @@ describe('getAssetsValueByAddress', () => {
         mockAssetTree
       )
     ).to.equal('My connection display name');
+    expect(getAssetsValueByAddress('this.address.should.not.exist', mockAssetTree)).to.equal(
+      undefined
+    );
+    expect(getAssetsValueByAddress('this.address.[should=not].exist', mockAssetTree)).to.equal(
+      undefined
+    );
+    expect(getAssetsValueByAddress('this.address.should.[not=exist]', mockAssetTree)).to.equal(
+      undefined
+    );
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -54,7 +54,17 @@ describe('#Keyword Preservation', () => {
           },
           array: [
             {
-              nestedArray: ['Nested array value 1 ##KEYWORD##', 'Nested array value 2 ##KEYWORD##'],
+              name: 'array-item-1',
+              nestedArray: [
+                {
+                  name: 'nested-array-item-1',
+                  value: 'Nested array value 1 ##KEYWORD##',
+                },
+                {
+                  name: 'nested-array-item-2',
+                  value: 'Nested array value 2 ##KEYWORD##',
+                },
+              ],
               notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
               nested: {
                 nestedProperty: 'Another nested array property ##KEYWORD##',
@@ -65,6 +75,7 @@ describe('#Keyword Preservation', () => {
           nullField: null,
           undefinedField: undefined,
         },
+        '',
         {
           KEYWORD: 'Travel0',
           ARRAY_REPLACE_KEYWORD: ['this value', 'that value'],
@@ -72,12 +83,12 @@ describe('#Keyword Preservation', () => {
       );
 
       expect(fieldsToPreserve).to.have.members([
-        'Friendly name ##KEYWORD##',
-        'Nested property ##KEYWORD##',
-        'Nested array value 1 ##KEYWORD##',
-        'Nested array value 2 ##KEYWORD##',
-        'Another nested array property ##KEYWORD##',
-        '@@ARRAY_REPLACE_KEYWORD@@',
+        '.object.friendly_name',
+        '.object.nested.nestedProperty',
+        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
+        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
+        '.array.[name=array-item-1].nested.nestedProperty',
+        '.arrayReplace',
       ]);
     });
   });


### PR DESCRIPTION
### 🔧 Changes

Building off of the previous few PRs for keyword preservation (#736, #738 , #740), this PR introduces the concept of an "address". An address is a proprietary notation for looking-up properties within an arbitrary data structure, similar to JSON dot notation. The primary difference is the ability to identify array items by a unique field instead of order. What this does is set us up to identify preservable fields in on asset tree and then look-up its value on another asset tree by the address.

**Example:**
```
{
  "tenant": {
    "friendly_name": "Friendly name ##KEYWORD##"
  },
  "actions": [
    {
      "name": "action-1",
      "enabled": true
    }
  ]
}
```
**Address for tenant `friendly_name` field:** `tenant.friendly_name`
**Address for action `name` field:** `actions.[name=action-1].name`


### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
