### PR TITLE
Fix: Management of clients when injecting access token

### DIFF
--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -56,7 +56,7 @@ export default class ClientHandler extends DefaultAPIHandler {
 
     // Always filter out the client we are using to access Auth0 Management API
     // As it could cause problems if it gets deleted or updated etc
-    const currentClient = this.config('AUTH0_CLIENT_ID');
+    const currentClient = this.config('AUTH0_CLIENT_ID') || '';
 
     const filterClients = (list) => {
       if (excludedClients.length) {

--- a/src/tools/deploy.ts
+++ b/src/tools/deploy.ts
@@ -11,7 +11,11 @@ export default async function deploy(
   // Setup log level
   log.level = process.env.AUTH0_DEBUG === 'true' ? 'debug' : 'info';
 
-  log.info('Getting access token for ' + config('AUTH0_CLIENT_ID') + '/' + config('AUTH0_DOMAIN'));
+  log.info(
+    `Getting access token for ${
+      config('AUTH0_CLIENT_ID') !== undefined ? `${config('AUTH0_CLIENT_ID')}/` : ''
+    }${config('AUTH0_DOMAIN')}`
+  );
 
   const auth0 = new Auth0(client, assets, config);
 


### PR DESCRIPTION
### 🔧 Changes

As reported by #769, there were issues managing clients when injecting an access token directly into the configuration as opposed to client credentials. This is because the exclusion logic was incorrectly filtering-out clients from being created, updated and deleted if the `AUTH0_CLIENT_ID` was not defined.

The simplest fix here is to not allow `currentClient` to be undefined by setting it to empty string if `AUTH0_CLIENT_ID` is not set. That way, when the exclusion comparison is executed, it will not evaluate to true if both it and `client_id` are undefined. 

### 📚 References

Original GH issue: #769 

### 🔬 Testing

Added new unit test.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
