### PR TITLE
Add `password-reset-post-challenge` to actions triggers enum

### DIFF
--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -61,6 +61,7 @@ const constants = {
     'post-user-registration',
     'post-change-password',
     'send-phone-message',
+    'password-reset-post-challenge'
   ],
   EMAIL_TEMPLATES_DIRECTORY: 'emails',
   EMAIL_VERIFY,

--- a/test/tools/auth0/handlers/triggers.tests.js
+++ b/test/tools/auth0/handlers/triggers.tests.js
@@ -32,6 +32,7 @@ describe('#triggers handler', () => {
         'post-user-registration': [],
         'post-change-password': [],
         'send-phone-message': [],
+        'password-reset-post-challenge': [],
       };
 
       await stageFn.apply(handler, [{ triggers: data }]);
@@ -47,6 +48,7 @@ describe('#triggers handler', () => {
         'post-user-registration': [],
         'post-change-password': [],
         'send-phone-message': [],
+        'password-reset-post-challenge': [],
       };
 
       const auth0 = {
@@ -76,6 +78,7 @@ describe('#triggers handler', () => {
         'post-user-registration': [{ action_name: 'action-one', display_name: 'email-user' }],
         'post-change-password': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
         'send-phone-message': [{ action_name: 'action-three', display_name: 'slack-integration' }],
+        'password-reset-post-challenge': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
       };
 
       const auth0 = {
@@ -90,6 +93,7 @@ describe('#triggers handler', () => {
               'post-user-registration',
               'post-change-password',
               'send-phone-message',
+              'password-reset-post-challenge',
             ]).to.include(trigger_id); // eslint-disable-line camelcase
             expect(bindings).to.be.an('array').that.is.empty; // eslint-disable-line no-unused-expressions
             timesUpdateTriggerBindingsCalled += 1;
@@ -112,11 +116,12 @@ describe('#triggers handler', () => {
             'post-user-registration': [],
             'post-change-password': [],
             'send-phone-message': [],
+            'password-reset-post-challenge': [],
           },
         },
       ]);
 
-      expect(timesUpdateTriggerBindingsCalled).to.equal(6);
+      expect(timesUpdateTriggerBindingsCalled).to.equal(7);
     });
 
     it('should not update triggers omitted from configuration', async () => {
@@ -134,6 +139,7 @@ describe('#triggers handler', () => {
         'post-user-registration': [{ action_name: 'action-one', display_name: 'email-user' }],
         'post-change-password': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
         'send-phone-message': [{ action_name: 'action-three', display_name: 'slack-integration' }],
+        'password-reset-post-challenge': [{ action_name: 'action-two', display_name: 'log-to-logger' }],
       };
 
       const updatePayload = [
@@ -193,6 +199,7 @@ describe('#triggers handler', () => {
         'post-user-registration': [],
         'post-change-password': [],
         'send-phone-message': [],
+        'password-reset-post-challenge': [],
       };
 
       const auth0 = {
@@ -223,6 +230,9 @@ describe('#triggers handler', () => {
                 res = { bindings: [] };
                 break;
               case 'send-phone-message':
+                res = { bindings: [] };
+                break;
+              case 'password-reset-post-challenge':
                 res = { bindings: [] };
                 break;
               default:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add `password-reset-post-challenge` to the available trigger bindings within the deploy cli.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
