### PR TITLE
DXCDT-374: Update field by address for keyword preservation

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -12,3 +12,33 @@ export const shouldFieldBePreserved = (
     return !hasArrayMarker && !hasStringMarker;
   });
 };
+
+export const getPreservableFieldsFromAssets = (
+  asset: any,
+  keywordMappings: KeywordMappings
+): string[] => {
+  if (typeof asset === 'string') {
+    if (shouldFieldBePreserved(asset, keywordMappings)) {
+      return [asset];
+    }
+    return [];
+  }
+  if (Array.isArray(asset)) {
+    return asset
+      .map((arrayItem) => {
+        return getPreservableFieldsFromAssets(arrayItem, keywordMappings);
+      })
+      .flat();
+  }
+  if (typeof asset === 'object') {
+    return Object.keys(asset)
+      .map((key: string): string[] => {
+        const value = asset[key];
+
+        if (value === undefined || value === null) return [];
+        return getPreservableFieldsFromAssets(value, keywordMappings);
+      })
+      .flat();
+  }
+  return [];
+};

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -32,6 +32,12 @@ export const getPreservableFieldsFromAssets = (
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
+        // Using the `name` field as the primary unique identifier for array items
+        // TODO: expand the available identifier fields to encompass objects that lack name
+        const hasIdentifier = arrayItem.name !== undefined;
+
+        if (!hasIdentifier) return [];
+
         return getPreservableFieldsFromAssets(
           arrayItem,
           `${address}${shouldRenderDot ? '.' : ''}[name=${arrayItem.name}]`,

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -102,3 +102,44 @@ export const getAssetsValueByAddress = (address: string, assets: any): any => {
     getByDotNotation(assets, directions[0])
   );
 };
+
+// convertAddressToDotNotation will convert the proprietary address into conventional
+// JS object notation. Performing this conversion simplifies the process
+// of updating a specific property for a given asset tree using the dot-prop library
+export const convertAddressToDotNotation = (
+  assets: any,
+  address: string,
+  finalAddressTrail = ''
+): string => {
+  const directions = address.split('.');
+
+  if (directions[0] === '') return finalAddressTrail;
+
+  if (directions[0].charAt(0) === '[') {
+    const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
+    const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+
+    let targetIndex = -1;
+
+    assets.forEach((item: any, index: number) => {
+      if (item[identifier] === identifierValue) {
+        targetIndex = index;
+      }
+    });
+
+    if (targetIndex === -1)
+      throw new Error(`Cannot find ${directions[0]} in ${JSON.stringify(assets)}`);
+
+    return convertAddressToDotNotation(
+      assets[targetIndex],
+      directions.slice(1).join('.'),
+      `${finalAddressTrail}.${targetIndex}`
+    );
+  }
+
+  return convertAddressToDotNotation(
+    getByDotNotation(assets, directions[0]),
+    directions.slice(1).join('.'),
+    finalAddressTrail === '' ? directions[0] : `${finalAddressTrail}.${directions[0]}`
+  );
+};

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -15,18 +15,23 @@ export const shouldFieldBePreserved = (
 
 export const getPreservableFieldsFromAssets = (
   asset: any,
+  address: string,
   keywordMappings: KeywordMappings
 ): string[] => {
   if (typeof asset === 'string') {
     if (shouldFieldBePreserved(asset, keywordMappings)) {
-      return [asset];
+      return [address];
     }
     return [];
   }
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
-        return getPreservableFieldsFromAssets(arrayItem, keywordMappings);
+        return getPreservableFieldsFromAssets(
+          arrayItem,
+          `${address}.[name=${arrayItem.name}]`,
+          keywordMappings
+        );
       })
       .flat();
   }
@@ -36,7 +41,7 @@ export const getPreservableFieldsFromAssets = (
         const value = asset[key];
 
         if (value === undefined || value === null) return [];
-        return getPreservableFieldsFromAssets(value, keywordMappings);
+        return getPreservableFieldsFromAssets(value, `${address}.${key}`, keywordMappings);
       })
       .flat();
   }

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,7 +1,6 @@
 import { get as getByDotNotation } from 'dot-prop';
 import { KeywordMappings } from './types';
 import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
-import { add } from 'lodash';
 
 export const shouldFieldBePreserved = (
   string: string,

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -26,12 +26,15 @@ export const getPreservableFieldsFromAssets = (
     }
     return [];
   }
+
+  const shouldRenderDot = address !== '';
+
   if (Array.isArray(asset)) {
     return asset
       .map((arrayItem) => {
         return getPreservableFieldsFromAssets(
           arrayItem,
-          `${address}.[name=${arrayItem.name}]`,
+          `${address}${shouldRenderDot ? '.' : ''}[name=${arrayItem.name}]`,
           keywordMappings
         );
       })
@@ -43,26 +46,44 @@ export const getPreservableFieldsFromAssets = (
         const value = asset[key];
 
         if (value === undefined || value === null) return [];
-        return getPreservableFieldsFromAssets(value, `${address}.${key}`, keywordMappings);
+
+        return getPreservableFieldsFromAssets(
+          value,
+          `${address}${shouldRenderDot ? '.' : ''}${key}`,
+          keywordMappings
+        );
       })
       .flat();
   }
   return [];
 };
 
+// getAssetsValueByAddress returns a value for an arbitrary data structure when
+// provided an "address" of that value. This address is similar to JS object notation
+// with the exception of identifying array items by a unique property instead of order.
+// Example:
+// Object: `{ actions: [ { name: "action-1", code: "..."}] }`
+// Address: `.actions[name=action-1].code`
 export const getAssetsValueByAddress = (address: string, assets: any): any => {
+  //Look ahead and see if the address path only contains dots (ex: `tenant.friendly_name`)
+  //if so the address is trivial and can use the dot-prop package to return the value
+
   const isTrivialAddress = address.indexOf('[') === -1;
   if (isTrivialAddress) {
     return getByDotNotation(assets, address);
   }
 
+  // It is easier to handle an address piece-by-piece by
+  // splitting on the period into separate "directions"
   const directions = address.split('.');
 
-  if (directions.length === 0) return assets;
-
+  // If the the next directions are the proprietary array syntax (ex: `[name=foo]`)
+  // then perform lookup against unique array-item property
   if (directions[0].charAt(0) === '[') {
     const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
     const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+
+    if (assets === undefined) return undefined;
 
     const target = assets.find((item: any) => {
       return item[identifier] === identifierValue;

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,4 +1,4 @@
-import { get as getByDotNotation } from 'dot-prop';
+import { get as getByDotNotation, set as setByDotNotation } from 'dot-prop';
 import { KeywordMappings } from './types';
 import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
 
@@ -142,4 +142,21 @@ export const convertAddressToDotNotation = (
     directions.slice(1).join('.'),
     finalAddressTrail === '' ? directions[0] : `${finalAddressTrail}.${directions[0]}`
   );
+};
+
+export const updateAssetsByAddress = (
+  assets: object,
+  address: string,
+  newValue: string
+): object => {
+  const dotNotationAddress = convertAddressToDotNotation(assets, address);
+
+  const doesPropertyExist = getByDotNotation(assets, dotNotationAddress) !== undefined;
+
+  if (!doesPropertyExist) {
+    throw new Error(`cannot update assets by address: ${address} because it does not exist.`);
+  }
+
+  setByDotNotation(assets, dotNotationAddress, newValue);
+  return assets;
 };

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,0 +1,14 @@
+import { KeywordMappings } from './types';
+import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
+
+export const shouldFieldBePreserved = (
+  string: string,
+  keywordMappings: KeywordMappings
+): boolean => {
+  return !Object.keys(keywordMappings).every((keyword) => {
+    const hasArrayMarker = keywordReplaceArrayRegExp(keyword).test(string);
+    const hasStringMarker = keywordReplaceStringRegExp(keyword).test(string);
+
+    return !hasArrayMarker && !hasStringMarker;
+  });
+};

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -1,5 +1,7 @@
+import { get as getByDotNotation } from 'dot-prop';
 import { KeywordMappings } from './types';
 import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
+import { add } from 'lodash';
 
 export const shouldFieldBePreserved = (
   string: string,
@@ -46,4 +48,31 @@ export const getPreservableFieldsFromAssets = (
       .flat();
   }
   return [];
+};
+
+export const getAssetsValueByAddress = (address: string, assets: any): any => {
+  const isTrivialAddress = address.indexOf('[') === -1;
+  if (isTrivialAddress) {
+    return getByDotNotation(assets, address);
+  }
+
+  const directions = address.split('.');
+
+  if (directions.length === 0) return assets;
+
+  if (directions[0].charAt(0) === '[') {
+    const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
+    const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+
+    const target = assets.find((item: any) => {
+      return item[identifier] === identifierValue;
+    });
+
+    return getAssetsValueByAddress(directions.slice(1).join('.'), target);
+  }
+
+  return getAssetsValueByAddress(
+    directions.slice(1).join('.'),
+    getByDotNotation(assets, directions[0])
+  );
 };

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -6,13 +6,22 @@ import log from '../logger';
 import { Asset, Assets, CalculatedChanges, KeywordMappings } from '../types';
 import constants from './constants';
 
+export const keywordReplaceArrayRegExp = (key) => {
+  const pattern = `@@${key}@@`;
+  const patternWithQuotes = `"${pattern}"`;
+
+  return new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
+};
+
+export const keywordReplaceStringRegExp = (key) => {
+  return new RegExp(`##${key}##`, 'g');
+};
+
 export function keywordArrayReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
     // Matching against two sets of patterns because a developer may provide their array replacement keyword with or without wrapping quotes. It is not obvious to the developer which to do depending if they're operating in YAML or JSON.
-    const pattern = `@@${key}@@`;
-    const patternWithQuotes = `"${pattern}"`;
+    const regex = keywordReplaceArrayRegExp(key);
 
-    const regex = new RegExp(`${patternWithQuotes}|${pattern}`, 'g');
     input = input.replace(regex, JSON.stringify(mappings[key]));
   });
   return input;
@@ -20,7 +29,7 @@ export function keywordArrayReplace(input: string, mappings: KeywordMappings): s
 
 export function keywordStringReplace(input: string, mappings: KeywordMappings): string {
   Object.keys(mappings).forEach(function (key) {
-    const regex = new RegExp(`##${key}##`, 'g');
+    const regex = keywordReplaceStringRegExp(key);
     // @ts-ignore TODO: come back and distinguish strings vs array replacement.
     input = input.replace(regex, mappings[key]);
   });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { shouldFieldBePreserved } from '../src/keywordPreservation';
+
+describe('#Keyword Preservation', () => {
+  describe('shouldFieldBePreserved', () => {
+    it('should return false when field does not contain keyword markers', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this is a field without a keyword marker', keywordMappings)).to
+        .be.false;
+      expect(shouldFieldBePreserved('this field has an invalid @keyword@ marker', keywordMappings))
+        .to.be.false;
+    });
+
+    it('should return false when field contain keyword markers but are absent in keyword mappings', () => {
+      const keywordMappings = {
+        BAR: 'bar',
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.false;
+      expect(shouldFieldBePreserved('this field has a @@FOO@@ marker', keywordMappings)).to.be
+        .false;
+    });
+
+    it('should return true when field contain keyword markers that exist in keyword mappings', () => {
+      const keywordMappings = {
+        FOO: 'foo keyword',
+        BAR: 'bar keyword',
+        ARRAY: ['foo', 'bar'],
+      };
+      expect(shouldFieldBePreserved('##FOO##', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('@@FOO@@', keywordMappings)).to.be.true;
+      expect(shouldFieldBePreserved('this field has a ##FOO## marker', keywordMappings)).to.be.true;
+      expect(
+        shouldFieldBePreserved('this field has both a ##FOO## and ##BAR## marker', keywordMappings)
+      ).to.be.true;
+    });
+  });
+});

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { shouldFieldBePreserved, getPreservableFieldsFromAssets } from '../src/keywordPreservation';
+import {
+  shouldFieldBePreserved,
+  getPreservableFieldsFromAssets,
+  getAssetsValueByAddress,
+} from '../src/keywordPreservation';
 
 describe('#Keyword Preservation', () => {
   describe('shouldFieldBePreserved', () => {
@@ -91,5 +95,47 @@ describe('#Keyword Preservation', () => {
         '.arrayReplace',
       ]);
     });
+  });
+});
+
+describe('getAssetsValueByAddress', () => {
+  it('should find address with proprietary notation', () => {
+    const mockAssetTree = {
+      tenant: {
+        display_name: 'This is my tenant display name',
+      },
+      clients: [
+        {
+          name: 'client-1',
+          display_name: 'Some Display Name',
+        },
+        {
+          name: 'client-2',
+          display_name: 'This is the target value',
+        },
+        {
+          name: 'client-3',
+          connections: [
+            {
+              connection_name: 'connection-1',
+              display_name: 'My connection display name',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getAssetsValueByAddress('tenant.display_name', mockAssetTree)).to.equal(
+      'This is my tenant display name'
+    );
+    expect(getAssetsValueByAddress('clients.[name=client-2].display_name', mockAssetTree)).to.equal(
+      'This is the target value'
+    );
+    expect(
+      getAssetsValueByAddress(
+        'clients.[name=client-3].connections.[connection_name=connection-1].display_name',
+        mockAssetTree
+      )
+    ).to.equal('My connection display name');
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -87,19 +87,19 @@ describe('#Keyword Preservation', () => {
       );
 
       expect(fieldsToPreserve).to.have.members([
-        '.object.friendly_name',
-        '.object.nested.nestedProperty',
-        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
-        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
-        '.array.[name=array-item-1].nested.nestedProperty',
-        '.arrayReplace',
+        'object.friendly_name',
+        'object.nested.nestedProperty',
+        'array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
+        'array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
+        'array.[name=array-item-1].nested.nestedProperty',
+        'arrayReplace',
       ]);
     });
   });
 });
 
 describe('getAssetsValueByAddress', () => {
-  it('should find address with proprietary notation', () => {
+  it('should find the value of the addressed property', () => {
     const mockAssetTree = {
       tenant: {
         display_name: 'This is my tenant display name',
@@ -137,5 +137,14 @@ describe('getAssetsValueByAddress', () => {
         mockAssetTree
       )
     ).to.equal('My connection display name');
+    expect(getAssetsValueByAddress('this.address.should.not.exist', mockAssetTree)).to.equal(
+      undefined
+    );
+    expect(getAssetsValueByAddress('this.address.[should=not].exist', mockAssetTree)).to.equal(
+      undefined
+    );
+    expect(getAssetsValueByAddress('this.address.should.[not=exist]', mockAssetTree)).to.equal(
+      undefined
+    );
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -62,6 +62,8 @@ describe('#Keyword Preservation', () => {
             },
           ],
           arrayReplace: '@@ARRAY_REPLACE_KEYWORD@@',
+          nullField: null,
+          undefinedField: undefined,
         },
         {
           KEYWORD: 'Travel0',

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { shouldFieldBePreserved } from '../src/keywordPreservation';
+import { shouldFieldBePreserved, getPreservableFieldsFromAssets } from '../src/keywordPreservation';
 
 describe('#Keyword Preservation', () => {
   describe('shouldFieldBePreserved', () => {
@@ -36,6 +36,44 @@ describe('#Keyword Preservation', () => {
       expect(
         shouldFieldBePreserved('this field has both a ##FOO## and ##BAR## marker', keywordMappings)
       ).to.be.true;
+    });
+  });
+
+  describe('getPreservableFieldsFromAssets', () => {
+    it('should retrieve all preservable fields from assets tree', () => {
+      const fieldsToPreserve = getPreservableFieldsFromAssets(
+        {
+          object: {
+            friendly_name: 'Friendly name ##KEYWORD##',
+            notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
+            number: 5,
+            boolean: true,
+            nested: {
+              nestedProperty: 'Nested property ##KEYWORD##',
+            },
+          },
+          array: [
+            {
+              nestedArray: ['Nested array value 1 ##KEYWORD##', 'Nested array value 2 ##KEYWORD##'],
+              notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
+              nested: {
+                nestedProperty: 'Another nested array property ##KEYWORD##',
+              },
+            },
+          ],
+        },
+        {
+          KEYWORD: 'Travel0',
+        }
+      );
+
+      expect(fieldsToPreserve).to.have.members([
+        'Friendly name ##KEYWORD##',
+        'Nested property ##KEYWORD##',
+        'Nested array value 1 ##KEYWORD##',
+        'Nested array value 2 ##KEYWORD##',
+        'Another nested array property ##KEYWORD##',
+      ]);
     });
   });
 });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -265,7 +265,7 @@ describe('updateAssetsByAddress', () => {
     );
   });
 
-  it('should _____ if invalid address provided', () => {
+  it('should throw errors if invalid addresses provided', () => {
     expect(() =>
       updateAssetsByAddress(mockAssetTree, 'clients.[name=this-client-does-not-exist]', '_')
     ).to.throw();

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -61,9 +61,11 @@ describe('#Keyword Preservation', () => {
               },
             },
           ],
+          arrayReplace: '@@ARRAY_REPLACE_KEYWORD@@',
         },
         {
           KEYWORD: 'Travel0',
+          ARRAY_REPLACE_KEYWORD: ['this value', 'that value'],
         }
       );
 
@@ -73,6 +75,7 @@ describe('#Keyword Preservation', () => {
         'Nested array value 1 ##KEYWORD##',
         'Nested array value 2 ##KEYWORD##',
         'Another nested array property ##KEYWORD##',
+        '@@ARRAY_REPLACE_KEYWORD@@',
       ]);
     });
   });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -54,7 +54,17 @@ describe('#Keyword Preservation', () => {
           },
           array: [
             {
-              nestedArray: ['Nested array value 1 ##KEYWORD##', 'Nested array value 2 ##KEYWORD##'],
+              name: 'array-item-1',
+              nestedArray: [
+                {
+                  name: 'nested-array-item-1',
+                  value: 'Nested array value 1 ##KEYWORD##',
+                },
+                {
+                  name: 'nested-array-item-2',
+                  value: 'Nested array value 2 ##KEYWORD##',
+                },
+              ],
               notInKeywordMapping: '##NOT_IN_KEYWORD_MAPPING##',
               nested: {
                 nestedProperty: 'Another nested array property ##KEYWORD##',
@@ -65,6 +75,7 @@ describe('#Keyword Preservation', () => {
           nullField: null,
           undefinedField: undefined,
         },
+        '',
         {
           KEYWORD: 'Travel0',
           ARRAY_REPLACE_KEYWORD: ['this value', 'that value'],
@@ -72,12 +83,12 @@ describe('#Keyword Preservation', () => {
       );
 
       expect(fieldsToPreserve).to.have.members([
-        'Friendly name ##KEYWORD##',
-        'Nested property ##KEYWORD##',
-        'Nested array value 1 ##KEYWORD##',
-        'Nested array value 2 ##KEYWORD##',
-        'Another nested array property ##KEYWORD##',
-        '@@ARRAY_REPLACE_KEYWORD@@',
+        '.object.friendly_name',
+        '.object.nested.nestedProperty',
+        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-1].value',
+        '.array.[name=array-item-1].nestedArray.[name=nested-array-item-2].value',
+        '.array.[name=array-item-1].nested.nestedProperty',
+        '.arrayReplace',
       ]);
     });
   });


### PR DESCRIPTION
### 🔧 Changes

Building off of the previous PRs for keyword preservation (#736, #738, #740, #741), this PR adds the `updateAssetsByAddress` function which will update a field on an arbitrary data structure when provided the address and the new value. This functionality is critical for keyword preservation because ultimately this is what will replace certain fields on the remote assets tree with the preserved fields of the local asset tree.

**Example:**

```js
updateAssetsByAddress(
  { tenant: { friendly_name: 'Original friendly name' } },
  'tenant.friendly_name',
  'New friendly name'
); // { tenant: { friendly_name: 'New friendly name' } },
```

📚 References
Related Issues:

 - #328
 - #688

🔬 Testing
Added and updated unit tests.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
