### PR TITLE
Add relative path import support for actions directory handler

### DIFF
--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -28,9 +28,12 @@ function parse(context: DirectoryContext): ParsedActions {
     const actionFolder = path.join(constants.ACTIONS_DIRECTORY, `${action.name}`);
 
     if (action.code) {
-      const toUnixPath = (somePath) =>
-        somePath.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
-      action.code = context.loadFile(toUnixPath(action.code), actionFolder);
+      const unixPath = action.code.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
+      if (fs.existsSync(unixPath)) {
+        action.code = context.loadFile(unixPath, actionFolder);
+      } else {
+        action.code = context.loadFile(path.join(context.filePath, action.code), actionFolder);
+      }
     }
 
     return action;

--- a/test/context/directory/actions.test.js
+++ b/test/context/directory/actions.test.js
@@ -111,6 +111,45 @@ describe('#directory context actions', () => {
     expect(context.assets.actions).to.deep.equal(actionsTarget);
   });
 
+  it('should process actions when code is stored in path relative to input file', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'test5');
+    const files = {
+      'separate-directory': {
+        'action-code.js':
+          '/** @type {PostLoginAction} */ module.exports = async (event, context) => { console.log("test-action"); return {}; };',
+      },
+      [constants.ACTIONS_DIRECTORY]: {
+        'action-one.json': `{
+          "name": "action-one",
+          "code": "./separate-directory/action-code.js",
+          "runtime": "node12",
+          "dependencies": [
+            {
+              "name": "lodash",
+              "version": "4.17.20"
+            }
+          ],
+          "secrets": [],
+          "status": "built",
+          "supported_triggers": [
+            {
+              "id": "post-login",
+              "version": "v1"
+            }
+          ],
+          "deployed": true
+        }`,
+      },
+    };
+    createDir(repoDir, files);
+    const config = {
+      AUTH0_INPUT_FILE: repoDir,
+    };
+    const context = new Context(config, mockMgmtClient());
+    await context.loadAssetsFromLocal();
+    expect(context.assets.actions).to.deep.equal(actionsTarget);
+  });
+
   it('should ignore bad actions directory', async () => {
     const repoDir = path.join(testDataDir, 'directory', 'test2');
     cleanThenMkdir(repoDir);


### PR DESCRIPTION
### 🔧 Changes

As reported by #840, actions managed in directory mode produce paths that are relative to the CLI. This is in contrast to other imports, specifically the actions YAML handler, that import relative to the input file. This inconsistency can create confusion and a worse DX for developers unsure how to import code.

The solution here is to add a backup import strategy that targets the action code file relative to the input file. This will ensure backwards compatibility. 

### 📚 References

Related issue: #840 

### 🔬 Testing

Added new test case.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
