### PR TITLE
DRAFT: Adding proxy functionality for node module usage

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -3,7 +3,7 @@ import nconf from 'nconf';
 import mkdirp from 'mkdirp';
 
 import log from '../logger';
-import { isDirectory } from '../utils';
+import { isDirectory, setupProxy } from '../utils';
 import { setupContext } from '../context/index';
 import { Config } from '../types';
 import { ExportParams } from '../args';
@@ -17,6 +17,7 @@ export default async function exportCMD(params: ExportParams) {
     export_ids: exportIds,
     secret: clientSecret,
     env: shouldInheritEnv = false,
+    proxy_url: proxyUrl,
   } = params;
 
   if (shouldInheritEnv) {
@@ -55,6 +56,8 @@ export default async function exportCMD(params: ExportParams) {
   }
 
   nconf.overrides(overrides);
+
+  setupProxy(proxyUrl);
 
   // Setup context and load
   const context = await setupContext(nconf.get(), 'export');

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,5 +1,6 @@
 import nconf from 'nconf';
 import { configFactory } from '../configFactory';
+import { setupProxy } from '../utils';
 import { deploy as toolsDeploy } from '../tools';
 import log from '../logger';
 import { setupContext } from '../context';
@@ -13,6 +14,7 @@ export default async function importCMD(params: ImportParams) {
     config: configObj,
     env: shouldInheritEnv = false,
     secret: clientSecret,
+    proxy_url: proxyUrl,
   } = params;
 
   if (shouldInheritEnv) {
@@ -40,6 +42,8 @@ export default async function importCMD(params: ImportParams) {
   }
 
   nconf.overrides(overrides);
+
+  setupProxy(proxyUrl);
 
   // Setup context and load
   const context = await setupContext(nconf.get(), 'import');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { bootstrap } from 'global-agent';
-
 import { getParams, CliParams } from './args';
 import log from './logger';
 import tools from './tools';
@@ -12,20 +10,6 @@ import exportCMD from './commands/export';
 async function run(params: CliParams): Promise<void> {
   // Run command
   const command = params._[0];
-
-  const proxy = params.proxy_url;
-
-  if (proxy) {
-    const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
-
-    if (MAJOR_NODEJS_VERSION < 10) {
-      // `global-agent` works with Node.js v10 and above.
-      throw new Error('The --proxy_url option is only supported on Node >= 10');
-    }
-
-    process.env.GLOBAL_AGENT_HTTP_PROXY = proxy;
-    bootstrap();
-  }
 
   log.debug(`Start command ${command}`);
   if (['deploy', 'import'].includes(command) && 'input_file' in params) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import sanitizeName from 'sanitize-filename';
 import dotProp from 'dot-prop';
+import { bootstrap } from 'global-agent';
 import { loadFileAndReplaceKeywords, Auth0 } from './tools';
 import log from './logger';
 import { Asset, Assets, Config, KeywordMappings } from './types';
@@ -205,3 +206,17 @@ export function mapClientID2NameSorted(enabledClients: string[], knownClients: A
     ...(enabledClients || []).map((clientId) => convertClientIdToName(clientId, knownClients)),
   ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 }
+
+export const setupProxy = (proxyUrl: string | undefined) => {
+  if (proxyUrl === undefined) return;
+
+  const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
+
+  if (MAJOR_NODEJS_VERSION < 10) {
+    // `global-agent` works with Node.js v10 and above.
+    throw new Error('The --proxy_url option is only supported on Node >= 10');
+  }
+
+  process.env.GLOBAL_AGENT_HTTP_PROXY = proxyUrl;
+  bootstrap();
+};

--- a/test/e2e/e2e.test.ts
+++ b/test/e2e/e2e.test.ts
@@ -17,6 +17,33 @@ const AUTH0_CLIENT_SECRET = process.env['AUTH0_E2E_CLIENT_SECRET'] || '';
 const AUTH0_ACCESS_TOKEN = shouldUseRecordings ? 'insecure' : undefined;
 
 describe('#end-to-end dump', function () {
+  it('should be able to set proxy URL for both dump and deploy', async function () {
+    await dump({
+      output_folder: testNameToWorkingDirectory(this.test?.title),
+      format: 'yaml',
+      config: {
+        AUTH0_DOMAIN,
+        AUTH0_CLIENT_ID,
+        AUTH0_CLIENT_SECRET,
+        AUTH0_ACCESS_TOKEN,
+        AUTH0_INCLUDED_ONLY: ['actions'],
+      },
+      proxy_url: 'http://www.some-proxy.com',
+    });
+
+    await deploy({
+      input_file: `${__dirname}/testdata/should-deploy-without-throwing-an-error/tenant.yaml`,
+      config: {
+        AUTH0_DOMAIN,
+        AUTH0_CLIENT_ID,
+        AUTH0_CLIENT_SECRET,
+        AUTH0_ACCESS_TOKEN,
+        AUTH0_INCLUDED_ONLY: ['actions'],
+      },
+      proxy_url: 'http://www.some-proxy.com',
+    });
+  });
+
   it('should dump without throwing an error', async function () {
     const workDirectory = testNameToWorkingDirectory(this.test?.title);
 


### PR DESCRIPTION

### 🔧 Changes

Even when a `proxy_url` is passed-in to the Deploy when used as a node module, it does not get utilized properly. This is because the `run` function, the sole function responsible for setting-up the proxy, is not executed when the functions are used as a node module. This PR proposed to move the proxy configuration into the `dump` and `deploy` functions themselves so that a proxy can be used by either mode of operation.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Added a placeholder E2E test for local testing. Not yet sure if this test can be run in CI for lack of dependency proxy server.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
