### PR TITLE
Processing custom domains before branding

### DIFF
--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -1,4 +1,4 @@
-import DefaultHandler from './default';
+import DefaultHandler, { order } from './default';
 import constants from '../../constants';
 import log from '../../../logger';
 import { Asset, Assets } from '../../../types';
@@ -68,6 +68,7 @@ export default class BrandingHandler extends DefaultHandler {
     }
   }
 
+  @order('60') //Run after custom domains
   async processChanges(assets: Assets) {
     if (!assets.branding) return;
 

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -59,7 +59,6 @@ export default class CustomDomainsHadnler extends DefaultAPIHandler {
         err.message ===
           'The account is not allowed to perform this operation, please contact our support team'
       ) {
-        console.log('CAUGHT!', err);
         return null;
       }
       throw err;

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -1,4 +1,4 @@
-import DefaultAPIHandler from './default';
+import DefaultAPIHandler, { order } from './default';
 import { Asset, Assets } from '../../../types';
 
 export const schema = {
@@ -65,6 +65,7 @@ export default class CustomDomainsHadnler extends DefaultAPIHandler {
     }
   }
 
+  @order('50')
   async processChanges(assets: Assets): Promise<void> {
     const { customDomains } = assets;
 

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -59,6 +59,7 @@ export default class CustomDomainsHadnler extends DefaultAPIHandler {
         err.message ===
           'The account is not allowed to perform this operation, please contact our support team'
       ) {
+        console.log('CAUGHT!', err);
         return null;
       }
       throw err;

--- a/src/tools/calculateChanges.ts
+++ b/src/tools/calculateChanges.ts
@@ -93,13 +93,13 @@ export function calculateChanges({
 }: {
   handler: APIHandler;
   assets: Asset[];
-  existing: Asset[];
+  existing: Asset[] | null;
   identifiers: string[];
   allowDelete: boolean;
 }): CalculatedChanges {
   // Calculate the changes required between two sets of assets.
   const update: Asset[] = [];
-  let del: Asset[] = [...existing];
+  let del: Asset[] = [...(existing || [])];
   let create: Asset[] = [...assets];
   const conflicts: Asset[] = [];
 
@@ -178,7 +178,8 @@ export function calculateChanges({
       // If the conflicting item is going to be deleted then skip
       const inDeleted = del.filter((e) => e.name === a.name && e[uniqueID] !== a[uniqueID])[0];
       if (!inDeleted) {
-        const conflict = existing.filter(
+        console.log('existing', existing);
+        const conflict = (existing || []).filter(
           (e) => e.name === a.name && e[uniqueID] !== a[uniqueID]
         )[0];
         if (conflict) {

--- a/src/tools/calculateChanges.ts
+++ b/src/tools/calculateChanges.ts
@@ -178,7 +178,6 @@ export function calculateChanges({
       // If the conflicting item is going to be deleted then skip
       const inDeleted = del.filter((e) => e.name === a.name && e[uniqueID] !== a[uniqueID])[0];
       if (!inDeleted) {
-        console.log('existing', existing);
         const conflict = (existing || []).filter(
           (e) => e.name === a.name && e[uniqueID] !== a[uniqueID]
         )[0];


### PR DESCRIPTION
### 🔧 Changes

As noted in #789, custom domains get processed after branding which can be problematic because some branding settings require a custom domain to be configured prior. This PR simply establishes a more logical order for these settings.

Additionally, during testing of this PR, I noticed that there are cases where custom domains are not supported by the tenant and incur runtime errors within the tool. This has been solved with introducing possibility of `null` within the `calculateChanges` function, which will convert to an empty array during processing. This solves #749 .

### 📚 References

Related issues: #789 , #749

### 🔬 Testing

Manually tested ordering of resources. Added unit tests for `calculateChanges` null possibility. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
