### PR TITLE
Update list of tenant migration flags

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -105,6 +105,9 @@ export const sanitizeMigrationFlags = ({
     'trust_azure_adfs_email_verified_connection_property',
     'include_email_in_reset_pwd_redirect',
     'include_email_in_verify_email_redirect',
+    'new_universal_login_experience_enabled',
+    'require_signed_request_object',
+    'enforce_client_authentication_on_passwordless_start',
   ];
 
   return Object.keys(proposedFlags).reduce(

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -59,7 +59,10 @@ describe('#tenant handler', () => {
 
     it("should remove migration flags if don't exist on target tenant", async () => {
       const mockFlags = {
-        trust_azure_adfs_email_verified_connection_property: true, // Migration flag
+        trust_azure_adfs_email_verified_connection_property: true, // Migration flag not on
+        new_universal_login_experience_enabled: true, // Migration flag not on remote
+        require_signed_request_object: true, // Migration flag not on remote tenant
+        enforce_client_authentication_on_passwordless_start: true, // Migration flag that *IS* on remote tenant
         'some-flag-1': true,
         'some-flag-2': false,
       };
@@ -68,7 +71,9 @@ describe('#tenant handler', () => {
         tenant: {
           getSettings: async () => {
             const flags = { ...mockFlags };
-            delete flags.trust_azure_adfs_email_verified_connection_property;
+            delete flags.trust_azure_adfs_email_verified_connection_property; // NOT on remote
+            delete flags.new_universal_login_experience_enabled; // NOT on remote
+            delete flags.require_signed_request_object; // NOT on remote
             return Promise.resolve({
               friendly_name: 'Test',
               default_directory: 'users',
@@ -81,6 +86,9 @@ describe('#tenant handler', () => {
               (() => {
                 const flags = { ...mockFlags };
                 delete flags.trust_azure_adfs_email_verified_connection_property;
+                delete flags.new_universal_login_experience_enabled;
+                delete flags.require_signed_request_object;
+                //NOTE:
                 return flags;
               })()
             );

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -112,7 +112,7 @@ describe('#tenant handler', () => {
       expect(result).to.deep.equal(flags);
     });
 
-    it("should not remove migration flag if proposed but doesn't exist currently", () => {
+    it("should remove migration flag if proposed but doesn't exist currently", () => {
       const existingFlags = {
         'some-flag-1': false,
         'some-flag-2': true,

--- a/test/tools/auth0/handlers/tenant.tests.js
+++ b/test/tools/auth0/handlers/tenant.tests.js
@@ -88,7 +88,7 @@ describe('#tenant handler', () => {
                 delete flags.trust_azure_adfs_email_verified_connection_property;
                 delete flags.new_universal_login_experience_enabled;
                 delete flags.require_signed_request_object;
-                //NOTE:
+                // NOTE:
                 return flags;
               })()
             );


### PR DESCRIPTION
### 🔧 Changes

There has been a recent uptick in incompatible tenant flags resulting in errors that resemble the following ([source](https://community.auth0.com/t/additional-properties-not-allowed-new-universal-login-experience-enabled/108069)):

```
Payload validation error: 'Additional properties not allowed: new_universal_login_experience_enabled' on property flags (Flags used to change the behavior of this tenant).
```

The above example specifically calls out the `new_universal_login_experience_enabled` flag but this issue could occur for a handful of other properties too. 

The issue here is that deprecations occur over time and sometimes these deprecations have a lag of rollout between environments and regions. What this means is that it is very possible for customers to have old config that successfully applies for one tenant but does not apply for another. The vast majority of the time, customers do not need to concern themselves with these tenant flags, they primarily exist to facilitate work behind the scenes.

This PR adds a few of the known problematic tenant flags that have been reported. This solution is more of a **temporary patch** to smooth over customer issues while a broader investigation around tenant flag management can be carried out. As a future note to folks, if anyone is continuing to receive this error after the release of this PR it is safe to remove the error-causing property from your `tenant.yaml` or `tenant.json` configuration.

### 📚 References

- [Related Community Thread](https://community.auth0.com/t/additional-properties-not-allowed-new-universal-login-experience-enabled/108069)
- [Related Github issue](https://github.com/auth0/auth0-deploy-cli/issues/788)


### 🔬 Testing

Added a few more test cases to prove that this will work.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
