### PR TITLE
Fix: Preserving client grants' `audience` field

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -208,17 +208,15 @@ export const preserveKeywords = ({
 }): object => {
   if (Object.keys(keywordMappings).length === 0) return remoteAssets;
 
-  const resourceSpecificIdentifiers = auth0Handlers.reduce(
-    (acc, handler): Partial<{ [key in AssetTypes]: string[] }> => {
+  const resourceSpecificIdentifiers: Partial<{ [key in AssetTypes]: string[] }> =
+    auth0Handlers.reduce((acc, handler): Partial<{ [key in AssetTypes]: string[] }> => {
       return {
         ...acc,
         [handler.type]: handler.identifiers.filter((identifiers) => {
           return identifiers !== handler.id;
         })[0],
       };
-    },
-    {}
-  );
+    }, {});
 
   const addresses = getPreservableFieldsFromAssets(
     localAssets,

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -67,6 +67,18 @@ describe('#Keyword Preservation', () => {
               },
             ],
           },
+          clientGrants: [
+            {
+              client_id: 'client-id',
+              audience: '##KEYWORD##',
+              name: 'Client grant name',
+            },
+            {
+              client_id: '##KEYWORD##',
+              audience: 'https://api.travel0.com',
+              name: 'Client grant name',
+            },
+          ],
           actions: [
             {
               actionName: 'action-1',
@@ -86,12 +98,16 @@ describe('#Keyword Preservation', () => {
           KEYWORD: 'Travel0',
           ARRAY_REPLACE_KEYWORD: ['this value', 'that value'],
         },
-        { actions: 'actionName' }
+        { actions: 'actionName', clientGrants: ['audience', 'client_id'] }
       );
 
       expect(fieldsToPreserve).to.have.members([
         'tenant.friendly_name',
         'tenant.nested.nestedProperty',
+        'clientGrants.[audience=##KEYWORD##].audience',
+        'clientGrants.[client_id=client-id].audience',
+        'clientGrants.[audience=https://api.travel0.com].client_id',
+        'clientGrants.[client_id=##KEYWORD##].client_id',
         'actions.[actionName=action-1].value',
         'actions.[actionName=action-2].value',
         'arrayReplace',
@@ -357,6 +373,20 @@ describe('preserveKeywords', () => {
         },
       },
     ],
+    clientGrants: [
+      {
+        client_id: 'API Explorer Application',
+        audience: '##API_MAIN_IDENTIFIER##',
+        scope: ['update:account'],
+        name: 'My M2M',
+      },
+      {
+        audience: 'https://test.auth0.com/api/v2/',
+        client_id: 'rFeR6vyzQcDEgSUsASPeF4tXr3xbZhxE',
+        id: 'cgr_0TLisL4eNHzhSR6j',
+        scope: ['read:logs'],
+      },
+    ],
     emailTemplates: [
       {
         template: 'welcome',
@@ -400,6 +430,14 @@ describe('preserveKeywords', () => {
     pages: undefined, //TODO: test these cases more thoroughly
     rules: null, //TODO: test these cases more thoroughly
     connections: [], // Empty on remote but has local assets
+    clientGrants: [
+      {
+        audience: 'https://travel0.com/api/v1',
+        client_id: 'rFeR6vyzQcDEgSUsASPeF4tXr3xbZhxE',
+        id: 'cgr_0TLisL4eNHzhSR6j',
+        scope: ['read:logs'],
+      },
+    ],
     actions: [
       {
         name: 'action-1',
@@ -453,6 +491,11 @@ describe('preserveKeywords', () => {
       type: 'resourceServers',
     },
     { id: 'id', identifiers: ['id', 'domain'], type: 'customDomains' },
+    {
+      type: 'clientGrants',
+      id: 'id',
+      identifiers: ['id', ['client_id', 'audience']],
+    },
   ];
 
   it('should preserve keywords when they correlate to keyword mappings', () => {
@@ -482,6 +525,7 @@ describe('preserveKeywords', () => {
           },
         ];
         expected.customDomains[0].domain = '##COMPANY_NAME##.com';
+        expected.clientGrants[0].audience = '##API_MAIN_IDENTIFIER##';
         return expected;
       })()
     );
@@ -657,12 +701,6 @@ describe('preserveKeywords', () => {
         },
       ],
     });
-
-    const expected = (() => {
-      let expected = mockLocalAssets;
-      expected.actions = [mockLocalAssets.actions[0]];
-      return expected;
-    })();
 
     expect(preservedAssets).to.deep.equal({
       connections: [

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -373,20 +373,6 @@ describe('preserveKeywords', () => {
         },
       },
     ],
-    clientGrants: [
-      {
-        client_id: 'API Explorer Application',
-        audience: '##API_MAIN_IDENTIFIER##',
-        scope: ['update:account'],
-        name: 'My M2M',
-      },
-      {
-        audience: 'https://test.auth0.com/api/v2/',
-        client_id: 'rFeR6vyzQcDEgSUsASPeF4tXr3xbZhxE',
-        id: 'cgr_0TLisL4eNHzhSR6j',
-        scope: ['read:logs'],
-      },
-    ],
     emailTemplates: [
       {
         template: 'welcome',
@@ -430,14 +416,6 @@ describe('preserveKeywords', () => {
     pages: undefined, //TODO: test these cases more thoroughly
     rules: null, //TODO: test these cases more thoroughly
     connections: [], // Empty on remote but has local assets
-    clientGrants: [
-      {
-        audience: 'https://travel0.com/api/v1',
-        client_id: 'rFeR6vyzQcDEgSUsASPeF4tXr3xbZhxE',
-        id: 'cgr_0TLisL4eNHzhSR6j',
-        scope: ['read:logs'],
-      },
-    ],
     actions: [
       {
         name: 'action-1',
@@ -491,11 +469,6 @@ describe('preserveKeywords', () => {
       type: 'resourceServers',
     },
     { id: 'id', identifiers: ['id', 'domain'], type: 'customDomains' },
-    {
-      type: 'clientGrants',
-      id: 'id',
-      identifiers: ['id', ['client_id', 'audience']],
-    },
   ];
 
   it('should preserve keywords when they correlate to keyword mappings', () => {
@@ -525,7 +498,6 @@ describe('preserveKeywords', () => {
           },
         ];
         expected.customDomains[0].domain = '##COMPANY_NAME##.com';
-        expected.clientGrants[0].audience = '##API_MAIN_IDENTIFIER##';
         return expected;
       })()
     );
@@ -550,6 +522,14 @@ describe('preserveKeywords', () => {
           options: {
             domain: '##ENV##.travel0.com',
           },
+        },
+      ],
+      clientGrants: [
+        {
+          client_id: 'API Explorer Application',
+          audience: 'https://##ENV##.travel0.com/api/v1',
+          scope: ['update:account'],
+          name: 'My M2M',
         },
       ],
       actions: [
@@ -580,6 +560,14 @@ describe('preserveKeywords', () => {
             options: {
               domain: 'dev.travel0.com',
             },
+          },
+        ],
+        clientGrants: [
+          {
+            client_id: 'API Explorer Application',
+            audience: 'https://dev.travel0.com/api/v1',
+            scope: ['update:account'],
+            name: 'My M2M',
           },
         ],
         actions: [
@@ -614,12 +602,18 @@ describe('preserveKeywords', () => {
           identifiers: ['id', 'identifier'],
           type: 'resourceServers',
         },
+        {
+          type: 'clientGrants',
+          id: 'id',
+          identifiers: ['id', ['client_id', 'audience']],
+        },
       ],
     });
 
     const expected = (() => {
       let expected = mockLocalAssets;
       expected.actions = [mockLocalAssets.actions[0]];
+      expected.clientGrants[0].audience = 'https://##ENV##.travel0.com/api/v1';
       return expected;
     })();
 


### PR DESCRIPTION
### 🔧 Changes

Internal issue raised (ESD-28198) that reported that `clientGrants[].audience` fields weren't being preserved on export even after #784 was released. This bug was occurring because a client grant does not have a single identifier field but two that create a "compound" identifier field that ensures uniqueness across tenants; client grants are the only resource that have this property. This logic was not accounted for in previous iterations of keyword preservation but is added in this PR.

### 📚 References

Previous PR that added identifier field preservation: #784 

### 🔬 Testing

Unit tests added to the primary `preserveKeywords` function tests but to also to the underlying `getPreservableFieldsFromAssets` function too.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
