### PR TITLE
Remove disallowed tenant flags from export

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -121,7 +121,11 @@ export const allowedTenantFlags = [
   'mfa_show_factor_list_on_enrollment',
 ];
 
-export const removeUnallowedTenantFlags = (proposedFlags: Tenant['flags']): Tenant['flags'] => {
+export const removeUnallowedTenantFlags = (
+  proposedFlags: Tenant['flags'] | undefined
+): Tenant['flags'] => {
+  if (proposedFlags === undefined) return {};
+
   const removedFlags: string[] = [];
   const filteredFlags = Object.keys(proposedFlags).reduce(
     (acc: Tenant['flags'], proposedKey: string): Tenant['flags'] => {

--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -31,6 +31,8 @@ export default class TenantHandler extends DefaultHandler {
   async getType(): Promise<Asset> {
     const tenant = await this.client.tenant.getSettings();
 
+    tenant.flags = removeUnallowedTenantFlags(tenant.flags);
+
     this.existing = tenant;
 
     blockPageKeys.forEach((key) => {

--- a/test/tools/auth0/handlers/tenant.tests.ts
+++ b/test/tools/auth0/handlers/tenant.tests.ts
@@ -6,6 +6,14 @@ import tenantHandler, {
   removeUnallowedTenantFlags,
 } from '../../../../src/tools/auth0/handlers/tenant';
 
+const mockAllowedFlags = Object.values(allowedTenantFlags).reduce<Record<string, boolean>>(
+  (acc, cur) => {
+    acc[cur] = true;
+    return acc;
+  },
+  {}
+);
+
 describe('#tenant handler', () => {
   describe('#tenant validate', () => {
     it('should not allow pages in tenant config', async () => {
@@ -28,6 +36,11 @@ describe('#tenant handler', () => {
         getSettings: () => ({
           friendly_name: 'Test',
           default_directory: 'users',
+          flags: {
+            ...mockAllowedFlags,
+            'unallowed-flag-1': false,
+            'unallowed-flag-2': true,
+          },
         }),
       },
     };
@@ -38,6 +51,7 @@ describe('#tenant handler', () => {
     expect(data).to.deep.equal({
       friendly_name: 'Test',
       default_directory: 'users',
+      flags: mockAllowedFlags,
     });
   });
 
@@ -119,14 +133,6 @@ describe('#tenant handler', () => {
   });
 
   describe('#removeUnallowedTenantFlags function', () => {
-    const mockAllowedFlags = Object.values(allowedTenantFlags).reduce<Record<string, boolean>>(
-      (acc, cur) => {
-        acc[cur] = true;
-        return acc;
-      },
-      {}
-    );
-
     it('should not alter flags if all are included and allowed', () => {
       const result = removeUnallowedTenantFlags(mockAllowedFlags);
       expect(result).to.deep.equal(mockAllowedFlags);


### PR DESCRIPTION
### 🔧 Changes

Related to #797 where disallowed flags are removed from management purview, this PR prevents those flags from being rendered to tenant definition files on export. This doesn't necessarily fix any current issue but will prevent these values from even being considered and more important, prevent the logging warning from being printed in the console on subsequent export.

### 📚 References

Related PR: #797 

### 🔬 Testing

Adding new test cases, ensuring that e2e tests pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
