### PR TITLE
Respect email template `body` value 

### DIFF
--- a/test/context/directory/emailTemplates.test.js
+++ b/test/context/directory/emailTemplates.test.js
@@ -19,7 +19,7 @@ const emailTemplates = {
   'welcome_email.html': '<html>some ##env## email</html>',
 };
 
-const emailTemplaesTarget = [
+const emailTemplatesTarget = [
   {
     body: '<html>some test email</html>',
     enabled: true,
@@ -44,7 +44,7 @@ describe('#directory context email templates', () => {
     const context = new Context(config, mockMgmtClient());
     await context.loadAssetsFromLocal();
 
-    expect(context.assets.emailTemplates).to.deep.equal(emailTemplaesTarget);
+    expect(context.assets.emailTemplates).to.deep.equal(emailTemplatesTarget);
   });
 
   it('should ignore unknown file', async () => {
@@ -62,7 +62,7 @@ describe('#directory context email templates', () => {
     const context = new Context(config, mockMgmtClient());
     await context.loadAssetsFromLocal();
 
-    expect(context.assets.emailTemplates).to.deep.equal(emailTemplaesTarget);
+    expect(context.assets.emailTemplates).to.deep.equal(emailTemplatesTarget);
   });
 
   it('should ignore bad email templates directory', async () => {

--- a/test/context/directory/emailTemplates.test.js
+++ b/test/context/directory/emailTemplates.test.js
@@ -12,8 +12,8 @@ import { cleanThenMkdir, testDataDir, createDir, mockMgmtClient } from '../../ut
 const emailTemplates = {
   'provider.json': '{"name": "smtp"}',
   'verify_email.json':
-    '{ "template": "verify_email", "enabled": true, "from": "test@##env##.com" }',
-  'verify_email.html': '<html>some ##env## email</html>',
+    '{ "template": "verify_email", "enabled": true, "from": "test@##env##.com" , "body" : "./verify_email.html.liquid" }',
+  'verify_email.html.liquid': '<html>some ##env## email</html>',
   'welcome_email.json':
     '{ "template": "welcome_email", "enabled": true, "from": "test@##env##.com" }',
   'welcome_email.html': '<html>some ##env## email</html>',
@@ -35,7 +35,19 @@ const emailTemplatesTarget = [
 ];
 
 describe('#directory context email templates', () => {
-  it('should process email temples', async () => {
+  it('should process email templates', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'emailTemplates1');
+    const dir = path.join(repoDir);
+    createDir(dir, { [constants.EMAIL_TEMPLATES_DIRECTORY]: emailTemplates });
+
+    const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_KEYWORD_REPLACE_MAPPINGS: { env: 'test' } };
+    const context = new Context(config, mockMgmtClient());
+    await context.loadAssetsFromLocal();
+
+    expect(context.assets.emailTemplates).to.deep.equal(emailTemplatesTarget);
+  });
+
+  it('should process email templates', async () => {
     const repoDir = path.join(testDataDir, 'directory', 'emailTemplates1');
     const dir = path.join(repoDir);
     createDir(dir, { [constants.EMAIL_TEMPLATES_DIRECTORY]: emailTemplates });


### PR DESCRIPTION
### 🔧 Changes

As reported by #776 , when managing email templates in directory mode, explicitly-defining an email template's file path in the `body` property does not work. Currently, email template files are resolved by following a rigid pattern of `<template_type>.html` without any flexibility of naming or file extension.

This PR enables an email template's file path to be defined through the `body` property allowing flexibility with conventions (filename, extension, directory, etc).

**Example :** (note the `body` property with `.liquid` file extension)
```
{
  "template": "enrollment_email",
  "syntax": "liquid",
  "body": "./enrollment_email.html.liquid",
  "from": "noreply@example.com",
  "subject": "Enroll in MFA",
  "enabled": true
}
```

### 📚 References

Related issue: #776 

### 🔬 Testing

Added change in unit test.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
