### PR TITLE
refactor: Add config.json as default file for config_file parameter

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -12,7 +12,7 @@ export default async function exportCMD(params: ExportParams) {
   const {
     output_folder: outputFolder,
     base_path: basePath,
-    config_file: configFile,
+    config_file: configFile = "config.json",
     config: configObj,
     export_ids: exportIds,
     secret: clientSecret,

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -9,7 +9,7 @@ export default async function importCMD(params: ImportParams) {
   const {
     input_file: inputFile,
     base_path: basePath,
-    config_file: configFile,
+    config_file: configFile= "config.json",
     config: configObj,
     env: shouldInheritEnv = false,
     secret: clientSecret,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add `config.json` as default file for config_file parameter in export and import commands. As per our documentation [here](https://github.com/auth0/auth0-deploy-cli/blob/master/docs/configuring-the-deploy-cli.md#configuration-file) the following command does not require configuration file parameter

`a0deploy import --input_file=local/tenant.yaml`

But the above command throws error even though there is a file in the folder called `config.json`

`The following parameters were missing. Please add them to your config.json or as an environment variable.`

This pull request adds `config.json` as default from current directory unless `--c` option is provided and in that case root directory `config.json` will be ignored.


### 📚 References

[Configuring CLI ](https://github.com/auth0/auth0-deploy-cli/blob/master/docs/configuring-the-deploy-cli.md#configuring-the-deploy-cli)

### 🔬 Testing

1. There are no tests for commands.
2. I am unable to run existing tests locally. 
3. Contribution guide does not mention how to setup and run tests locally [guide](https://github.com/auth0/auth0-deploy-cli/blob/2d42e4b7f8c8c455be5a64b254a3eadf43bf46d6/CONTRIBUTING.md)

### 📝 Checklist

- [N/A] All new/changed/fixed functionality is covered by tests (or N/A)
- [N/A] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
