### PR TITLE
Fetch clients if not defined in client grants YAML handler

### DIFF
--- a/src/context/yaml/handlers/clientGrants.ts
+++ b/src/context/yaml/handlers/clientGrants.ts
@@ -17,9 +17,16 @@ async function parse(context: YAMLContext): Promise<ParsedClientGrants> {
 }
 
 async function dump(context: YAMLContext): Promise<ParsedClientGrants> {
-  const { clientGrants, clients } = context.assets;
+  let { clientGrants, clients } = context.assets;
 
   if (!clientGrants) return { clientGrants: null };
+
+  if (clients === undefined) {
+    clients = await context.mgmtClient.clients.getAll({
+      paginate: true,
+      include_totals: true,
+    });
+  }
 
   // Convert client_id to the client name for readability
   return {

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -7,6 +7,7 @@ import {
   wrapArrayReplaceMarkersInQuotes,
   Auth0,
 } from '../../tools';
+import pagedClient from '../../tools/auth0/client';
 
 import log from '../../logger';
 import { isFile, toConfigFn, stripIdentifiers, formatResults, recordsSorter } from '../../utils';
@@ -29,7 +30,7 @@ export default class YAMLContext {
     this.configFile = config.AUTH0_INPUT_FILE;
     this.config = config;
     this.mappings = config.AUTH0_KEYWORD_REPLACE_MAPPINGS || {};
-    this.mgmtClient = mgmtClient;
+    this.mgmtClient = pagedClient(mgmtClient);
     this.disableKeywordReplacement = false;
 
     //@ts-ignore because the assets property gets filled out throughout

--- a/test/context/yaml/clientGrants.test.js
+++ b/test/context/yaml/clientGrants.test.js
@@ -40,11 +40,58 @@ describe('#YAML context client grants', () => {
   it('should dump client grants', async () => {
     const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
     const clientGrants = [
-      { audience: 'https://test.myapp.com/api/v1', client_id: 'My M2M', scope: ['update:account'] },
+      {
+        audience: 'https://test.myapp.com/api/v1',
+        client_id: 'client-id',
+        scope: ['update:account'],
+      },
     ];
     context.assets.clientGrants = clientGrants;
 
     const dumped = await handler.dump(context);
     expect(dumped).to.deep.equal({ clientGrants });
+  });
+
+  it('should dump client grants and replace client ID with client name if clients in assets', async () => {
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
+    const clientGrants = [
+      {
+        audience: 'https://test.myapp.com/api/v1',
+        client_id: 'client-id-1',
+        scope: ['update:account'],
+      },
+    ];
+    context.assets.clientGrants = clientGrants;
+    context.assets.clients = [{ client_id: 'client-id-1', name: 'Client 1' }];
+
+    const dumped = await handler.dump(context);
+    const expected = (() => {
+      const ret = clientGrants;
+      ret[0].client_id = 'Client 1';
+      return { clientGrants: ret };
+    })();
+    expect(dumped).to.deep.equal(expected);
+  });
+
+  it('should dump client grants and replace client ID with client name even if clients not in assets', async () => {
+    const mockMgmt = mockMgmtClient();
+    mockMgmt.clients.getAll = () => [[{ client_id: 'client-id-1', name: 'Client 1' }]];
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmt);
+    const clientGrants = [
+      {
+        audience: 'https://test.myapp.com/api/v1',
+        client_id: 'client-id-1',
+        scope: ['update:account'],
+      },
+    ];
+    context.assets.clientGrants = clientGrants;
+
+    const dumped = await handler.dump(context);
+    const expected = (() => {
+      const ret = clientGrants;
+      ret[0].client_id = 'Client 1';
+      return { clientGrants: ret };
+    })();
+    expect(dumped).to.deep.equal(expected);
   });
 });


### PR DESCRIPTION
### 🔧 Changes

While troubleshooting #855, I noticed that for YAML exports, an exported client grant wouldn't have the `client_id` swapped with its correlating client's name if the clients didn't exist in the `assets` object. This _should_ be fairly rare but still technically possible in cases where you're excluding clients from the management purview. 

### 🔬 Testing

Added two new test cases to round-out all possibilities:
1. Clients exist on `assets` object already, client name replace for ID
2. Clients do not exist on `assets`, clients fetched but ID not replaced for name because no correlating client exists
3. Clients do not exist on `assets`, clients fetched and ID replaced for name because correlating client found

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
