### PR TITLE
GH-828: Adjust order of branding and themes

### DIFF
--- a/src/tools/auth0/handlers/branding.ts
+++ b/src/tools/auth0/handlers/branding.ts
@@ -68,7 +68,7 @@ export default class BrandingHandler extends DefaultHandler {
     }
   }
 
-  @order('60') //Run after custom domains
+  @order('70') // Run after custom domains and themes.
   async processChanges(assets: Assets) {
     if (!assets.branding) return;
 

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -1,6 +1,6 @@
 import { Assets } from '../../../types';
 import log from '../../../logger';
-import DefaultHandler from './default';
+import DefaultHandler, { order } from './default';
 
 export default class ThemesHandler extends DefaultHandler {
   existing: Theme[] | null;
@@ -25,6 +25,7 @@ export default class ThemesHandler extends DefaultHandler {
     return this.existing;
   }
 
+  @order('60') // Run after custom domains.
   async processChanges(assets: Assets): Promise<void> {
     const { themes } = assets;
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As raised in https://github.com/auth0/auth0-deploy-cli/issues/828, there is currently an edge case where running the themes create/update after the branding create/update doesn't not immediately apply the theme. This is caused by the fact that the cache does not get invalidated when adjusting these settings on the API side. In order to patch this and force the revalidation only through API calls we reorder when the changes apply on the theme, so they can get applied before any branding changes.

### 📚 References

- https://github.com/auth0/auth0-deploy-cli/issues/828

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
