### PR TITLE
Bugfix/issue 875

### DIFF
--- a/src/tools/auth0/handlers/logStreams.ts
+++ b/src/tools/auth0/handlers/logStreams.ts
@@ -40,7 +40,7 @@ export default class LogStreamsHandler extends DefaultAPIHandler {
       ...config,
       type: 'logStreams',
       stripUpdateFields: ['type'],
-      stripCreateFields: ['status', 'sink.awsPartnerEventSource'],
+      stripCreateFields: ['status', 'sink.awsPartnerEventSource', 'sink.azurePartnerTopic'],
       sensitiveFieldsToObfuscate: [
         'sink.httpAuthorization',
         'sink.splunkToken',

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -6,10 +6,19 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 0,
+            "total": 1,
             "start": 0,
             "limit": 100,
-            "rules": []
+            "rules": [
+                {
+                    "id": "rul_lr4Xo8OyXNEz4R6v",
+                    "enabled": true,
+                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
+                    "name": "my-rule",
+                    "order": 2,
+                    "stage": "login_success"
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -21,28 +30,36 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 0,
+            "total": 1,
             "start": 0,
             "limit": 100,
-            "rules": []
+            "rules": [
+                {
+                    "id": "rul_lr4Xo8OyXNEz4R6v",
+                    "enabled": true,
+                    "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
+                    "name": "my-rule",
+                    "order": 2,
+                    "stage": "login_success"
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/rules",
+        "method": "PATCH",
+        "path": "/api/v2/rules/rul_lr4Xo8OyXNEz4R6v",
         "body": {
             "name": "my-rule",
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
-            "stage": "login_success",
             "enabled": true,
             "order": 2
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "rul_Sjij7JPRIyGmTeHf",
+            "id": "rul_lr4Xo8OyXNEz4R6v",
             "enabled": true,
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
             "name": "my-rule",
@@ -247,7 +264,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -894,6 +912,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -924,7 +958,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 9,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -994,7 +1028,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ohJchrySIGMHYfCQ4Huey161rE1EmQOm",
+                    "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1009,6 +1043,368 @@
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -1018,7 +1414,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ohJchrySIGMHYfCQ4Huey161rE1EmQOm",
+        "path": "/api/v2/clients/aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
         "body": {},
         "status": 204,
         "response": "",
@@ -1027,8 +1423,188 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
+        "method": "PATCH",
+        "path": "/api/v2/clients/RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+        "body": {
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
+        "body": {
+            "name": "Quickstarts API (Test Application)",
+            "app_type": "non_interactive",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -1050,8 +1626,7 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
+                "lifetime_in_seconds": 36000
             },
             "native_social_login": {
                 "apple": {
@@ -1075,7 +1650,7 @@
             "token_endpoint_auth_method": "client_secret_post",
             "web_origins": []
         },
-        "status": 201,
+        "status": 200,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1106,17 +1681,15 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
-            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
             "allowed_origins": [],
-            "client_id": "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+            "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1141,272 +1714,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Quickstarts API (Test Application)",
-            "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
+        "method": "PATCH",
+        "path": "/api/v2/clients/FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
         "body": {
             "name": "The Default App",
             "allowed_clients": [],
@@ -1425,8 +1734,7 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
+                "lifetime_in_seconds": 36000
             },
             "native_social_login": {
                 "apple": {
@@ -1450,7 +1758,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 201,
+        "status": 200,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1481,16 +1789,14 @@
             },
             "sso": false,
             "sso_disabled": false,
-            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+            "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1513,8 +1819,83 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
+        "method": "PATCH",
+        "path": "/api/v2/clients/LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/WZycF991qhrOzwWsHmECCdnls0r14R8L",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -1538,8 +1919,7 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
+                "lifetime_in_seconds": 36000
             },
             "native_social_login": {
                 "apple": {
@@ -1565,7 +1945,7 @@
                 "http://localhost:3000"
             ]
         },
-        "status": 201,
+        "status": 200,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1600,16 +1980,14 @@
                 "rotation_type": "rotating"
             },
             "sso_disabled": false,
-            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+            "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1635,8 +2013,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
+        "method": "PATCH",
+        "path": "/api/v2/clients/PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
         "body": {
             "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
@@ -1653,8 +2031,7 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
+                "lifetime_in_seconds": 36000
             },
             "native_social_login": {
                 "apple": {
@@ -1677,7 +2054,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 201,
+        "status": 200,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -1707,16 +2084,14 @@
                 "rotation_type": "non-rotating"
             },
             "sso_disabled": false,
-            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+            "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1740,19 +2115,19 @@
         "method": "GET",
         "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
         "body": "",
-        "status": 404,
+        "status": 200,
         "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "There is not a configured email provider",
-            "errorCode": "inexistent_email_provider"
+            "name": "mandrill",
+            "credentials": {},
+            "default_from_address": "auth0-user@auth0.com",
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
+        "method": "PATCH",
         "path": "/api/v2/emails/provider?enabled=false&name=mandrill",
         "body": {
             "name": "mandrill",
@@ -1762,11 +2137,53 @@
             "default_from_address": "auth0-user@auth0.com",
             "enabled": false
         },
-        "status": 201,
+        "status": 200,
         "response": {
             "name": "mandrill",
             "credentials": {},
             "default_from_address": "auth0-user@auth0.com",
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": true
+        },
+        "status": 200,
+        "response": {
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
             "enabled": false
         },
         "rawHeaders": [],
@@ -1817,49 +2234,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -2018,16 +2393,6 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/log-streams?paginate=false",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": {
@@ -2053,19 +2418,88 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/log-streams",
+        "method": "GET",
+        "path": "/api/v2/log-streams?paginate=false",
+        "body": "",
+        "status": 200,
+        "response": [
+            {
+                "id": "lst_0000000000015064",
+                "name": "Amazon EventBridge",
+                "type": "eventbridge",
+                "status": "active",
+                "sink": {
+                    "awsAccountId": "123456789012",
+                    "awsRegion": "us-east-2",
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-ad7deb22-8b6e-4242-ba40-344f97b05739/auth0.logs"
+                },
+                "filters": [
+                    {
+                        "type": "category",
+                        "name": "auth.login.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.notification"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.signup.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.token_exchange.fail"
+                    }
+                ]
+            },
+            {
+                "id": "lst_0000000000015063",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            }
+        ],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/log-streams/lst_0000000000015063",
         "body": {
             "name": "Suspended DD Log Stream",
             "sink": {
                 "datadogApiKey": "some-sensitive-api-key",
                 "datadogRegion": "us"
-            },
-            "type": "datadog"
+            }
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000013776",
+            "id": "lst_0000000000015063",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -2079,8 +2513,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/log-streams",
+        "method": "PATCH",
+        "path": "/api/v2/log-streams/lst_0000000000015064",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -2121,22 +2555,18 @@
                     "name": "auth.token_exchange.fail"
                 }
             ],
-            "sink": {
-                "awsAccountId": "123456789012",
-                "awsRegion": "us-east-2"
-            },
-            "type": "eventbridge"
+            "status": "active"
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000013777",
+            "id": "lst_0000000000015064",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-79a58600-ea32-48ae-bd81-e289c20ed37f/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-ad7deb22-8b6e-4242-ba40-344f97b05739/auth0.logs"
             },
             "filters": [
                 {
@@ -2235,6 +2665,58 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Node App",
                     "allowed_clients": [],
                     "allowed_logout_urls": [],
@@ -2269,7 +2751,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+                    "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2317,99 +2799,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+                    "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2461,7 +2851,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+                    "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2475,6 +2865,46 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2520,7 +2950,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+                    "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2577,7 +3007,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+                    "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2637,19 +3067,93 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_yf17tj2N7LKO6iBp",
+                    "id": "con_K5DvCabszfTqFX2a",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": [
+                        "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
+                    ]
+                },
+                {
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -2674,19 +3178,93 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_yf17tj2N7LKO6iBp",
+                    "id": "con_K5DvCabszfTqFX2a",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": [
+                        "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
+                    ]
+                },
+                {
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -2707,25 +3285,93 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_yf17tj2N7LKO6iBp",
+        "path": "/api/v2/connections/con_qavKC44AnXdVIktG",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2023-10-27T17:58:21.317Z"
+            "deleted_at": "2023-12-22T14:45:57.357Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/connections",
-        "body": {
-            "name": "boo-baz-db-connection-test",
+        "method": "GET",
+        "path": "/api/v2/connections/con_K5DvCabszfTqFX2a",
+        "body": "",
+        "status": 200,
+        "response": {
+            "id": "con_K5DvCabszfTqFX2a",
+            "options": {
+                "mfa": {
+                    "active": true,
+                    "return_enroll_settings": true
+                },
+                "import_mode": false,
+                "customScripts": {
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                },
+                "disable_signup": false,
+                "passwordPolicy": "low",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
+                "password_history": {
+                    "size": 5,
+                    "enable": false
+                },
+                "strategy_version": 2,
+                "requires_username": true,
+                "password_dictionary": {
+                    "enable": true,
+                    "dictionary": []
+                },
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
+                "brute_force_protection": true,
+                "password_no_personal_info": {
+                    "enable": true
+                },
+                "password_complexity_options": {
+                    "min_length": 8
+                },
+                "enabledDatabaseCustomization": true
+            },
             "strategy": "auth0",
+            "name": "boo-baz-db-connection-test",
+            "is_domain_connection": false,
             "enabled_clients": [
-                "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
-                "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V"
+                "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
+            ],
+            "realms": [
+                "boo-baz-db-connection-test"
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/connections/con_K5DvCabszfTqFX2a",
+        "body": {
+            "enabled_clients": [
+                "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
             ],
             "is_domain_connection": false,
             "options": {
@@ -2744,6 +3390,11 @@
                 },
                 "disable_signup": false,
                 "passwordPolicy": "low",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "password_history": {
                     "size": 5,
                     "enable": false
@@ -2753,6 +3404,14 @@
                 "password_dictionary": {
                     "enable": true,
                     "dictionary": []
+                },
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
                 },
                 "brute_force_protection": true,
                 "password_no_personal_info": {
@@ -2767,25 +3426,30 @@
                 "boo-baz-db-connection-test"
             ]
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "con_i71jW6OTkuVtMpGT",
+            "id": "con_K5DvCabszfTqFX2a",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "low",
                 "import_mode": false,
                 "customScripts": {
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
                     "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
                 },
                 "disable_signup": false,
+                "passwordPolicy": "low",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "password_history": {
                     "size": 5,
                     "enable": false
@@ -2795,6 +3459,14 @@
                 "password_dictionary": {
                     "enable": true,
                     "dictionary": []
+                },
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
                 },
                 "brute_force_protection": true,
                 "password_no_personal_info": {
@@ -2809,8 +3481,8 @@
             "name": "boo-baz-db-connection-test",
             "is_domain_connection": false,
             "enabled_clients": [
-                "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK"
+                "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -2874,6 +3546,58 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Node App",
                     "allowed_clients": [],
                     "allowed_logout_urls": [],
@@ -2908,7 +3632,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+                    "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2956,99 +3680,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+                    "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3100,7 +3732,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+                    "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3114,6 +3746,46 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3159,7 +3831,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+                    "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3216,7 +3888,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+                    "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3276,12 +3948,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_i71jW6OTkuVtMpGT",
+                    "id": "con_K5DvCabszfTqFX2a",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3298,6 +3970,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -3307,6 +3984,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -3324,8 +4009,29 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                        "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK"
+                        "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
+                    ]
+                },
+                {
+                    "id": "con_F6FupkR2JVv0xmQV",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": [
+                        "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
                     ]
                 }
             ]
@@ -3340,12 +4046,12 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_i71jW6OTkuVtMpGT",
+                    "id": "con_K5DvCabszfTqFX2a",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3362,6 +4068,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -3371,6 +4082,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -3388,8 +4107,29 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                        "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK"
+                        "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
+                    ]
+                },
+                {
+                    "id": "con_F6FupkR2JVv0xmQV",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": [
+                        "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
                     ]
                 }
             ]
@@ -3399,14 +4139,12 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/connections",
+        "method": "PATCH",
+        "path": "/api/v2/connections/con_F6FupkR2JVv0xmQV",
         "body": {
-            "name": "google-oauth2",
-            "strategy": "google-oauth2",
             "enabled_clients": [
-                "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
-                "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V"
+                "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3418,9 +4156,9 @@
                 "profile": true
             }
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "con_WEXY9ZnXOS8DngUu",
+            "id": "con_F6FupkR2JVv0xmQV",
             "options": {
                 "email": true,
                 "scope": [
@@ -3433,8 +4171,8 @@
             "name": "google-oauth2",
             "is_domain_connection": false,
             "enabled_clients": [
-                "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61"
+                "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
             ],
             "realms": [
                 "google-oauth2"
@@ -3552,6 +4290,58 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Node App",
                     "allowed_clients": [],
                     "allowed_logout_urls": [],
@@ -3586,7 +4376,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+                    "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3634,99 +4424,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+                    "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3778,7 +4476,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+                    "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3792,6 +4490,46 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3837,7 +4575,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+                    "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3894,7 +4632,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+                    "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3954,12 +4692,286 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 1,
+            "total": 3,
             "start": 0,
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_gTGj8tQZaiX5UlSe",
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
+                {
+                    "id": "cgr_oq3uveZxzwc7wss0",
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
+                {
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -4130,11 +5142,9 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/client-grants",
+        "method": "PATCH",
+        "path": "/api/v2/client-grants/cgr_gTGj8tQZaiX5UlSe",
         "body": {
-            "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -4268,10 +5278,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "cgr_mgrh7iyIZ4W0zrep",
-            "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
+            "id": "cgr_gTGj8tQZaiX5UlSe",
+            "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4411,11 +5421,9 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/client-grants",
+        "method": "PATCH",
+        "path": "/api/v2/client-grants/cgr_oq3uveZxzwc7wss0",
         "body": {
-            "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
-            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -4549,10 +5557,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "cgr_yGReGyOkgUBrfmKG",
-            "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+            "id": "cgr_oq3uveZxzwc7wss0",
+            "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4697,7 +5705,43 @@
         "body": "",
         "status": 200,
         "response": {
-            "roles": [],
+            "roles": [
+                {
+                    "id": "rol_akyigjRpa1CNc2RA",
+                    "name": "Admin",
+                    "description": "Can read and write things"
+                },
+                {
+                    "id": "rol_BXNSxZlMD6p3fj8y",
+                    "name": "Reader",
+                    "description": "Can only read things"
+                },
+                {
+                    "id": "rol_D8YUHJmpsX4Gxn7W",
+                    "name": "read_only",
+                    "description": "Read Only"
+                },
+                {
+                    "id": "rol_ZjTN0eReZsvpoZRw",
+                    "name": "read_osnly",
+                    "description": "Readz Only"
+                }
+            ],
+            "start": 0,
+            "limit": 100,
+            "total": 4
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/roles/rol_akyigjRpa1CNc2RA/permissions?include_totals=true&page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "permissions": [],
             "start": 0,
             "limit": 100,
             "total": 0
@@ -4707,68 +5751,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/roles",
-        "body": {
-            "name": "Admin",
-            "description": "Can read and write things"
-        },
+        "method": "GET",
+        "path": "/api/v2/roles/rol_BXNSxZlMD6p3fj8y/permissions?include_totals=true&page=0&per_page=100",
+        "body": "",
         "status": 200,
         "response": {
-            "id": "rol_VFV74oRWWXdG425f",
-            "name": "Admin",
-            "description": "Can read and write things"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/roles",
-        "body": {
-            "name": "Reader",
-            "description": "Can only read things"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_GYGhQHbigkWhaDGp",
-            "name": "Reader",
-            "description": "Can only read things"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/roles",
-        "body": {
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_fuGysc36ODvKYBtX",
-            "name": "read_only",
-            "description": "Read Only"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/roles",
-        "body": {
-            "name": "read_osnly",
-            "description": "Readz Only"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_Y0tWSxZo0gb0Lpjn",
-            "name": "read_osnly",
-            "description": "Readz Only"
+            "permissions": [],
+            "start": 0,
+            "limit": 100,
+            "total": 0
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4776,51 +5767,97 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "path": "/api/v2/roles/rol_D8YUHJmpsX4Gxn7W/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
-            "actions": [],
-            "per_page": 100
+            "permissions": [],
+            "start": 0,
+            "limit": 100,
+            "total": 0
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/actions/actions",
-        "body": {
-            "name": "My Custom Action",
-            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-            "dependencies": [],
-            "runtime": "node16",
-            "secrets": [],
-            "supported_triggers": [
-                {
-                    "id": "post-login",
-                    "version": "v2"
-                }
-            ]
-        },
-        "status": 201,
+        "method": "GET",
+        "path": "/api/v2/roles/rol_ZjTN0eReZsvpoZRw/permissions?include_totals=true&page=0&per_page=100",
+        "body": "",
+        "status": 200,
         "response": {
-            "id": "4527e217-e35f-43e0-b09e-9b89156783f0",
-            "name": "My Custom Action",
-            "supported_triggers": [
-                {
-                    "id": "post-login",
-                    "version": "v2"
-                }
-            ],
-            "created_at": "2023-10-27T17:58:23.504387838Z",
-            "updated_at": "2023-10-27T17:58:23.527609242Z",
-            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-            "dependencies": [],
-            "runtime": "node16",
-            "status": "pending",
-            "secrets": [],
-            "all_changes_deployed": false
+            "permissions": [],
+            "start": 0,
+            "limit": 100,
+            "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/roles/rol_akyigjRpa1CNc2RA",
+        "body": {
+            "name": "Admin",
+            "description": "Can read and write things"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_akyigjRpa1CNc2RA",
+            "name": "Admin",
+            "description": "Can read and write things"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/roles/rol_BXNSxZlMD6p3fj8y",
+        "body": {
+            "name": "Reader",
+            "description": "Can only read things"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_BXNSxZlMD6p3fj8y",
+            "name": "Reader",
+            "description": "Can only read things"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/roles/rol_D8YUHJmpsX4Gxn7W",
+        "body": {
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_D8YUHJmpsX4Gxn7W",
+            "name": "read_only",
+            "description": "Read Only"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/roles/rol_ZjTN0eReZsvpoZRw",
+        "body": {
+            "name": "read_osnly",
+            "description": "Readz Only"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_ZjTN0eReZsvpoZRw",
+            "name": "read_osnly",
+            "description": "Readz Only"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4834,7 +5871,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "4527e217-e35f-43e0-b09e-9b89156783f0",
+                    "id": "e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4842,14 +5879,173 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:58:23.504387838Z",
-                    "updated_at": "2023-10-27T17:58:23.527609242Z",
+                    "created_at": "2023-12-22T14:45:43.350819427Z",
+                    "updated_at": "2023-12-22T14:45:43.371906693Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
-                    "all_changes_deployed": false
+                    "current_version": {
+                        "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node16",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2023-12-22T14:45:44.108234134Z",
+                        "created_at": "2023-12-22T14:45:44.002123868Z",
+                        "updated_at": "2023-12-22T14:45:44.109212689Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2023-12-22T14:45:44.108234134Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2023-12-22T14:45:44.002123868Z",
+                        "updated_at": "2023-12-22T14:45:44.109212689Z",
+                        "runtime": "node16",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/actions/actions/e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
+        "body": {
+            "name": "My Custom Action",
+            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+            "dependencies": [],
+            "runtime": "node16",
+            "secrets": [],
+            "supported_triggers": [
+                {
+                    "id": "post-login",
+                    "version": "v2"
+                }
+            ]
+        },
+        "status": 200,
+        "response": {
+            "id": "e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
+            "name": "My Custom Action",
+            "supported_triggers": [
+                {
+                    "id": "post-login",
+                    "version": "v2"
+                }
+            ],
+            "created_at": "2023-12-22T14:45:43.350819427Z",
+            "updated_at": "2023-12-22T14:46:00.070960661Z",
+            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+            "dependencies": [],
+            "runtime": "node16",
+            "status": "pending",
+            "secrets": [],
+            "current_version": {
+                "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                "runtime": "node16",
+                "status": "BUILT",
+                "number": 1,
+                "build_time": "2023-12-22T14:45:44.108234134Z",
+                "created_at": "2023-12-22T14:45:44.002123868Z",
+                "updated_at": "2023-12-22T14:45:44.109212689Z"
+            },
+            "deployed_version": {
+                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                "dependencies": [],
+                "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                "deployed": true,
+                "number": 1,
+                "built_at": "2023-12-22T14:45:44.108234134Z",
+                "secrets": [],
+                "status": "built",
+                "created_at": "2023-12-22T14:45:44.002123868Z",
+                "updated_at": "2023-12-22T14:45:44.109212689Z",
+                "runtime": "node16",
+                "supported_triggers": [
+                    {
+                        "id": "post-login",
+                        "version": "v2"
+                    }
+                ]
+            },
+            "all_changes_deployed": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2023-12-22T14:45:43.350819427Z",
+                    "updated_at": "2023-12-22T14:46:00.070960661Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node16",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node16",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2023-12-22T14:45:44.108234134Z",
+                        "created_at": "2023-12-22T14:45:44.002123868Z",
+                        "updated_at": "2023-12-22T14:45:44.109212689Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "a657fb2e-7560-4955-837c-a68bc9d17c1b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2023-12-22T14:45:44.108234134Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2023-12-22T14:45:44.002123868Z",
+                        "updated_at": "2023-12-22T14:45:44.109212689Z",
+                        "runtime": "node16",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
                 }
             ],
             "total": 1,
@@ -4861,19 +6057,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/4527e217-e35f-43e0-b09e-9b89156783f0/deploy",
+        "path": "/api/v2/actions/actions/e805e03c-f0a3-4915-9c55-5f5c3acf9a4a/deploy",
         "body": {},
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "aa09492f-33b0-4c1c-82cc-d52f70749fa7",
+            "id": "499c9883-f19b-4144-90aa-03f09d13273e",
             "deployed": false,
-            "number": 1,
+            "number": 2,
             "secrets": [],
             "status": "built",
-            "created_at": "2023-10-27T17:58:23.825684110Z",
-            "updated_at": "2023-10-27T17:58:23.825684110Z",
+            "created_at": "2023-12-22T14:46:00.330514258Z",
+            "updated_at": "2023-12-22T14:46:00.330514258Z",
             "runtime": "node16",
             "supported_triggers": [
                 {
@@ -4882,7 +6078,7 @@
                 }
             ],
             "action": {
-                "id": "4527e217-e35f-43e0-b09e-9b89156783f0",
+                "id": "e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -4890,8 +6086,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2023-10-27T17:58:23.504387838Z",
-                "updated_at": "2023-10-27T17:58:23.504387838Z",
+                "created_at": "2023-12-22T14:45:43.350819427Z",
+                "updated_at": "2023-12-22T14:46:00.044033047Z",
                 "all_changes_deployed": false
             }
         },
@@ -4905,10 +6101,27 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [],
+            "organizations": [
+                {
+                    "id": "org_X3jse0Pb1WGt3TwO",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    }
+                },
+                {
+                    "id": "org_SfCOLMvgKxL7kirf",
+                    "name": "org2",
+                    "display_name": "Organization2"
+                }
+            ],
             "start": 0,
             "limit": 50,
-            "total": 0
+            "total": 2
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4920,8 +6133,45 @@
         "body": "",
         "status": 200,
         "response": {
-            "organizations": []
+            "organizations": [
+                {
+                    "id": "org_X3jse0Pb1WGt3TwO",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    }
+                },
+                {
+                    "id": "org_SfCOLMvgKxL7kirf",
+                    "name": "org2",
+                    "display_name": "Organization2"
+                }
+            ]
         },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_X3jse0Pb1WGt3TwO/enabled_connections",
+        "body": "",
+        "status": 200,
+        "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_SfCOLMvgKxL7kirf/enabled_connections",
+        "body": "",
+        "status": 200,
+        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -4937,7 +6187,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_i71jW6OTkuVtMpGT",
+                    "id": "con_K5DvCabszfTqFX2a",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4954,6 +6204,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -4963,6 +6218,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -4980,12 +6243,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                        "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK"
+                        "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
                     ]
                 },
                 {
-                    "id": "con_WEXY9ZnXOS8DngUu",
+                    "id": "con_F6FupkR2JVv0xmQV",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5001,8 +6264,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
-                        "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61"
+                        "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
+                        "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN"
                     ]
                 }
             ]
@@ -5012,10 +6275,9 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
+        "method": "PATCH",
+        "path": "/api/v2/organizations/org_X3jse0Pb1WGt3TwO",
         "body": {
-            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
@@ -5024,34 +6286,33 @@
             },
             "display_name": "Organization"
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "name": "org1",
             "branding": {
                 "colors": {
                     "page_background": "#fff5f5",
                     "primary": "#57ddff"
                 }
             },
+            "id": "org_X3jse0Pb1WGt3TwO",
             "display_name": "Organization",
-            "id": "org_AvcDY3hlJsPXIrF6"
+            "name": "org1"
         },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
+        "method": "PATCH",
+        "path": "/api/v2/organizations/org_SfCOLMvgKxL7kirf",
         "body": {
-            "name": "org2",
             "display_name": "Organization2"
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "name": "org2",
+            "id": "org_SfCOLMvgKxL7kirf",
             "display_name": "Organization2",
-            "id": "org_6JCwlF8xQAPNoP8s"
+            "name": "org2"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5148,7 +6409,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -5169,7 +6431,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_Sjij7JPRIyGmTeHf",
+                    "id": "rul_lr4Xo8OyXNEz4R6v",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -5193,7 +6455,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_Sjij7JPRIyGmTeHf",
+                    "id": "rul_lr4Xo8OyXNEz4R6v",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -5208,7 +6470,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/rules/rul_Sjij7JPRIyGmTeHf",
+        "path": "/api/v2/rules/rul_lr4Xo8OyXNEz4R6v",
         "body": {},
         "status": 204,
         "response": "",
@@ -5883,6 +7145,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -5961,6 +7239,58 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Node App",
                     "allowed_clients": [],
                     "allowed_logout_urls": [],
@@ -5995,7 +7325,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+                    "client_id": "4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6043,99 +7373,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+                    "client_id": "bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6187,7 +7425,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+                    "client_id": "FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6201,6 +7439,46 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6246,7 +7524,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+                    "client_id": "WZycF991qhrOzwWsHmECCdnls0r14R8L",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6303,7 +7581,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+                    "client_id": "PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6327,7 +7605,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/AuMFvd4rZcROjl8gc8QjyXfifGUh0rJL",
+        "path": "/api/v2/clients/RISe90DMj8TYCqt0dX14Qp9Mh2JNqC1A",
         "body": {},
         "status": 204,
         "response": "",
@@ -6337,7 +7615,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/rIhtaYsBG8C2yk7yi4SloLiDwJN5h9KK",
+        "path": "/api/v2/clients/4MgHIXo0wZ7u90rrycMN8I11XmbbC0Ax",
         "body": {},
         "status": 204,
         "response": "",
@@ -6347,7 +7625,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/aIN78DlIth5F3iFxZF6BGdWFMst5Qsv5",
+        "path": "/api/v2/clients/bPI0YoW8tVuPzNv5pk3vSftlPbzT5UbM",
         "body": {},
         "status": 204,
         "response": "",
@@ -6357,7 +7635,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/0JvkloSYOQ58IJ7bfA5RhXJprbcmPhda",
+        "path": "/api/v2/clients/FRxIplFoWIhKqwDz5Qo3MvuJowBbsXxJ",
         "body": {},
         "status": 204,
         "response": "",
@@ -6367,7 +7645,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ShABsGq1S5Sbd8eva2qpG8PyeEn5VN61",
+        "path": "/api/v2/clients/LKpF9l0hv7A0v8UjXfFZ1zn2J7ZxVu3K",
         "body": {},
         "status": 204,
         "response": "",
@@ -6377,7 +7655,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ywRnwJqaVZf4a6ahFzEU8A7OBFLLfeGl",
+        "path": "/api/v2/clients/WZycF991qhrOzwWsHmECCdnls0r14R8L",
         "body": {},
         "status": 204,
         "response": "",
@@ -6387,7 +7665,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ODPXCHjP5ewgwaWIgoOAkfkrXoHCID4V",
+        "path": "/api/v2/clients/PFX8PjbMn07NXLHgVjr8aZaAEpupYtyN",
         "body": {},
         "status": 204,
         "response": "",
@@ -6457,7 +7735,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+            "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -6504,63 +7782,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -6588,6 +7824,20 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
@@ -6602,7 +7852,35 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -6663,6 +7941,101 @@
             "universal_login_experience": "new",
             "identifier_first": true
         },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/log-streams?paginate=false",
+        "body": "",
+        "status": 200,
+        "response": [
+            {
+                "id": "lst_0000000000015063",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000015064",
+                "name": "Amazon EventBridge",
+                "type": "eventbridge",
+                "status": "active",
+                "sink": {
+                    "awsAccountId": "123456789012",
+                    "awsRegion": "us-east-2",
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-ad7deb22-8b6e-4242-ba40-344f97b05739/auth0.logs"
+                },
+                "filters": [
+                    {
+                        "type": "category",
+                        "name": "auth.login.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.notification"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.signup.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.token_exchange.fail"
+                    }
+                ]
+            }
+        ],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -6740,103 +8113,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/log-streams?paginate=false",
-        "body": "",
-        "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000013776",
-                "name": "Suspended DD Log Stream",
-                "type": "datadog",
-                "status": "active",
-                "sink": {
-                    "datadogApiKey": "some-sensitive-api-key",
-                    "datadogRegion": "us"
-                }
-            },
-            {
-                "id": "lst_0000000000013777",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-79a58600-ea32-48ae-bd81-e289c20ed37f/auth0.logs"
-                },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ]
-            }
-        ],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000013776",
+        "path": "/api/v2/log-streams/lst_0000000000015063",
         "body": {},
         "status": 204,
         "response": "",
@@ -6846,7 +8124,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000013777",
+        "path": "/api/v2/log-streams/lst_0000000000015064",
         "body": {},
         "status": 204,
         "response": "",
@@ -6930,7 +8208,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6995,7 +8273,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_i71jW6OTkuVtMpGT",
+                    "id": "con_K5DvCabszfTqFX2a",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7012,6 +8290,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -7021,6 +8304,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -7056,7 +8347,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_i71jW6OTkuVtMpGT",
+                    "id": "con_K5DvCabszfTqFX2a",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7073,6 +8364,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -7082,6 +8378,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -7108,11 +8412,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_i71jW6OTkuVtMpGT",
+        "path": "/api/v2/connections/con_K5DvCabszfTqFX2a",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2023-10-27T17:58:32.226Z"
+            "deleted_at": "2023-12-22T14:46:11.010Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7126,7 +8430,7 @@
             "strategy": "auth0",
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD"
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "is_domain_connection": false,
             "options": {
@@ -7144,7 +8448,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_jqlYBGj0EXGWWwDq",
+            "id": "con_eSHGfDptLUMkQdaq",
             "options": {
                 "mfa": {
                     "active": true,
@@ -7152,14 +8456,27 @@
                 },
                 "passwordPolicy": "good",
                 "strategy_version": 2,
-                "brute_force_protection": true
+                "brute_force_protection": true,
+                "authentication_methods": {
+                    "password": {
+                        "enabled": true
+                    },
+                    "passkey": {
+                        "enabled": false
+                    }
+                },
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "progressive_enrollment_enabled": true,
+                    "local_enrollment_enabled": true
+                }
             },
             "strategy": "auth0",
             "name": "Username-Password-Authentication",
             "is_domain_connection": false,
             "enabled_clients": [
-                "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -7245,7 +8562,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7310,7 +8627,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_WEXY9ZnXOS8DngUu",
+                    "id": "con_F6FupkR2JVv0xmQV",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7328,14 +8645,27 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -7345,8 +8675,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -7366,7 +8696,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_WEXY9ZnXOS8DngUu",
+                    "id": "con_F6FupkR2JVv0xmQV",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7384,14 +8714,27 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -7401,8 +8744,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -7413,11 +8756,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_WEXY9ZnXOS8DngUu",
+        "path": "/api/v2/connections/con_F6FupkR2JVv0xmQV",
         "body": {},
         "status": 202,
         "response": {
-            "deleted_at": "2023-10-27T17:58:32.981Z"
+            "deleted_at": "2023-12-22T14:46:11.672Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7499,7 +8842,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7564,7 +8907,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -7742,22 +9085,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_VFV74oRWWXdG425f",
+                    "id": "rol_akyigjRpa1CNc2RA",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_GYGhQHbigkWhaDGp",
+                    "id": "rol_BXNSxZlMD6p3fj8y",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_fuGysc36ODvKYBtX",
+                    "id": "rol_D8YUHJmpsX4Gxn7W",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_Y0tWSxZo0gb0Lpjn",
+                    "id": "rol_ZjTN0eReZsvpoZRw",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -7772,7 +9115,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_VFV74oRWWXdG425f/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_akyigjRpa1CNc2RA/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7787,7 +9130,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_GYGhQHbigkWhaDGp/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_BXNSxZlMD6p3fj8y/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7802,7 +9145,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_fuGysc36ODvKYBtX/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_D8YUHJmpsX4Gxn7W/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7817,7 +9160,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_Y0tWSxZo0gb0Lpjn/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_ZjTN0eReZsvpoZRw/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -7832,7 +9175,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_VFV74oRWWXdG425f",
+        "path": "/api/v2/roles/rol_akyigjRpa1CNc2RA",
         "body": {},
         "status": 200,
         "response": {},
@@ -7842,7 +9185,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_GYGhQHbigkWhaDGp",
+        "path": "/api/v2/roles/rol_BXNSxZlMD6p3fj8y",
         "body": {},
         "status": 200,
         "response": {},
@@ -7852,7 +9195,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_fuGysc36ODvKYBtX",
+        "path": "/api/v2/roles/rol_D8YUHJmpsX4Gxn7W",
         "body": {},
         "status": 200,
         "response": {},
@@ -7862,7 +9205,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_Y0tWSxZo0gb0Lpjn",
+        "path": "/api/v2/roles/rol_ZjTN0eReZsvpoZRw",
         "body": {},
         "status": 200,
         "response": {},
@@ -7878,7 +9221,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "4527e217-e35f-43e0-b09e-9b89156783f0",
+                    "id": "e805e03c-f0a3-4915-9c55-5f5c3acf9a4a",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -7886,34 +9229,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:58:23.504387838Z",
-                    "updated_at": "2023-10-27T17:58:23.527609242Z",
+                    "created_at": "2023-12-22T14:45:43.350819427Z",
+                    "updated_at": "2023-12-22T14:46:00.070960661Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "aa09492f-33b0-4c1c-82cc-d52f70749fa7",
+                        "id": "499c9883-f19b-4144-90aa-03f09d13273e",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2023-10-27T17:58:23.993986433Z",
-                        "created_at": "2023-10-27T17:58:23.825684110Z",
-                        "updated_at": "2023-10-27T17:58:23.994943778Z"
+                        "number": 2,
+                        "build_time": "2023-12-22T14:46:00.414694589Z",
+                        "created_at": "2023-12-22T14:46:00.330514258Z",
+                        "updated_at": "2023-12-22T14:46:00.415386737Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "aa09492f-33b0-4c1c-82cc-d52f70749fa7",
+                        "id": "499c9883-f19b-4144-90aa-03f09d13273e",
                         "deployed": true,
-                        "number": 1,
-                        "built_at": "2023-10-27T17:58:23.993986433Z",
+                        "number": 2,
+                        "built_at": "2023-12-22T14:46:00.414694589Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2023-10-27T17:58:23.825684110Z",
-                        "updated_at": "2023-10-27T17:58:23.994943778Z",
+                        "created_at": "2023-12-22T14:46:00.330514258Z",
+                        "updated_at": "2023-12-22T14:46:00.415386737Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -7934,7 +9277,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/4527e217-e35f-43e0-b09e-9b89156783f0?force=true",
+        "path": "/api/v2/actions/actions/e805e03c-f0a3-4915-9c55-5f5c3acf9a4a?force=true",
         "body": {},
         "status": 204,
         "response": "",
@@ -7963,7 +9306,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_AvcDY3hlJsPXIrF6",
+                    "id": "org_X3jse0Pb1WGt3TwO",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -7974,7 +9317,7 @@
                     }
                 },
                 {
-                    "id": "org_6JCwlF8xQAPNoP8s",
+                    "id": "org_SfCOLMvgKxL7kirf",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -7995,7 +9338,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_AvcDY3hlJsPXIrF6",
+                    "id": "org_X3jse0Pb1WGt3TwO",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -8006,7 +9349,7 @@
                     }
                 },
                 {
-                    "id": "org_6JCwlF8xQAPNoP8s",
+                    "id": "org_SfCOLMvgKxL7kirf",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -8018,7 +9361,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_AvcDY3hlJsPXIrF6/enabled_connections",
+        "path": "/api/v2/organizations/org_X3jse0Pb1WGt3TwO/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -8028,7 +9371,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_6JCwlF8xQAPNoP8s/enabled_connections",
+        "path": "/api/v2/organizations/org_SfCOLMvgKxL7kirf/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -8047,14 +9390,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -8064,8 +9420,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -8076,7 +9432,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_AvcDY3hlJsPXIrF6",
+        "path": "/api/v2/organizations/org_SfCOLMvgKxL7kirf",
         "body": {},
         "status": 204,
         "response": "",
@@ -8086,7 +9442,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_6JCwlF8xQAPNoP8s",
+        "path": "/api/v2/organizations/org_X3jse0Pb1WGt3TwO",
         "body": {},
         "status": 204,
         "response": "",
@@ -8160,7 +9516,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -8966,6 +10323,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -9066,7 +10439,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9099,14 +10472,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -9116,8 +10502,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -9137,14 +10523,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -9154,8 +10553,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -9252,7 +10651,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -9282,7 +10696,86 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -9330,100 +10823,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/client-grants?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -9433,7 +10832,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -9853,6 +11252,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/login/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
@@ -9864,16 +11273,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9933,7 +11332,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9943,7 +11342,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9963,7 +11362,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -9973,7 +11372,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -10004,6 +11403,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/mfa-email/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -10044,16 +11453,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -10137,22 +11536,11 @@
             "triggers": [
                 {
                     "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12"
-                    ],
-                    "default_runtime": "node12",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v2",
                     "status": "DEPRECATED",
                     "runtimes": [
                         "node12",
-                        "node16",
-                        "node18"
+                        "node16"
                     ],
                     "default_runtime": "node16",
                     "compatible_triggers": []
@@ -10164,7 +11552,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -10176,6 +11563,16 @@
                     ]
                 },
                 {
+                    "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12"
+                    ],
+                    "default_runtime": "node12",
+                    "compatible_triggers": []
+                },
+                {
                     "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -10192,7 +11589,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -10215,20 +11611,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
-                        "node18-actions"
-                    ],
-                    "default_runtime": "node18-actions",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -10245,13 +11627,12 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-change-password",
+                    "id": "post-user-registration",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -10265,6 +11646,18 @@
                         "node12"
                     ],
                     "default_runtime": "node12",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-change-password",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16",
+                        "node18-actions"
+                    ],
+                    "default_runtime": "node18-actions",
                     "compatible_triggers": []
                 },
                 {
@@ -10283,7 +11676,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -10295,10 +11687,17 @@
                     "status": "CURRENT",
                     "runtimes": [
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "login-post-identifier",
+                    "version": "v1",
+                    "status": "CURRENT",
+                    "default_runtime": "node18",
+                    "runtimes": [],
                     "compatible_triggers": []
                 }
             ]
@@ -10400,6 +11799,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/triggers/login-post-identifier/bindings",
+        "body": "",
+        "status": 200,
+        "response": {
+            "bindings": [],
+            "per_page": 20
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/organizations?include_totals=true",
         "body": "",
         "status": 200,
@@ -10420,25 +11832,6 @@
         "status": 200,
         "response": {
             "organizations": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10486,6 +11879,25 @@
                     "rate": 1200
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false

--- a/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
+++ b/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
@@ -42,7 +42,7 @@
         },
         "status": 201,
         "response": {
-            "id": "rul_C7jutXH10zOIrWjD",
+            "id": "rul_wSNZtfFVlghPXbCh",
             "enabled": true,
             "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
             "name": "my-rule",
@@ -247,7 +247,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -894,6 +895,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -994,7 +1011,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1011,6 +1028,192 @@
                     "custom_login_page_on": true
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Quickstarts API (Test Application)",
+            "app_type": "non_interactive",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -1106,7 +1309,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+            "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1124,480 +1327,6 @@
                 "client_credentials"
             ],
             "web_origins": [],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Quickstarts API (Test Application)",
-            "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "auth0-deploy-cli-extension",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_auth": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
             "custom_login_page_on": true
         },
         "rawHeaders": [],
@@ -1701,7 +1430,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+            "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1719,6 +1448,294 @@
             ],
             "web_origins": [
                 "http://localhost:3000"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "auth0-deploy-cli-extension",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_auth": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
             ],
             "custom_login_page_on": true
         },
@@ -1765,7 +1782,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -1793,7 +1810,49 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": true
+        },
+        "status": 200,
+        "response": {
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -1822,48 +1881,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/duo",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -1934,36 +1951,39 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/log-streams?paginate=false",
-        "body": "",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 66
+        },
         "status": 200,
-        "response": [],
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 66
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
+        "method": "GET",
+        "path": "/api/v2/log-streams?paginate=false",
+        "body": "",
         "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                }
-            }
-        },
+        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -2016,27 +2036,24 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
+        "path": "/api/v2/attack-protection/breached-password-detection",
         "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 66
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
         },
         "status": 200,
         "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 66
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2055,7 +2072,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000013778",
+            "id": "lst_0000000000015065",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -2119,14 +2136,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000013779",
+            "id": "lst_0000000000015066",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-0da0aa0b-670c-4088-9b45-b5f59405aade/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-a0d29214-9e3a-4756-ad63-145ad18d8001/auth0.logs"
             },
             "filters": [
                 {
@@ -2247,7 +2264,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2259,6 +2276,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2291,7 +2360,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2344,7 +2413,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2368,20 +2437,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -2400,7 +2458,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2408,7 +2466,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -2453,7 +2510,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2467,46 +2524,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2552,7 +2569,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2609,7 +2626,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2674,14 +2691,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -2691,8 +2721,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -2712,14 +2742,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -2729,8 +2772,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -2746,8 +2789,8 @@
             "name": "boo-baz-db-connection-test",
             "strategy": "auth0",
             "enabled_clients": [
-                "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
-                "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU"
+                "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
+                "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D"
             ],
             "is_domain_connection": false,
             "options": {
@@ -2791,7 +2834,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_N4wxJ8dAAKN5aAbi",
+            "id": "con_qtM6Tit8tl0FMG0U",
             "options": {
                 "mfa": {
                     "active": true,
@@ -2825,14 +2868,27 @@
                 "password_complexity_options": {
                     "min_length": 8
                 },
-                "enabledDatabaseCustomization": true
+                "enabledDatabaseCustomization": true,
+                "authentication_methods": {
+                    "password": {
+                        "enabled": true
+                    },
+                    "passkey": {
+                        "enabled": false
+                    }
+                },
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "progressive_enrollment_enabled": true,
+                    "local_enrollment_enabled": true
+                }
             },
             "strategy": "auth0",
             "name": "boo-baz-db-connection-test",
             "is_domain_connection": false,
             "enabled_clients": [
-                "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -2918,7 +2974,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2930,6 +2986,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2962,7 +3070,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3015,7 +3123,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3039,20 +3147,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -3071,7 +3168,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3079,7 +3176,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -3124,7 +3220,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3138,46 +3234,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3223,7 +3279,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3280,7 +3336,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3345,7 +3401,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3362,6 +3418,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -3371,6 +3432,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -3388,19 +3457,32 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -3410,8 +3492,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -3431,7 +3513,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3448,6 +3530,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -3457,6 +3544,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -3474,19 +3569,32 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -3496,8 +3604,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -3513,8 +3621,8 @@
             "name": "google-oauth2",
             "strategy": "google-oauth2",
             "enabled_clients": [
-                "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
-                "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU"
+                "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
+                "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D"
             ],
             "is_domain_connection": false,
             "options": {
@@ -3528,7 +3636,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_qXhJkhSirvwvOHpc",
+            "id": "con_5GrbjeMQ0PbSYHPc",
             "options": {
                 "email": true,
                 "scope": [
@@ -3541,8 +3649,8 @@
             "name": "google-oauth2",
             "is_domain_connection": false,
             "enabled_clients": [
-                "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
             ],
             "realms": [
                 "google-oauth2"
@@ -3682,7 +3790,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3694,6 +3802,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3726,7 +3886,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3779,7 +3939,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3803,20 +3963,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -3835,7 +3984,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3843,7 +3992,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -3888,7 +4036,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3902,46 +4050,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3987,7 +4095,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4044,7 +4152,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4109,7 +4217,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -4283,7 +4391,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
+            "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4420,8 +4528,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_saPqZnrza0C1gDas",
-            "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
+            "id": "cgr_WrFlRGbdZ6AbrsLZ",
+            "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4564,7 +4672,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+            "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4701,8 +4809,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_Aa6SaHhfwHIMZctB",
-            "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+            "id": "cgr_2zq7mVXA87scv9MN",
+            "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -4865,7 +4973,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_wCNt1OJGjx5XM8xo",
+            "id": "rol_rdIzOQupZMdQ7JAJ",
             "name": "Admin",
             "description": "Can read and write things"
         },
@@ -4882,7 +4990,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_WO708ZFi8mkRKQDQ",
+            "id": "rol_wvQhvLwCJ5rGOqvW",
             "name": "Reader",
             "description": "Can only read things"
         },
@@ -4899,7 +5007,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_IDZdN2XbY72UAlNg",
+            "id": "rol_Mubp0xpYSP1f7JyM",
             "name": "read_only",
             "description": "Read Only"
         },
@@ -4916,7 +5024,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_6hr4gXp3Hn5l13B6",
+            "id": "rol_x9WzmRo0VhIA1UoP",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -4955,7 +5063,7 @@
         },
         "status": 201,
         "response": {
-            "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+            "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -4963,8 +5071,8 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2023-10-27T17:59:29.019781220Z",
-            "updated_at": "2023-10-27T17:59:29.029582969Z",
+            "created_at": "2023-12-22T14:51:47.252041680Z",
+            "updated_at": "2023-12-22T14:51:47.290735734Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node16",
@@ -4984,7 +5092,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+                    "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4992,8 +5100,8 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:59:29.019781220Z",
-                    "updated_at": "2023-10-27T17:59:29.029582969Z",
+                    "created_at": "2023-12-22T14:51:47.252041680Z",
+                    "updated_at": "2023-12-22T14:51:47.290735734Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
@@ -5011,19 +5119,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/cd2e3be4-4860-48e2-b94e-bd655b137f17/deploy",
+        "path": "/api/v2/actions/actions/8f0c40cf-653b-4705-9381-3479c0ed03c2/deploy",
         "body": {},
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+            "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
             "deployed": false,
             "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2023-10-27T17:59:29.317291Z",
-            "updated_at": "2023-10-27T17:59:29.317291Z",
+            "created_at": "2023-12-22T14:51:47.533727461Z",
+            "updated_at": "2023-12-22T14:51:47.533727461Z",
             "runtime": "node16",
             "supported_triggers": [
                 {
@@ -5032,7 +5140,7 @@
                 }
             ],
             "action": {
-                "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+                "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -5040,8 +5148,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2023-10-27T17:59:29.019781220Z",
-                "updated_at": "2023-10-27T17:59:29.019781220Z",
+                "created_at": "2023-12-22T14:51:47.252041680Z",
+                "updated_at": "2023-12-22T14:51:47.252041680Z",
                 "all_changes_deployed": false
             }
         },
@@ -5087,7 +5195,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5104,6 +5212,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -5113,6 +5226,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -5130,12 +5251,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_qXhJkhSirvwvOHpc",
+                    "id": "con_5GrbjeMQ0PbSYHPc",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5151,19 +5272,32 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -5173,8 +5307,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -5206,7 +5340,7 @@
                 }
             },
             "display_name": "Organization",
-            "id": "org_KGHEhn16DHYitg8j"
+            "id": "org_w77D4ZISPOWL3v9R"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5223,7 +5357,7 @@
         "response": {
             "name": "org2",
             "display_name": "Organization2",
-            "id": "org_oGfwJLbdRss0aiIU"
+            "id": "org_wyehRBjAkFeGeYib"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5320,7 +5454,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -5341,7 +5476,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_C7jutXH10zOIrWjD",
+                    "id": "rul_wSNZtfFVlghPXbCh",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -5365,7 +5500,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_C7jutXH10zOIrWjD",
+                    "id": "rul_wSNZtfFVlghPXbCh",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -6045,6 +6180,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -6145,7 +6296,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6157,6 +6308,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6189,7 +6392,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6242,7 +6445,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6266,20 +6469,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -6298,7 +6490,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6306,7 +6498,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -6351,7 +6542,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6365,46 +6556,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6450,7 +6601,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6507,7 +6658,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6531,7 +6682,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+        "path": "/api/v2/clients/xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -6588,7 +6739,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+            "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -6625,21 +6776,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -6667,7 +6804,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -6681,7 +6818,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -6723,7 +6874,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -6789,6 +6940,101 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/log-streams?paginate=false",
+        "body": "",
+        "status": 200,
+        "response": [
+            {
+                "id": "lst_0000000000015065",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000015066",
+                "name": "Amazon EventBridge",
+                "type": "eventbridge",
+                "status": "active",
+                "sink": {
+                    "awsAccountId": "123456789012",
+                    "awsRegion": "us-east-2",
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-a0d29214-9e3a-4756-ad63-145ad18d8001/auth0.logs"
+                },
+                "filters": [
+                    {
+                        "type": "category",
+                        "name": "auth.login.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.notification"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.login.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.signup.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.logout.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.fail"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.silent_auth.success"
+                    },
+                    {
+                        "type": "category",
+                        "name": "auth.token_exchange.fail"
+                    }
+                ]
+            }
+        ],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
@@ -6834,94 +7080,603 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/log-streams?paginate=false",
+        "path": "/api/v2/clients?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000013779",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-0da0aa0b-670c-4088-9b45-b5f59405aade/auth0.logs"
+        "response": {
+            "total": 10,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
                     },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ]
-            },
-            {
-                "id": "lst_0000000000013778",
-                "name": "Suspended DD Log Stream",
-                "type": "datadog",
-                "status": "active",
-                "sink": {
-                    "datadogApiKey": "some-sensitive-api-key",
-                    "datadogRegion": "us"
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
                 }
-            }
-        ],
+            ]
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
+        "method": "GET",
+        "path": "/api/v2/connections?strategy=auth0&include_totals=true&page=0&per_page=100",
+        "body": "",
         "status": 200,
         "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
+            "total": 2,
+            "start": 0,
+            "limit": 100,
+            "connections": [
+                {
+                    "id": "con_qtM6Tit8tl0FMG0U",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": [
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
+                    ]
+                },
+                {
+                    "id": "con_eSHGfDptLUMkQdaq",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
+                        "brute_force_protection": true
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
+                    ]
                 }
-            }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6957,498 +7712,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients?include_totals=true&page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 10,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/connections?strategy=auth0&include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -7458,7 +7721,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7475,6 +7738,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -7484,6 +7752,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -7501,19 +7777,32 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -7523,8 +7812,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -7535,112 +7824,39 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?strategy=auth0&include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/connections/con_eSHGfDptLUMkQdaq",
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
-            "start": 0,
-            "limit": 100,
-            "connections": [
-                {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
-                    ]
-                },
-                {
-                    "id": "con_jqlYBGj0EXGWWwDq",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "strategy_version": 2,
-                        "brute_force_protection": true
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_jqlYBGj0EXGWWwDq",
-        "body": "",
-        "status": 200,
-        "response": {
-            "id": "con_jqlYBGj0EXGWWwDq",
+            "id": "con_eSHGfDptLUMkQdaq",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
             "name": "Username-Password-Authentication",
             "is_domain_connection": false,
             "enabled_clients": [
-                "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -7652,11 +7868,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_jqlYBGj0EXGWWwDq",
+        "path": "/api/v2/connections/con_eSHGfDptLUMkQdaq",
         "body": {
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD"
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "is_domain_connection": false,
             "options": {
@@ -7665,7 +7881,20 @@
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "realms": [
@@ -7674,14 +7903,27 @@
         },
         "status": 200,
         "response": {
-            "id": "con_jqlYBGj0EXGWWwDq",
+            "id": "con_eSHGfDptLUMkQdaq",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
@@ -7689,7 +7931,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD"
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -7775,7 +8017,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7787,6 +8029,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -7819,7 +8113,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7872,7 +8166,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7896,20 +8190,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -7928,7 +8211,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7936,7 +8219,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -7981,7 +8263,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7995,46 +8277,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8080,7 +8322,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8137,7 +8379,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8202,7 +8444,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8219,6 +8461,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -8228,6 +8475,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -8245,12 +8500,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_qXhJkhSirvwvOHpc",
+                    "id": "con_5GrbjeMQ0PbSYHPc",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8266,19 +8521,32 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -8288,8 +8556,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -8309,7 +8577,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8326,6 +8594,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -8335,6 +8608,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -8352,12 +8633,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_qXhJkhSirvwvOHpc",
+                    "id": "con_5GrbjeMQ0PbSYHPc",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8373,19 +8654,32 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -8395,8 +8689,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -8481,7 +8775,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8493,6 +8787,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8525,7 +8871,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8578,7 +8924,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8602,20 +8948,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8634,7 +8969,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8642,7 +8977,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8687,7 +9021,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8701,46 +9035,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8786,7 +9080,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8843,7 +9137,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8908,8 +9202,8 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Aa6SaHhfwHIMZctB",
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "id": "cgr_2zq7mVXA87scv9MN",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -9045,7 +9339,144 @@
                     ]
                 },
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_WrFlRGbdZ6AbrsLZ",
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
+                {
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -9208,143 +9639,6 @@
                         "update:client_credentials",
                         "delete:client_credentials"
                     ]
-                },
-                {
-                    "id": "cgr_saPqZnrza0C1gDas",
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
                 }
             ]
         },
@@ -9360,22 +9654,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_wCNt1OJGjx5XM8xo",
+                    "id": "rol_rdIzOQupZMdQ7JAJ",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_WO708ZFi8mkRKQDQ",
+                    "id": "rol_wvQhvLwCJ5rGOqvW",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_IDZdN2XbY72UAlNg",
+                    "id": "rol_Mubp0xpYSP1f7JyM",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_6hr4gXp3Hn5l13B6",
+                    "id": "rol_x9WzmRo0VhIA1UoP",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -9390,7 +9684,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_wCNt1OJGjx5XM8xo/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_rdIzOQupZMdQ7JAJ/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -9405,7 +9699,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_WO708ZFi8mkRKQDQ/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_wvQhvLwCJ5rGOqvW/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -9420,7 +9714,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_IDZdN2XbY72UAlNg/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_Mubp0xpYSP1f7JyM/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -9435,7 +9729,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_6hr4gXp3Hn5l13B6/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_x9WzmRo0VhIA1UoP/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -9456,7 +9750,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+                    "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -9464,34 +9758,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:59:29.019781220Z",
-                    "updated_at": "2023-10-27T17:59:29.029582969Z",
+                    "created_at": "2023-12-22T14:51:47.252041680Z",
+                    "updated_at": "2023-12-22T14:51:47.290735734Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2023-10-27T17:59:29.414649344Z",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z"
+                        "build_time": "2023-12-22T14:51:47.619418918Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2023-10-27T17:59:29.414649344Z",
+                        "built_at": "2023-12-22T14:51:47.619418918Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -9518,7 +9812,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+                    "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -9526,34 +9820,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:59:29.019781220Z",
-                    "updated_at": "2023-10-27T17:59:29.029582969Z",
+                    "created_at": "2023-12-22T14:51:47.252041680Z",
+                    "updated_at": "2023-12-22T14:51:47.290735734Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2023-10-27T17:59:29.414649344Z",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z"
+                        "build_time": "2023-12-22T14:51:47.619418918Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2023-10-27T17:59:29.414649344Z",
+                        "built_at": "2023-12-22T14:51:47.619418918Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -9580,7 +9874,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_KGHEhn16DHYitg8j",
+                    "id": "org_w77D4ZISPOWL3v9R",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -9591,7 +9885,7 @@
                     }
                 },
                 {
-                    "id": "org_oGfwJLbdRss0aiIU",
+                    "id": "org_wyehRBjAkFeGeYib",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -9612,7 +9906,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_KGHEhn16DHYitg8j",
+                    "id": "org_w77D4ZISPOWL3v9R",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -9623,7 +9917,7 @@
                     }
                 },
                 {
-                    "id": "org_oGfwJLbdRss0aiIU",
+                    "id": "org_wyehRBjAkFeGeYib",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -9635,7 +9929,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KGHEhn16DHYitg8j/enabled_connections",
+        "path": "/api/v2/organizations/org_w77D4ZISPOWL3v9R/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -9645,7 +9939,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_oGfwJLbdRss0aiIU/enabled_connections",
+        "path": "/api/v2/organizations/org_wyehRBjAkFeGeYib/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -9664,7 +9958,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -9681,6 +9975,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -9690,6 +9989,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -9707,12 +10014,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_qXhJkhSirvwvOHpc",
+                    "id": "con_5GrbjeMQ0PbSYHPc",
                     "options": {
                         "email": true,
                         "scope": [
@@ -9728,19 +10035,32 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -9750,8 +10070,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -9826,7 +10146,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -9847,7 +10168,7 @@
             "limit": 100,
             "rules": [
                 {
-                    "id": "rul_C7jutXH10zOIrWjD",
+                    "id": "rul_wSNZtfFVlghPXbCh",
                     "enabled": true,
                     "script": "function (user, context, callback) {\n  callback(null, user, context);\n}\n",
                     "name": "my-rule",
@@ -10641,6 +10962,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -10741,7 +11078,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10753,6 +11090,58 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -10785,7 +11174,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "aiCLMsJhaiAU5AQF6ivtGhOgX5kdVrew",
+                    "client_id": "5i1LKZRN9jQzCsQrmW2ESUt68nkGFMKA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10838,7 +11227,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i",
+                    "client_id": "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10862,20 +11251,9 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Terraform Provider",
                     "cross_origin_auth": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -10894,7 +11272,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10902,7 +11280,6 @@
                         "lifetime_in_seconds": 36000,
                         "secret_encoded": false
                     },
-                    "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -10947,7 +11324,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK",
+                    "client_id": "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10961,46 +11338,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11046,7 +11383,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IkrAr3QznUL7J5YBXjNabFo1R5En7Vth",
+                    "client_id": "G6vSeNYLDhpWWwEIxMjiaFwVVjAgI6aZ",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11103,7 +11440,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
+                    "client_id": "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11136,7 +11473,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -11153,6 +11490,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -11162,6 +11504,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -11179,19 +11529,32 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -11201,8 +11564,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -11222,7 +11585,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_N4wxJ8dAAKN5aAbi",
+                    "id": "con_qtM6Tit8tl0FMG0U",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -11239,6 +11602,11 @@
                         },
                         "disable_signup": false,
                         "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "password_history": {
                             "size": 5,
                             "enable": false
@@ -11248,6 +11616,14 @@
                         "password_dictionary": {
                             "enable": true,
                             "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
                         },
                         "brute_force_protection": true,
                         "password_no_personal_info": {
@@ -11265,12 +11641,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "XU3HEdULg0LbN6de15xJ7IJXlN8yzc2i"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "xWWNesHlqi9LIJ7lyi0ck3hJRbNvqyXT"
                     ]
                 },
                 {
-                    "id": "con_qXhJkhSirvwvOHpc",
+                    "id": "con_5GrbjeMQ0PbSYHPc",
                     "options": {
                         "email": true,
                         "scope": [
@@ -11286,19 +11662,32 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "4MrfAJP6yC2ZwoTZoc7iSeNrf02CFUSU",
-                        "6O6nqtWY3q8ZeCsWotJCX6aQkFEv2owK"
+                        "3QDtbJP8aTej8tDtPs3sOFdQyCyT0x8D",
+                        "MllkXGZYbvCEeB19PsrCEH6r7gQICBEQ"
                     ]
                 },
                 {
-                    "id": "con_jqlYBGj0EXGWWwDq",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -11308,8 +11697,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "HbMrMJdzWweU8OT06lnGlw6kOvsegmJD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -11424,37 +11813,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -11488,67 +11862,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -11578,6 +11892,81 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/client-grants?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -11587,8 +11976,8 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Aa6SaHhfwHIMZctB",
-                    "client_id": "C7rgq9izKWOshVEWDXXN6b4U9kO2pG4I",
+                    "id": "cgr_2zq7mVXA87scv9MN",
+                    "client_id": "eGfUEoW6KgKKBY7tVRG26SNMfOSDOW0e",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -11724,7 +12113,144 @@
                     ]
                 },
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_WrFlRGbdZ6AbrsLZ",
+                    "client_id": "0itJPHYpEe5IeQBicfvZiwe4lhiZxts9",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ]
+                },
+                {
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -11887,143 +12413,6 @@
                         "update:client_credentials",
                         "delete:client_credentials"
                     ]
-                },
-                {
-                    "id": "cgr_saPqZnrza0C1gDas",
-                    "client_id": "hDDRxPqUrBYtyNqiQ8frHkBmIE9YI2Wm",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ]
                 }
             ]
         },
@@ -12162,22 +12551,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_wCNt1OJGjx5XM8xo",
+                    "id": "rol_rdIzOQupZMdQ7JAJ",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_WO708ZFi8mkRKQDQ",
+                    "id": "rol_wvQhvLwCJ5rGOqvW",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_IDZdN2XbY72UAlNg",
+                    "id": "rol_Mubp0xpYSP1f7JyM",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_6hr4gXp3Hn5l13B6",
+                    "id": "rol_x9WzmRo0VhIA1UoP",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -12192,7 +12581,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_wCNt1OJGjx5XM8xo/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_rdIzOQupZMdQ7JAJ/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12207,7 +12596,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_WO708ZFi8mkRKQDQ/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_wvQhvLwCJ5rGOqvW/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12222,7 +12611,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_IDZdN2XbY72UAlNg/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_Mubp0xpYSP1f7JyM/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12237,7 +12626,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_6hr4gXp3Hn5l13B6/permissions?include_totals=true&page=0&per_page=100",
+        "path": "/api/v2/roles/rol_x9WzmRo0VhIA1UoP/permissions?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
@@ -12362,16 +12751,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
@@ -12383,6 +12762,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -12442,7 +12831,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/consent/custom-text/en",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -12462,7 +12851,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "path": "/api/v2/prompts/consent/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -12552,7 +12941,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -12562,7 +12951,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -12632,7 +13021,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "cd2e3be4-4860-48e2-b94e-bd655b137f17",
+                    "id": "8f0c40cf-653b-4705-9381-3479c0ed03c2",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -12640,34 +13029,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2023-10-27T17:59:29.019781220Z",
-                    "updated_at": "2023-10-27T17:59:29.029582969Z",
+                    "created_at": "2023-12-22T14:51:47.252041680Z",
+                    "updated_at": "2023-12-22T14:51:47.290735734Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node16",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node16",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2023-10-27T17:59:29.414649344Z",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z"
+                        "build_time": "2023-12-22T14:51:47.619418918Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "4fb88542-f3f6-4ded-bf87-fed2d7275f46",
+                        "id": "cd0e4435-4242-43ed-9441-dee1cb701b27",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2023-10-27T17:59:29.414649344Z",
+                        "built_at": "2023-12-22T14:51:47.619418918Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2023-10-27T17:59:29.317291Z",
-                        "updated_at": "2023-10-27T17:59:29.416228236Z",
+                        "created_at": "2023-12-22T14:51:47.533727461Z",
+                        "updated_at": "2023-12-22T14:51:47.620010749Z",
                         "runtime": "node16",
                         "supported_triggers": [
                             {
@@ -12700,7 +13089,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -12713,27 +13101,26 @@
                 },
                 {
                     "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12"
+                    ],
+                    "default_runtime": "node12",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v2",
                     "status": "DEPRECATED",
                     "runtimes": [
                         "node12",
-                        "node16",
-                        "node18"
+                        "node16"
                     ],
                     "default_runtime": "node16",
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12"
-                    ],
-                    "default_runtime": "node12",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -12750,7 +13137,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -12773,20 +13159,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
-                        "node18-actions"
-                    ],
-                    "default_runtime": "node18-actions",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -12800,6 +13172,18 @@
                         "node12"
                     ],
                     "default_runtime": "node12",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-user-registration",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16",
+                        "node18-actions"
+                    ],
+                    "default_runtime": "node18-actions",
                     "compatible_triggers": []
                 },
                 {
@@ -12819,7 +13203,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -12841,7 +13224,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -12853,10 +13235,17 @@
                     "status": "CURRENT",
                     "runtimes": [
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "login-post-identifier",
+                    "version": "v1",
+                    "status": "CURRENT",
+                    "default_runtime": "node18",
+                    "runtimes": [],
                     "compatible_triggers": []
                 }
             ]
@@ -12958,13 +13347,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/triggers/login-post-identifier/bindings",
+        "body": "",
+        "status": 200,
+        "response": {
+            "bindings": [],
+            "per_page": 20
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/organizations?include_totals=true",
         "body": "",
         "status": 200,
         "response": {
             "organizations": [
                 {
-                    "id": "org_KGHEhn16DHYitg8j",
+                    "id": "org_w77D4ZISPOWL3v9R",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -12975,7 +13377,7 @@
                     }
                 },
                 {
-                    "id": "org_oGfwJLbdRss0aiIU",
+                    "id": "org_wyehRBjAkFeGeYib",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -12996,7 +13398,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_KGHEhn16DHYitg8j",
+                    "id": "org_w77D4ZISPOWL3v9R",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -13007,7 +13409,7 @@
                     }
                 },
                 {
-                    "id": "org_oGfwJLbdRss0aiIU",
+                    "id": "org_wyehRBjAkFeGeYib",
                     "name": "org2",
                     "display_name": "Organization2"
                 }
@@ -13019,7 +13421,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KGHEhn16DHYitg8j/enabled_connections",
+        "path": "/api/v2/organizations/org_w77D4ZISPOWL3v9R/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -13029,7 +13431,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_oGfwJLbdRss0aiIU/enabled_connections",
+        "path": "/api/v2/organizations/org_wyehRBjAkFeGeYib/enabled_connections",
         "body": "",
         "status": 200,
         "response": [],
@@ -13039,19 +13441,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/breached-password-detection",
+        "path": "/api/v2/attack-protection/brute-force-protection",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                }
-            }
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13086,18 +13487,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
+        "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                }
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13110,14 +13512,24 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000013779",
+                "id": "lst_0000000000015065",
+                "name": "Suspended DD Log Stream",
+                "type": "datadog",
+                "status": "active",
+                "sink": {
+                    "datadogApiKey": "some-sensitive-api-key",
+                    "datadogRegion": "us"
+                }
+            },
+            {
+                "id": "lst_0000000000015066",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-0da0aa0b-670c-4088-9b45-b5f59405aade/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-a0d29214-9e3a-4756-ad63-145ad18d8001/auth0.logs"
                 },
                 "filters": [
                     {
@@ -13157,16 +13569,6 @@
                         "name": "auth.token_exchange.fail"
                     }
                 ]
-            },
-            {
-                "id": "lst_0000000000013778",
-                "name": "Suspended DD Log Stream",
-                "type": "datadog",
-                "status": "active",
-                "sink": {
-                    "datadogApiKey": "some-sensitive-api-key",
-                    "datadogRegion": "us"
-                }
             }
         ],
         "rawHeaders": [],

--- a/test/e2e/recordings/should-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-deploy-without-throwing-an-error.json
@@ -697,6 +697,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -731,48 +747,6 @@
             "start": 0,
             "limit": 100,
             "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
                 {
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
@@ -812,6 +786,48 @@
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -821,7 +837,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/WM31waMImeHDtQnjVLPzg2uvu00vgdim",
+        "path": "/api/v2/clients/aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -878,7 +894,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
+            "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -902,26 +918,12 @@
         "method": "GET",
         "path": "/api/v2/emails/provider?include_fields=true&fields=name%2Cenabled%2Ccredentials%2Csettings%2Cdefault_from_address",
         "body": "",
-        "status": 200,
+        "status": 404,
         "response": {
-            "name": "mandrill",
-            "credentials": {},
-            "default_from_address": "auth0-user@auth0.com",
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "There is not a configured email provider",
+            "errorCode": "inexistent_email_provider"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -944,6 +946,20 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -985,35 +1001,35 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -1071,35 +1087,8 @@
         },
         "status": 200,
         "response": {
-            "universal_login_experience": "new"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
+            "universal_login_experience": "new",
+            "identifier_first": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -1161,6 +1150,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": {
             "enabled": false,
@@ -1208,48 +1225,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Deploy CLI",
                     "is_first_party": true,
                     "oidc_conformant": true,
@@ -1282,6 +1257,48 @@
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -1335,14 +1352,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_tPtALYZ6wQWOFos3",
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -1352,7 +1382,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 }
             ]
@@ -1372,14 +1403,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_tPtALYZ6wQWOFos3",
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -1389,7 +1433,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 }
             ]
@@ -1400,25 +1445,39 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_tPtALYZ6wQWOFos3",
+        "path": "/api/v2/connections/con_qavKC44AnXdVIktG",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_tPtALYZ6wQWOFos3",
+            "id": "con_qavKC44AnXdVIktG",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
             "name": "Username-Password-Authentication",
             "is_domain_connection": false,
             "enabled_clients": [
-                "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -1430,11 +1489,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_tPtALYZ6wQWOFos3",
+        "path": "/api/v2/connections/con_qavKC44AnXdVIktG",
         "body": {
             "enabled_clients": [
-                "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
             ],
             "is_domain_connection": false,
             "options": {
@@ -1443,7 +1502,20 @@
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "realms": [
@@ -1452,22 +1524,35 @@
         },
         "status": 200,
         "response": {
-            "id": "con_tPtALYZ6wQWOFos3",
+            "id": "con_qavKC44AnXdVIktG",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
             "name": "Username-Password-Authentication",
             "is_domain_connection": false,
             "enabled_clients": [
-                "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -1491,48 +1576,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Deploy CLI",
                     "is_first_party": true,
                     "oidc_conformant": true,
@@ -1565,6 +1608,48 @@
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -1618,14 +1703,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_tPtALYZ6wQWOFos3",
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -1636,7 +1734,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 }
             ]
@@ -1656,14 +1754,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_tPtALYZ6wQWOFos3",
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -1674,7 +1785,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 }
             ]
@@ -1690,8 +1801,8 @@
             "name": "google-oauth2",
             "strategy": "google-oauth2",
             "enabled_clients": [
-                "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
             ],
             "is_domain_connection": false,
             "options": {
@@ -1705,7 +1816,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_9EN7bDJcMepWxhmM",
+            "id": "con_F6FupkR2JVv0xmQV",
             "options": {
                 "email": true,
                 "scope": [
@@ -1719,7 +1830,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
             ],
             "realms": [
                 "google-oauth2"
@@ -1743,48 +1854,6 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_auth": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WM31waMImeHDtQnjVLPzg2uvu00vgdim",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
                     "name": "Deploy CLI",
                     "is_first_party": true,
                     "oidc_conformant": true,
@@ -1817,6 +1886,48 @@
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_auth": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -1870,7 +1981,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -2119,7 +2230,7 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_9EN7bDJcMepWxhmM",
+                    "id": "con_F6FupkR2JVv0xmQV",
                     "options": {
                         "email": true,
                         "scope": [
@@ -2136,18 +2247,31 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 },
                 {
-                    "id": "con_tPtALYZ6wQWOFos3",
+                    "id": "con_qavKC44AnXdVIktG",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -2158,7 +2282,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "WM31waMImeHDtQnjVLPzg2uvu00vgdim"
+                        "aeVst9TwA6QPHDkpexs1vfl9PiQBJUza"
                     ]
                 }
             ]
@@ -2184,7 +2308,7 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://travel0.com/logoutCallback"
+                "https://mycompany.org/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
@@ -2220,7 +2344,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "This tenant name should be preserved",
+            "friendly_name": "My Test Tenant",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -2229,13 +2353,14 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@travel0.com",
-            "support_url": "https://travel0.com/support",
+            "support_email": "support@mycompany.org",
+            "support_url": "https://mycompany.org/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"

--- a/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
@@ -796,6 +796,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -896,7 +912,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -929,14 +945,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -946,8 +975,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -967,14 +996,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -984,8 +1026,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -1082,40 +1124,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -1149,7 +1158,40 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
         "body": "",
         "status": 404,
         "response": {
@@ -1209,21 +1251,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
@@ -1254,6 +1281,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/client-grants?include_totals=true&page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -1263,7 +1305,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -1486,6 +1528,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
@@ -1495,16 +1547,6 @@
             "from": "from bar",
             "messaging_service_sid": "foo"
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
-        "body": "",
-        "status": 200,
-        "response": {},
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -1693,7 +1735,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -1703,7 +1745,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -1763,6 +1805,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/consent/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-otp/custom-text/en",
         "body": "",
         "status": 200,
@@ -1783,16 +1835,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/consent/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
@@ -1803,7 +1845,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -1813,7 +1855,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -1843,6 +1885,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
         "body": "",
         "status": 200,
@@ -1863,26 +1915,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
@@ -1894,6 +1926,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -1977,12 +2019,22 @@
                 },
                 {
                     "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node12",
+                        "node16"
+                    ],
+                    "default_runtime": "node16",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -1994,31 +2046,6 @@
                     ]
                 },
                 {
-                    "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node12",
-                        "node16",
-                        "node18"
-                    ],
-                    "default_runtime": "node16",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "credentials-exchange",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16",
-                        "node18",
-                        "node18-actions"
-                    ],
-                    "default_runtime": "node18-actions",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -2029,13 +2056,24 @@
                     "compatible_triggers": []
                 },
                 {
+                    "id": "credentials-exchange",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16",
+                        "node18-actions"
+                    ],
+                    "default_runtime": "node18-actions",
+                    "compatible_triggers": []
+                },
+                {
                     "id": "pre-user-registration",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -2068,7 +2106,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -2091,20 +2128,6 @@
                     "runtimes": [
                         "node12",
                         "node16",
-                        "node18",
-                        "node18-actions"
-                    ],
-                    "default_runtime": "node18-actions",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "send-phone-message",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node12",
-                        "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
@@ -2117,6 +2140,18 @@
                     "runtimes": [
                         "node12"
                     ],
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "send-phone-message",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node12",
+                        "node16",
+                        "node18-actions"
+                    ],
+                    "default_runtime": "node18-actions",
                     "compatible_triggers": []
                 },
                 {
@@ -2125,10 +2160,17 @@
                     "status": "CURRENT",
                     "runtimes": [
                         "node16",
-                        "node18",
                         "node18-actions"
                     ],
                     "default_runtime": "node18-actions",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "login-post-identifier",
+                    "version": "v1",
+                    "status": "CURRENT",
+                    "default_runtime": "node18",
+                    "runtimes": [],
                     "compatible_triggers": []
                 }
             ]
@@ -2230,6 +2272,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/triggers/login-post-identifier/bindings",
+        "body": "",
+        "status": 200,
+        "response": {
+            "bindings": [],
+            "per_page": 20
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/organizations?include_totals=true",
         "body": "",
         "status": 200,
@@ -2257,25 +2312,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
@@ -2289,6 +2325,25 @@
                     "shields": []
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2580,7 +2635,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"
@@ -3227,6 +3283,22 @@
                             "value": "delete:encryption_keys"
                         },
                         {
+                            "description": "Read Sessions",
+                            "value": "read:sessions"
+                        },
+                        {
+                            "description": "Delete Sessions",
+                            "value": "delete:sessions"
+                        },
+                        {
+                            "description": "Read Refresh Tokens",
+                            "value": "read:refresh_tokens"
+                        },
+                        {
+                            "description": "Delete Refresh Tokens",
+                            "value": "delete:refresh_tokens"
+                        },
+                        {
                             "value": "read:client_credentials",
                             "description": "Read Client Credentials"
                         },
@@ -3327,7 +3399,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3351,7 +3423,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+        "path": "/api/v2/clients/xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -3408,7 +3480,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+            "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3445,7 +3517,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -3473,7 +3545,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -3515,7 +3587,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -3647,34 +3719,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -3723,6 +3767,34 @@
         "body": "",
         "status": 200,
         "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -3843,7 +3915,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3908,14 +3980,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -3925,8 +4010,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -3946,14 +4031,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -3963,8 +4061,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -3975,26 +4073,39 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_jhN5HBbQHUJEcF6n",
+        "path": "/api/v2/connections/con_eSHGfDptLUMkQdaq",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_jhN5HBbQHUJEcF6n",
+            "id": "con_eSHGfDptLUMkQdaq",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
             "name": "Username-Password-Authentication",
             "is_domain_connection": false,
             "enabled_clients": [
-                "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -4006,11 +4117,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_jhN5HBbQHUJEcF6n",
+        "path": "/api/v2/connections/con_eSHGfDptLUMkQdaq",
         "body": {
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD"
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "is_domain_connection": false,
             "options": {
@@ -4019,7 +4130,20 @@
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "realms": [
@@ -4028,14 +4152,27 @@
         },
         "status": 200,
         "response": {
-            "id": "con_jhN5HBbQHUJEcF6n",
+            "id": "con_eSHGfDptLUMkQdaq",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
                 "passwordPolicy": "good",
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "local_enrollment_enabled": true,
+                    "progressive_enrollment_enabled": true
+                },
                 "strategy_version": 2,
+                "authentication_methods": {
+                    "passkey": {
+                        "enabled": false
+                    },
+                    "password": {
+                        "enabled": true
+                    }
+                },
                 "brute_force_protection": true
             },
             "strategy": "auth0",
@@ -4043,7 +4180,7 @@
             "is_domain_connection": false,
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD"
+                "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -4129,7 +4266,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4194,14 +4331,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -4211,8 +4361,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -4232,14 +4382,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -4249,8 +4412,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -4389,7 +4552,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
+                    "client_id": "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4454,7 +4617,7 @@
             "limit": 100,
             "client_grants": [
                 {
-                    "id": "cgr_Uvfv2anWyTWpI1qQ",
+                    "id": "cgr_t3j1isctGZmOVylt",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
@@ -4725,14 +4888,27 @@
             "limit": 100,
             "connections": [
                 {
-                    "id": "con_jhN5HBbQHUJEcF6n",
+                    "id": "con_eSHGfDptLUMkQdaq",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
                         "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
                         "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true
+                            }
+                        },
                         "brute_force_protection": true
                     },
                     "strategy": "auth0",
@@ -4742,8 +4918,8 @@
                         "Username-Password-Authentication"
                     ],
                     "enabled_clients": [
-                        "GunrGye8hwbrx4eUMZJvsSuAhjiLsLdD",
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "xy3hfqvRZhP9glmLayoGXrnFS5EDaAMm"
                     ]
                 }
             ]
@@ -4846,7 +5022,8 @@
                 "colors": {
                     "primary": "#F8F8F2",
                     "page_background": "#222221"
-                }
+                },
+                "identifier_first": true
             },
             "session_cookie": {
                 "mode": "non-persistent"

--- a/test/tools/auth0/handlers/logStreams.test.ts
+++ b/test/tools/auth0/handlers/logStreams.test.ts
@@ -49,6 +49,29 @@ const mockLogStreams = [
       httpEndpoint: 'https://suspended.com/logs',
     },
   },
+  {
+    id: 'log-stream-5',
+    name: 'Active EventGrid Log Stream',
+    type: 'eventgrid',
+    status: 'active',
+    sink: {
+      azureSubscriptionId: 'some id',
+      azureRegion: 'some region',
+      azureResourceGroup: 'some rg',
+      azurePartnerTopic: 'some topic name',
+    },
+  },
+  {
+    id: 'log-stream-6',
+    name: 'Active EventBridge Log Stream',
+    type: 'eventbridge',
+    status: 'active',
+    sink: {
+      awsRegion: "some region",
+      awsAccountId: "some id",
+      awsPartnerEventSource: "some source",
+    },
+  },
 ];
 
 const auth0ApiClientMock = {
@@ -119,8 +142,69 @@ describe('#logStreams handler', () => {
               httpEndpoint: 'https://suspended.com/logs',
             },
           },
+          {
+            id: 'log-stream-5',
+            name: 'Active EventGrid Log Stream',
+            type: 'eventgrid',
+            status: 'active',
+            sink: {
+              azureSubscriptionId: 'some id',
+              azureRegion: 'some region',
+              azureResourceGroup: 'some rg',
+              azurePartnerTopic: 'some topic name',
+            },
+          },
+          {
+            id: 'log-stream-6',
+            name: 'Active EventBridge Log Stream',
+            type: 'eventbridge',
+            status: 'active',
+            sink: {
+              awsRegion: "some region",
+		          awsAccountId: "some id",
+              awsPartnerEventSource: "some source",
+            },
+          },
         ],
       });
+    });
+
+    it('should create log streams', async () => {
+      let didCreateFunctionGetCalled = false;
+
+      const handler = new logStreamsHandler({
+        config: () => {},
+        client: {
+          ...auth0ApiClientMock,
+          logStreams: {
+            ...auth0ApiClientMock.logStreams,
+            getAll: async () => [],
+          },
+        },
+        functions: {
+          create: (data) => {
+            didCreateFunctionGetCalled = true;
+            const expectedValue = (() => {
+              const value = mockLogStreams.find((logStream) => {
+                return logStream.id === data.id;
+              });
+              value.sink = { ...value.sink };
+              //@ts-ignore because it's actually ok for sink property to be omitted in POST payload
+              delete value.status; // Not expecting status in POST payload
+              if (value?.type == 'eventgrid') delete value.sink.azurePartnerTopic; // Topic name is auto-generated on create, not expecting it in POST payload
+              if (value?.type == 'eventbridge') delete value.sink.awsPartnerEventSource; // Not expecting this in POST payload
+
+              return value;
+            })();
+
+            expect(data).to.deep.equal(expectedValue);
+            return Promise.resolve(data);
+          },
+        },
+      });
+
+      await handler.processChanges({ logStreams: mockLogStreams });
+      expect(didCreateFunctionGetCalled).to.equal(true);
     });
 
     it('should update log streams settings', async () => {
@@ -136,10 +220,13 @@ describe('#logStreams handler', () => {
               const value = mockLogStreams.find((logStream) => {
                 return logStream.id === id;
               });
+              //@ts-ignore because it's actually ok for status property to be omitted in PATCH payload
+              if (value?.type === 'eventbridge' || value?.type === 'eventgrid') delete value.sink;
               delete value.id; // Not expecting ID in PATCH payload
               delete value.type; // Not expecting type in PATCH payload
               //@ts-ignore because it's actually ok for status property to be omitted in PATCH payload
               if (value?.status === 'suspended') delete value.status; // Not expecting status in PATCH payload if suspended
+
               return value;
             })();
 


### PR DESCRIPTION
### 🔧 Changes

- Added `sink.azurePartnerTopic` as a field to be stripped when creating a log stream
- Fixes #875 

### 📚 References

- [Create a log stream - Auth0 Management API v2](https://auth0.com/docs/api/management/v2/log-streams/post-log-streams)

### 🔬 Testing

- Covered by unit test
- Manual testing: 
1. Import log stream of the format
```yaml
logStreams:
  - name: Azure Event Grid
    filters:
      - type: category
        name: auth.token_exchange.fail
      - ...
    sink:
      azureSubscriptionId: <subscription id>
      azureRegion: <region>
      azureResourceGroup: <resource group>
      azurePartnerTopic: <partner topic name>
    status: active
    type: eventgrid
```
2. Create operation should succeed

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
