### PR TITLE
Fixing broken link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_a_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_a_bug.yml
@@ -26,7 +26,7 @@ body:
           required: true
         - label: I have upgraded to the [latest version](https://github.com/auth0/auth0-deploy-cli/releases/latest) of this tool and the issue still persists.
           required: true
-        - label: I have searched the [Auth0 Community](https://community.auth0.com/c/sdks/5) forums and have not found a suitable solution or answer.
+        - label: I have searched the [Auth0 Community](https://community.auth0.com/tag/auth0-deploy-cli) forums and have not found a suitable solution or answer.
           required: true
         - label: I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
           required: true


### PR DESCRIPTION
### 🔧 Changes

As noted in #832 there is a broken link in the Github issue template. This fixes that link. Not a perfect replacement but guides folks to a useful resource at least.

### 📚 References

New link: https://community.auth0.com/tag/auth0-deploy-cli


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
