### PR TITLE
DXCDT-375: Renaming context handler's `load` to `loadAssetsFromLocal` (1/x)

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -43,7 +43,7 @@ export default async function importCMD(params: ImportParams) {
 
   // Setup context and load
   const context = await setupContext(nconf.get());
-  await context.load();
+  await context.loadAssetsFromLocal();
 
   const config = configFactory();
   config.setProvider((key) => nconf.get(key));

--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -47,7 +47,7 @@ export default class DirectoryContext {
     return loadFileAndReplaceKeywords(toLoad, this.mappings);
   }
 
-  async load(): Promise<void> {
+  async loadAssetsFromLocal(): Promise<void> {
     if (isDirectory(this.filePath)) {
       /* If this is a directory, look for each file in the directory */
       log.info(`Processing directory ${this.filePath}`);

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -52,7 +52,7 @@ export default class YAMLContext {
     return loadFileAndReplaceKeywords(path.resolve(toLoad), this.mappings);
   }
 
-  async load() {
+  async loadAssetsFromLocal() {
     // Allow to send object/json directly
     if (typeof this.configFile === 'object') {
       this.assets = this.configFile;

--- a/test/context/directory/actions.test.js
+++ b/test/context/directory/actions.test.js
@@ -95,7 +95,7 @@ describe('#directory context actions', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { replace: 'test-action' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.actions).to.deep.equal(actionsTarget);
   });
 
@@ -107,7 +107,7 @@ describe('#directory context actions', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { replace: 'test-action' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.actions).to.deep.equal(actionsTarget);
   });
 
@@ -119,7 +119,7 @@ describe('#directory context actions', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/attackProtection.test.js
+++ b/test/context/directory/attackProtection.test.js
@@ -31,7 +31,7 @@ describe('#directory context attack-protection', () => {
     };
 
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = {
       breachedPasswordDetection: {
@@ -84,7 +84,7 @@ describe('#directory context attack-protection', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = {
       breachedPasswordDetection: {

--- a/test/context/directory/branding.test.js
+++ b/test/context/directory/branding.test.js
@@ -39,7 +39,7 @@ describe('#directory context branding', () => {
 
     const config = { AUTH0_INPUT_FILE: dir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.branding).to.be.an('object');
     expect(context.assets.branding.templates).to.deep.equal([
@@ -66,7 +66,7 @@ describe('#directory context branding', () => {
 
     const config = { AUTH0_INPUT_FILE: dir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.branding).to.deep.equal({
       templates: [
@@ -88,7 +88,7 @@ describe('#directory context branding', () => {
 
     const config = { AUTH0_INPUT_FILE: dir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.branding).to.deep.equal(JSON.parse(brandingSettings));
   });

--- a/test/context/directory/clientGrants.test.js
+++ b/test/context/directory/clientGrants.test.js
@@ -42,7 +42,7 @@ describe('#directory context clientGrants', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { var: 'something' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.clientGrants).to.deep.equal([
       {
@@ -88,7 +88,7 @@ describe('#directory context clientGrants', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { var: 'something' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       {
@@ -112,7 +112,7 @@ describe('#directory context clientGrants', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -29,7 +29,7 @@ describe('#directory context clients', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       { app_type: 'spa', name: 'customLoginClient', custom_login_page: 'html code spa "spa"' },
@@ -55,7 +55,7 @@ describe('#directory context clients', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [{ app_type: 'spa', name: 'someClient' }];
 
@@ -72,7 +72,7 @@ describe('#directory context clients', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -29,7 +29,7 @@ describe('#directory context connections', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { secret: 'test secret', var: 'something' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       { name: 'myad-waad', strategy: 'waad', var: 'something' },
@@ -62,7 +62,7 @@ describe('#directory context connections', () => {
       AUTH0_CONNECTIONS_DIRECTORY: customConnectionDirectory,
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [{ name: 'A Connection' }];
 
@@ -85,7 +85,7 @@ describe('#directory context connections', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { var: 'something' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [{ name: 'myad-waad', strategy: 'waad', var: 'something' }];
 
@@ -102,7 +102,7 @@ describe('#directory context connections', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });
@@ -217,7 +217,7 @@ describe('#directory context connections', () => {
       mockMgmtClient()
     );
 
-    await expect(context.load()).to.be.eventually.rejectedWith(
+    await expect(context.loadAssetsFromLocal()).to.be.eventually.rejectedWith(
       `Passwordless email template purportedly located at ${path.join(
         repoDir,
         'connections',

--- a/test/context/directory/context.test.js
+++ b/test/context/directory/context.test.js
@@ -13,7 +13,7 @@ describe('#directory context validation', () => {
     cleanThenMkdir(dir);
 
     const context = new Context({ AUTH0_INPUT_FILE: dir });
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(Object.keys(context.assets).length).to.equal(Object.keys(handlers).length + 1);
     Object.keys(context.assets).forEach((key) => {
@@ -47,7 +47,7 @@ describe('#directory context validation', () => {
       AUTH0_EXCLUDED_DEFAULTS: ['emailProvider'],
     };
     const context = new Context(config);
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.exclude.rules).to.deep.equal(['rule']);
     expect(context.assets.exclude.clients).to.deep.equal(['client']);
@@ -72,14 +72,14 @@ describe('#directory context validation', () => {
       AUTH0_INPUT_FILE: dir,
       AUTH0_EXCLUDED: ['tenant'],
     });
-    await contextWithExclusion.load();
+    await contextWithExclusion.loadAssetsFromLocal();
     expect(contextWithExclusion.assets.tenant).to.equal(undefined);
 
     const contextWithoutExclusion = new Context({
       AUTH0_INPUT_FILE: dir,
       AUTH0_EXCLUDED: [], // Not excluding tenant resource
     });
-    await contextWithoutExclusion.load();
+    await contextWithoutExclusion.loadAssetsFromLocal();
     expect(contextWithoutExclusion.assets.tenant).to.deep.equal(tenantConfig);
   });
 
@@ -98,7 +98,7 @@ describe('#directory context validation', () => {
       AUTH0_INPUT_FILE: dir,
       AUTH0_INCLUDED_ONLY: ['tenant'],
     });
-    await contextWithInclusion.load();
+    await contextWithInclusion.loadAssetsFromLocal();
     expect(contextWithInclusion.assets.tenant).to.deep.equal(tenantConfig);
     expect(contextWithInclusion.assets.actions).to.equal(undefined); // Arbitrary sample resources
     expect(contextWithInclusion.assets.clients).to.equal(undefined); // Arbitrary sample resources
@@ -108,7 +108,7 @@ describe('#directory context validation', () => {
     const dir = path.resolve(testDataDir, 'directory', 'doesNotExist');
     const context = new Context({ AUTH0_INPUT_FILE: dir });
     const errorMessage = `Not sure what to do with, ${dir} as it is not a directory...`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });
@@ -128,7 +128,7 @@ describe('#directory context validation', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: link });
     const errorMessage = `Not sure what to do with, ${link} as it is not a directory...`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/databases.test.js
+++ b/test/context/directory/databases.test.js
@@ -32,7 +32,7 @@ describe('#directory context databases', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal([
       {
@@ -56,7 +56,7 @@ describe('#directory context databases', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal([]);
   });
@@ -71,7 +71,7 @@ describe('#directory context databases', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });
@@ -112,7 +112,7 @@ describe('#directory context databases', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal([
       {
@@ -144,7 +144,7 @@ describe('#directory context databases', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal([
       {

--- a/test/context/directory/emailProvider.test.js
+++ b/test/context/directory/emailProvider.test.js
@@ -20,7 +20,7 @@ describe('#directory context email provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.emailProvider).to.deep.equal({
       enabled: true,

--- a/test/context/directory/emailTemplates.test.js
+++ b/test/context/directory/emailTemplates.test.js
@@ -42,7 +42,7 @@ describe('#directory context email templates', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.emailTemplates).to.deep.equal(emailTemplaesTarget);
   });
@@ -60,7 +60,7 @@ describe('#directory context email templates', () => {
     createDir(dir, files);
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.emailTemplates).to.deep.equal(emailTemplaesTarget);
   });
@@ -73,7 +73,7 @@ describe('#directory context email templates', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/guardianFactorProviders.test.js
+++ b/test/context/directory/guardianFactorProviders.test.js
@@ -25,7 +25,7 @@ describe('#directory context guardian factors providers provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianFactorProviders).to.deep.equal([
       {

--- a/test/context/directory/guardianFactorTemplates.test.js
+++ b/test/context/directory/guardianFactorTemplates.test.js
@@ -23,7 +23,7 @@ describe('#directory context guardian factors templates provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianFactorTemplates).to.deep.equal([
       {

--- a/test/context/directory/guardianFactors.test.js
+++ b/test/context/directory/guardianFactors.test.js
@@ -26,7 +26,7 @@ describe('#directory context guardian factors provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianFactors).to.deep.equal([
       { enabled: true, name: 'otp' },

--- a/test/context/directory/guardianPhoneFactorMessageTypes.test.js
+++ b/test/context/directory/guardianPhoneFactorMessageTypes.test.js
@@ -19,7 +19,7 @@ describe('#directory context guardian phone factor message types provider', () =
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianPhoneFactorMessageTypes).to.deep.equal({
       message_types: ['sms', 'voice'],

--- a/test/context/directory/guardianPhoneFactorSelectedProvider.test.js
+++ b/test/context/directory/guardianPhoneFactorSelectedProvider.test.js
@@ -19,7 +19,7 @@ describe('#directory context guardian phone factor selected provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianPhoneFactorSelectedProvider).to.deep.equal({
       provider: 'twilio',

--- a/test/context/directory/guardianPolicies.test.js
+++ b/test/context/directory/guardianPolicies.test.js
@@ -21,7 +21,7 @@ describe('#directory context guardian policies provider', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.guardianPolicies).to.deep.equal({
       policies: ['all-applications'],

--- a/test/context/directory/hooks.test.js
+++ b/test/context/directory/hooks.test.js
@@ -43,7 +43,7 @@ describe('#directory context hooks', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'goodbye' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.hooks).to.deep.equal(hooksTarget);
   });
@@ -58,7 +58,7 @@ describe('#directory context hooks', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'goodbye' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.hooks).to.deep.equal(hooksTarget);
   });
@@ -71,7 +71,7 @@ describe('#directory context hooks', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/migrations.test.js
+++ b/test/context/directory/migrations.test.js
@@ -25,7 +25,7 @@ describe('#directory context migrations', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.migrations).to.deep.equal(migrationsTarget);
   });

--- a/test/context/directory/organizations.test.js
+++ b/test/context/directory/organizations.test.js
@@ -24,7 +24,7 @@ describe('#directory context organizations', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       {
@@ -89,7 +89,7 @@ describe('#directory context organizations', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/pages.test.js
+++ b/test/context/directory/pages.test.js
@@ -39,7 +39,7 @@ describe('#directory context pages', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.pages).to.deep.equal(pagesTarget);
   });
@@ -57,7 +57,7 @@ describe('#directory context pages', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.pages).to.deep.equal([
       {
@@ -84,7 +84,7 @@ describe('#directory context pages', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.pages).to.deep.equal(pagesTarget);
   });
@@ -97,7 +97,7 @@ describe('#directory context pages', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/prompts.test.ts
+++ b/test/context/directory/prompts.test.ts
@@ -59,7 +59,7 @@ describe('#directory context prompts', () => {
       },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.prompts).to.deep.equal({
       universal_login_experience: 'classic',
@@ -110,7 +110,7 @@ describe('#directory context prompts', () => {
         AUTH0_INPUT_FILE: promptsDirectory,
       };
       const context = new Context(config, mockMgmtClient());
-      await context.load();
+      await context.loadAssetsFromLocal();
 
       expect(context.assets.prompts).to.deep.equal({ ...mockPromptsSettings, customText: {} });
     });
@@ -127,7 +127,7 @@ describe('#directory context prompts', () => {
         AUTH0_INPUT_FILE: promptsDirectory,
       };
       const context = new Context(config, mockMgmtClient());
-      await context.load();
+      await context.loadAssetsFromLocal();
 
       expect(context.assets.prompts).to.deep.equal({ customText: {} });
     });

--- a/test/context/directory/resourceServers.js
+++ b/test/context/directory/resourceServers.js
@@ -32,7 +32,7 @@ describe('#directory context resourceServers', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.resourceServers).to.deep.equal(resourceServersTarget);
   });
@@ -46,7 +46,7 @@ describe('#directory context resourceServers', () => {
     createDir(repoDir, { [constants.RESOURCE_SERVERS_DIRECTORY]: invalid });
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.resourceServers).to.deep.equal(resourceServersTarget);
   });
@@ -61,7 +61,7 @@ describe('#directory context resourceServers', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/roles.test.js
+++ b/test/context/directory/roles.test.js
@@ -24,7 +24,7 @@ describe('#directory context roles', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       {
@@ -66,7 +66,7 @@ describe('#directory context roles', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       {
@@ -119,7 +119,7 @@ describe('#directory context roles', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/rules.test.js
+++ b/test/context/directory/rules.test.js
@@ -32,7 +32,7 @@ describe('#directory context rules', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'goodbye' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.rules).to.deep.equal(rulesTarget);
   });
@@ -47,7 +47,7 @@ describe('#directory context rules', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'goodbye' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.rules).to.deep.equal(rulesTarget);
   });
@@ -60,7 +60,7 @@ describe('#directory context rules', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/rulesConfigs.js
+++ b/test/context/directory/rulesConfigs.js
@@ -22,7 +22,7 @@ describe('#directory context rulesConfigs', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [
       { key: 'setting1', value: 'test' },
@@ -44,7 +44,7 @@ describe('#directory context rulesConfigs', () => {
 
     const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     const target = [{ key: 'setting1', value: 'test' }];
 
@@ -61,7 +61,7 @@ describe('#directory context rulesConfigs', () => {
     const context = new Context(config, mockMgmtClient());
 
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/directory/tenant.test.js
+++ b/test/context/directory/tenant.test.js
@@ -32,7 +32,7 @@ describe('#directory context tenant', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.tenant).to.deep.equal(tenantTarget);
   });
@@ -58,7 +58,7 @@ describe('#directory context tenant', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.tenant).to.deep.equal(tenantTarget);
   });

--- a/test/context/directory/themes.test.js
+++ b/test/context/directory/themes.test.js
@@ -19,7 +19,7 @@ describe('#directory context themes', () => {
 
     const config = { AUTH0_INPUT_FILE: dir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.themes).to.be.an('Array');
     expect(context.assets.themes).to.deep.equal([theme]);
@@ -41,7 +41,7 @@ describe('#directory context themes', () => {
 
     const config = { AUTH0_INPUT_FILE: dir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.themes).to.be.an('Array');
     expect(context.assets.themes).to.deep.equal([theme1, theme2]);

--- a/test/context/directory/triggers.test.js
+++ b/test/context/directory/triggers.test.js
@@ -47,7 +47,7 @@ describe('#directory context triggers', () => {
     createDir(repoDir, actionFiles);
     const config = { AUTH0_INPUT_FILE: repoDir };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.triggers).to.deep.equal(triggersTarget);
   });
 
@@ -59,7 +59,7 @@ describe('#directory context triggers', () => {
 
     const context = new Context({ AUTH0_INPUT_FILE: repoDir });
     const errorMessage = `Expected ${dir} to be a folder but got a file?`;
-    await expect(context.load())
+    await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
   });

--- a/test/context/yaml/actions.test.js
+++ b/test/context/yaml/actions.test.js
@@ -62,7 +62,7 @@ describe('#YAML context actions', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { replace: 'test-action' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.actions).to.deep.equal(target);
   });
 

--- a/test/context/yaml/attackProtection.test.js
+++ b/test/context/yaml/attackProtection.test.js
@@ -77,7 +77,7 @@ describe('#YAML context attack-protection', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.attackProtection).to.deep.equal(target);
   });
 

--- a/test/context/yaml/branding.test.js
+++ b/test/context/yaml/branding.test.js
@@ -33,7 +33,7 @@ describe('#YAML context branding templates', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.branding).to.deep.equal({
       colors: {
         page_background: '#0f5a1b',

--- a/test/context/yaml/clientGrants.test.js
+++ b/test/context/yaml/clientGrants.test.js
@@ -33,7 +33,7 @@ describe('#YAML context client grants', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.clientGrants).to.deep.equal(target);
   });
 

--- a/test/context/yaml/clients.test.js
+++ b/test/context/yaml/clients.test.js
@@ -45,7 +45,7 @@ describe('#YAML context clients', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.clients).to.deep.equal(target);
   });

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -97,7 +97,7 @@ describe('#YAML context connections', () => {
       },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.connections).to.deep.equal(target);
   });
@@ -128,7 +128,9 @@ describe('#YAML context connections', () => {
       mockMgmtClient()
     );
 
-    await expect(context.load()).to.be.eventually.rejectedWith('Problem deploying connections');
+    await expect(context.loadAssetsFromLocal()).to.be.eventually.rejectedWith(
+      'Problem deploying connections'
+    );
   });
 
   it('should dump connections', async () => {

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -16,7 +16,7 @@ describe('#YAML context validation', () => {
 
     const config = { AUTH0_INPUT_FILE: yaml };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.rules).to.deep.equal(null);
     expect(context.assets.databases).to.deep.equal(null);
@@ -47,7 +47,7 @@ describe('#YAML context validation', () => {
     };
 
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.exclude.rules).to.deep.equal(['rule']);
     expect(context.assets.exclude.clients).to.deep.equal(['client']);
@@ -80,7 +80,7 @@ describe('#YAML context validation', () => {
       mockMgmtClient()
     );
 
-    await contextWithExclusion.load();
+    await contextWithExclusion.loadAssetsFromLocal();
     exclusions.forEach((excludedResource) => {
       expect(contextWithExclusion.assets[excludedResource]).to.equal(null); // Ensure all excluded resources, defined or not, are null
     });
@@ -94,7 +94,7 @@ describe('#YAML context validation', () => {
       mockMgmtClient()
     );
 
-    await contextWithoutExclusion.load();
+    await contextWithoutExclusion.loadAssetsFromLocal();
     expect(contextWithoutExclusion.assets.actions).to.deep.equal([]);
     expect(contextWithoutExclusion.assets.hooks).to.deep.equal([]);
     expect(contextWithoutExclusion.assets.rules).to.deep.equal([]);
@@ -124,7 +124,7 @@ describe('#YAML context validation', () => {
       mockMgmtClient()
     );
 
-    await contextWithInclusion.load();
+    await contextWithInclusion.loadAssetsFromLocal();
     expect(contextWithInclusion.assets.tenant).to.deep.equal({
       enabled_locales: ['en'],
     });
@@ -141,14 +141,14 @@ describe('#YAML context validation', () => {
 
     const config = { AUTH0_INPUT_FILE: yaml };
     const context = new Context(config, mockMgmtClient());
-    await expect(context.load()).to.be.eventually.rejectedWith(Error);
+    await expect(context.loadAssetsFromLocal()).to.be.eventually.rejectedWith(Error);
   });
 
   it('should error on bad file', async () => {
     const yaml = path.resolve(testDataDir, 'yaml', 'notexist.yml');
     const config = { AUTH0_INPUT_FILE: yaml };
     const context = new Context(config, mockMgmtClient());
-    await expect(context.load()).to.be.eventually.rejectedWith(Error);
+    await expect(context.loadAssetsFromLocal()).to.be.eventually.rejectedWith(Error);
   });
 
   it('should load relative file', async () => {

--- a/test/context/yaml/customDomains.test.ts
+++ b/test/context/yaml/customDomains.test.ts
@@ -23,7 +23,7 @@ describe('#YAML context custom domains', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.customDomains).to.deep.equal([
       {

--- a/test/context/yaml/databases.test.js
+++ b/test/context/yaml/databases.test.js
@@ -44,7 +44,7 @@ describe('#YAML context databases', () => {
     fs.writeFileSync(yamlFile, yaml);
 
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal(target);
   });
@@ -93,7 +93,7 @@ describe('#YAML context databases', () => {
     fs.writeFileSync(yamlFile, yaml);
 
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.databases).to.deep.equal(target);
   });

--- a/test/context/yaml/emailProvider.test.js
+++ b/test/context/yaml/emailProvider.test.js
@@ -37,7 +37,7 @@ describe('#YAML context email provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.emailProvider).to.deep.equal(target);
   });
 

--- a/test/context/yaml/emailTemplates.test.js
+++ b/test/context/yaml/emailTemplates.test.js
@@ -55,7 +55,7 @@ describe('#YAML context email templates', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.emailTemplates).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianFactorProviders.test.js
+++ b/test/context/yaml/guardianFactorProviders.test.js
@@ -35,7 +35,7 @@ describe('#YAML context guardian factor provider provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianFactorProviders).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianFactorTemplates.test.js
+++ b/test/context/yaml/guardianFactorTemplates.test.js
@@ -31,7 +31,7 @@ describe('#YAML context guardian factors templates provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianFactorTemplates).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianFactors.test.js
+++ b/test/context/yaml/guardianFactors.test.js
@@ -38,7 +38,7 @@ describe('#YAML context guardian factors provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianFactors).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianPhoneFactorMessageTypes.test.js
+++ b/test/context/yaml/guardianPhoneFactorMessageTypes.test.js
@@ -27,7 +27,7 @@ describe('#YAML context guardian phone factor message types provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianPhoneFactorMessageTypes).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianPhoneFactorSelectedProvider.test.js
+++ b/test/context/yaml/guardianPhoneFactorSelectedProvider.test.js
@@ -25,7 +25,7 @@ describe('#YAML context guardian phone factor selected provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianPhoneFactorSelectedProvider).to.deep.equal(target);
   });
 

--- a/test/context/yaml/guardianPolicies.test.js
+++ b/test/context/yaml/guardianPolicies.test.js
@@ -26,7 +26,7 @@ describe('#YAML context guardian policies provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianPolicies).to.deep.equal(target);
   });
 
@@ -48,7 +48,7 @@ describe('#YAML context guardian policies provider', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.guardianPolicies).to.deep.equal(target);
   });
 

--- a/test/context/yaml/hooks.test.js
+++ b/test/context/yaml/hooks.test.js
@@ -40,7 +40,7 @@ describe('#YAML context hooks', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'test' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.hooks).to.deep.equal(target);
   });

--- a/test/context/yaml/logStreams.test.js
+++ b/test/context/yaml/logStreams.test.js
@@ -34,7 +34,7 @@ describe('#YAML context log streams', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.logStreams).to.deep.equal([
       {

--- a/test/context/yaml/migrations.test.js
+++ b/test/context/yaml/migrations.test.js
@@ -27,7 +27,7 @@ describe('#YAML context migrations', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.migrations).to.deep.equal(target);
   });

--- a/test/context/yaml/organizations.test.js
+++ b/test/context/yaml/organizations.test.js
@@ -73,7 +73,7 @@ describe('#YAML context organizations', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.organizations).to.deep.equal(target);
   });
 

--- a/test/context/yaml/pages.test.js
+++ b/test/context/yaml/pages.test.js
@@ -78,7 +78,7 @@ describe('#YAML context pages', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { val1: 'env1', val2: 'env2' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.pages).to.deep.equal(target);
   });
@@ -253,7 +253,7 @@ describe('#YAML context pages', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.pages).to.deep.equal(target);
   });

--- a/test/context/yaml/prompts.test.ts
+++ b/test/context/yaml/prompts.test.ts
@@ -69,7 +69,7 @@ describe('#YAML context prompts', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.prompts).to.deep.equal({
       customText: {

--- a/test/context/yaml/resourceServers.test.js
+++ b/test/context/yaml/resourceServers.test.js
@@ -45,7 +45,7 @@ describe('#YAML context resource servers', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { name: 'my resource', identifier: 'http://myapi.com/api' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.resourceServers).to.deep.equal(target);
   });

--- a/test/context/yaml/roles.test.js
+++ b/test/context/yaml/roles.test.js
@@ -53,7 +53,7 @@ describe('#YAML context roles', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
     expect(context.assets.roles).to.deep.equal(target);
   });
 

--- a/test/context/yaml/rules.test.js
+++ b/test/context/yaml/rules.test.js
@@ -40,7 +40,7 @@ describe('#YAML context rules', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: { hello: 'test' },
     };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.rules).to.deep.equal(target);
   });

--- a/test/context/yaml/rulesConfigs.test.js
+++ b/test/context/yaml/rulesConfigs.test.js
@@ -23,7 +23,7 @@ describe('#YAML context rules configs', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.rulesConfigs).to.deep.equal(target);
   });

--- a/test/context/yaml/tenant.test.js
+++ b/test/context/yaml/tenant.test.js
@@ -31,7 +31,7 @@ describe('#YAML context tenant settings', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.tenant).to.deep.equal(target);
   });
@@ -56,7 +56,7 @@ describe('#YAML context tenant settings', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { ENV: 'test' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.tenant).to.deep.equal(target);
   });

--- a/test/context/yaml/themes.test.js
+++ b/test/context/yaml/themes.test.js
@@ -23,7 +23,7 @@ describe('#YAML context themes', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.themes).to.deep.equal([theme]);
   });
@@ -46,7 +46,7 @@ describe('#YAML context themes', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile, AUTH0_KEYWORD_REPLACE_MAPPINGS: { foo: 'bar' } };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.themes).to.deep.equal([theme1, theme2]);
   });

--- a/test/context/yaml/triggers.test.js
+++ b/test/context/yaml/triggers.test.js
@@ -41,7 +41,7 @@ describe('#YAML context triggers', () => {
 
     const config = { AUTH0_INPUT_FILE: yamlFile };
     const context = new Context(config, mockMgmtClient());
-    await context.load();
+    await context.loadAssetsFromLocal();
 
     expect(context.assets.triggers).to.deep.equal(target);
   });


### PR DESCRIPTION
### 🔧 Changes

Renaming the YAML and directory context`load()` method to `loadAssetsFromLocal()` to better clarify _what_ is being loaded. This function reads the local resource configuration files and loads them into memory to then push to the remote tenant.

This renaming is helpful because with keyword preservation, the export process will now include loading assets from Auth0 and loading assets from your local directory. Both of these processes are named `load()` and can be confusing about what they load.


### 🔬 Testing

No functional changes. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
