### PR TITLE
Sanitize tenant flags only if available in config

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -67,11 +67,14 @@ export default class TenantHandler extends DefaultHandler {
 
     const updatedTenant = {
       ...tenant,
-      flags: sanitizeMigrationFlags({
+    };
+
+    if ('flags' in updatedTenant) {
+      updatedTenant.flags = sanitizeMigrationFlags({
         existingFlags: existingTenant.flags,
         proposedFlags: tenant.flags,
-      }),
-    };
+      });
+    }
 
     if (updatedTenant && Object.keys(updatedTenant).length > 0) {
       await this.client.tenant.updateSettings(updatedTenant);
@@ -91,7 +94,7 @@ export const sanitizeMigrationFlags = ({
   /*
   Tenants can only update migration flags that are already configured.
   If moving configuration from one tenant to another, there may be instances
-  where different migration flags exist and cause an error on update. This 
+  where different migration flags exist and cause an error on update. This
   function removes any migration flags that aren't already present on the target
   tenant. See: https://github.com/auth0/auth0-deploy-cli/issues/374
   */

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -45,6 +45,7 @@ describe('#tenant handler', () => {
           updateSettings: (data) => {
             expect(data).to.be.an('object');
             expect(data.sandbox_version).to.equal('4');
+            expect(data.flags).to.equal(undefined);
             return Promise.resolve(data);
           },
         },


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In cases where the tenant config doesn't include the flags property, we were previously still sending an empty flags object as we were enforcing a sanitization step always. 

In this PR we only do so if we encounter the flags property within the config. 

This now prevents issues such as:

```
`Bad Request: Payload validation error: 'Too few properties defined (0), minimum 1' on property flags (Flags used to change the behavior of this tenant).`
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
