### PR TITLE
Multi-identifier specificity during keyword preservation (GH-826)

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -65,8 +65,6 @@ export const getPreservableFieldsFromAssets = (
           ''
         );
 
-        console.log({ specificAddress });
-
         if (specificAddress === null) {
           return [];
         }

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -2,7 +2,7 @@ import { get as getByDotNotation, set as setByDotNotation } from 'dot-prop';
 import { keywordReplace } from './tools/utils';
 import { AssetTypes, KeywordMappings } from './types';
 import { keywordReplaceArrayRegExp, keywordReplaceStringRegExp } from './tools/utils';
-import { cloneDeep, isArray } from 'lodash';
+import { cloneDeep, forEach, isArray } from 'lodash';
 import APIHandler from './tools/auth0/handlers/default';
 
 /*
@@ -48,24 +48,35 @@ export const getPreservableFieldsFromAssets = (
           return [identifiers];
         })();
 
-        return resourceIdentifiers
-          .map((resourceIdentifier) => {
+        const specificAddress = resourceIdentifiers.reduce(
+          (aggregateAddress, resourceIdentifier) => {
             resourceSpecificIdentifiers[address];
-            if (resourceIdentifier === undefined) return []; // See if this specific resource type has an identifier
+            if (resourceIdentifier === undefined) return null; // See if this specific resource type has an identifier
 
             const identifierFieldValue = arrayItem[resourceIdentifier];
-            if (identifierFieldValue === undefined) return []; // See if this specific array item possess the resource-specific identifier
+            if (identifierFieldValue === undefined) return null; // See if this specific array item possess the resource-specific identifier
 
-            return getPreservableFieldsFromAssets(
-              arrayItem,
-              keywordMappings,
-              resourceSpecificIdentifiers,
-              `${address}${
-                shouldRenderDot ? '.' : ''
-              }[${resourceIdentifier}=${identifierFieldValue}]`
-            );
-          })
-          .flat();
+            if (aggregateAddress === '') {
+              return `${resourceIdentifier}=${identifierFieldValue}`;
+            }
+
+            return `${aggregateAddress}||${resourceIdentifier}=${identifierFieldValue}`;
+          },
+          ''
+        );
+
+        console.log({ specificAddress });
+
+        if (specificAddress === null) {
+          return [];
+        }
+
+        return getPreservableFieldsFromAssets(
+          arrayItem,
+          keywordMappings,
+          resourceSpecificIdentifiers,
+          `${address}${shouldRenderDot ? '.' : ''}[${specificAddress}]`
+        );
       })
       .flat();
   }
@@ -110,13 +121,17 @@ export const getAssetsValueByAddress = (address: string, assets: any): any => {
   // If the the next directions are the proprietary array syntax (ex: `[name=foo]`)
   // then perform lookup against unique array-item property
   if (directions[0].charAt(0) === '[') {
-    const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
-    const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
-
     if (!isArray(assets)) return undefined;
 
     const target = assets.find((item: any) => {
-      return item[identifier] === identifierValue;
+      const parts = directions[0].substring(1).slice(0, -1).split('||');
+
+      return parts.every((part) => {
+        const identifier = part.split('=')[0];
+        const identifierValue = part.split('=')[1];
+
+        return item[identifier] === identifierValue;
+      });
     });
 
     return getAssetsValueByAddress(directions.slice(1).join('.'), target);
@@ -144,13 +159,19 @@ export const convertAddressToDotNotation = (
   if (directions[0] === '') return finalAddressTrail;
 
   if (directions[0].charAt(0) === '[') {
-    const identifier = directions[0].substring(1, directions[0].length - 1).split('=')[0];
-    const identifierValue = directions[0].substring(1, directions[0].length - 1).split('=')[1];
+    const identifiers = directions[0].substring(1).slice(0, -1).split('||');
 
     let targetIndex = -1;
 
     assets.forEach((item: any, index: number) => {
-      if (item[identifier] === identifierValue) {
+      if (
+        identifiers.every((part) => {
+          const identifier = part.split('=')[0];
+          const identifierValue = part.split('=')[1];
+
+          return item[identifier] === identifierValue;
+        })
+      ) {
         targetIndex = index;
       }
     });

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -194,19 +194,78 @@ describe('getAssetsValueByAddress', () => {
 
   it('should find the value of the addressed property for multi-part identifiers', () => {
     const mockAssetTree = {
-      foo: [
+      clientGrants: [
         {
-          prop1: 'A',
-          prop2: 'A',
+          client_id: 'client-1',
+          audience: 'audience-1',
+          name: 'Client 1, Audience 1',
         },
         {
-          prop1: 'A',
-          prop2: 'B',
+          client_id: 'client-1',
+          audience: 'audience-2',
+          name: 'Client 1, Audience 2',
+        },
+        {
+          client_id: 'client-2',
+          audience: 'audience-2',
+          name: 'Client 2, Audience 2',
+        },
+        {
+          client_id: 'client-2',
+          audience: 'audience-1',
+          name: 'Client 2, Audience 1',
         },
       ],
     };
-    expect(getAssetsValueByAddress('foo.[prop1=A||prop2=A].prop2', mockAssetTree)).to.equal('A');
-    expect(getAssetsValueByAddress('foo.[prop1=A||prop2=B].prop2', mockAssetTree)).to.equal('B');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-1].name',
+        mockAssetTree
+      )
+    ).to.equal('Client 1, Audience 1');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-2].name',
+        mockAssetTree
+      )
+    ).to.equal('Client 1, Audience 2');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-2||audience=audience-1].name',
+        mockAssetTree
+      )
+    ).to.equal('Client 2, Audience 1');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-2||audience=audience-2].name',
+        mockAssetTree
+      )
+    ).to.equal('Client 2, Audience 2');
+
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-1].audience',
+        mockAssetTree
+      )
+    ).to.equal('audience-1');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-2].audience',
+        mockAssetTree
+      )
+    ).to.equal('audience-2');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-1].client_id',
+        mockAssetTree
+      )
+    ).to.equal('client-1');
+    expect(
+      getAssetsValueByAddress(
+        'clientGrants.[client_id=client-1||audience=audience-2].client_id',
+        mockAssetTree
+      )
+    ).to.equal('client-1');
   });
 
   it('should handle a non-array assets value', () => {


### PR DESCRIPTION
### 🔧 Changes

As reported in #826, there can be instances where a client grant uses a keyword marker in an identifier but upon export, an adjacent client grant with an identical client ID or audience has some properties overwritten. 

This happened because client grants have two identifiers, client ID and audience. The addressing mechanism for keyword preservation only attempted to match based on one of the two identifiers. In order for the addressing to identify a single unique client grant, we need to encode both identifiers into the address. Multiple identifiers are delimited by a `||` which should prevent any collisions. 

**Example:**
Before:
```
clientGrants.[audience=##KEYWORD##].audience
```

After:
```
clientGrants.[audience=##KEYWORD##||client_id=client-id].audience
```

This ensures the single, correct client grant is being selected for preservation.

**Note:** There is still a limitation where keywords may not get preserved if multiple aspects of a client grant contain keyword markers. However, this will just result some fields not being preserved; no destructive changes should occur.

### 📚 References

Related Issue: #826 

### 🔬 Testing

All existing unit tests pass. Slew of new unit tests for this specific issue.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
