### PR TITLE
[ULX-1596] feat: add custom prompts partials

### DIFF
--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -21,7 +21,7 @@ export default class DirectoryContext {
   assets: Assets;
   disableKeywordReplacement: boolean;
 
-  constructor(config: Config, mgmtClient: Auth0APIClient) {
+  constructor(config: Config, mgmtClient) {
     this.filePath = config.AUTH0_INPUT_FILE;
     this.config = config;
     this.mappings = config.AUTH0_KEYWORD_REPLACE_MAPPINGS || {};

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -161,19 +161,19 @@ export const setupContext = async (
       return new AuthenticationClient({
         domain: AUTH0_DOMAIN,
         clientId: AUTH0_CLIENT_ID,
-        clientAssertionSigningKey: readFileSync(AUTH0_CLIENT_SIGNING_KEY_PATH),
+        clientAssertionSigningKey: readFileSync(AUTH0_CLIENT_SIGNING_KEY_PATH, 'utf-8'),
         clientAssertionSigningAlg: !!AUTH0_CLIENT_SIGNING_ALGORITHM
           ? AUTH0_CLIENT_SIGNING_ALGORITHM
           : undefined,
       });
     })();
-
-    const clientCredentials = await authClient.clientCredentialsGrant({
+    
+    const clientCredentials = await authClient.oauth.clientCredentialsGrant({
       audience: config.AUTH0_AUDIENCE
         ? config.AUTH0_AUDIENCE
         : `https://${config.AUTH0_DOMAIN}/api/v2/`,
     });
-    return clientCredentials.access_token;
+    return clientCredentials.data.access_token;
   })();
 
   const mgmtClient = new ManagementClient({

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ import {
   Prompts,
   PromptsCustomText,
   PromptSettings,
+  CustomPromptPartials,
+  CustomPromptsPromptTypes,
+  CustomPromptPartialsScreens,
 } from './tools/auth0/handlers/prompts';
 import { Tenant } from './tools/auth0/handlers/tenant';
 import { Theme } from './tools/auth0/handlers/themes';
@@ -159,6 +162,14 @@ export type BaseAuth0APIClient = {
       prompt: PromptTypes;
       language: Language;
     }) => Promise<Partial<PromptsCustomText>>;
+    updatePartials: (arg0: {
+      prompt: CustomPromptsPromptTypes;
+    },
+      body: CustomPromptPartialsScreens
+    ) => Promise<void>;
+    getPartials: (arg0: {
+      prompt: CustomPromptsPromptTypes;
+    }) => Promise<CustomPromptPartials>;
     getSettings: () => Promise<PromptSettings>;
     updateSettings: (arg0: {}, arg1: Partial<PromptSettings>) => Promise<void>;
   };

--- a/test/context/directory/prompts.test.ts
+++ b/test/context/directory/prompts.test.ts
@@ -12,6 +12,7 @@ const promptsDirectory = path.join(dir, constants.PROMPTS_DIRECTORY);
 
 const promptsSettingsFile = 'prompts.json';
 const customTextFile = 'custom-text.json';
+const partialsFile = 'partials.json';
 
 describe('#directory context prompts', () => {
   it('should parse prompts', async () => {
@@ -45,11 +46,38 @@ describe('#directory context prompts', () => {
             },
           },
         }),
+        [partialsFile]: JSON.stringify({
+          login: [
+            {
+              name: 'form-content-start',
+              template: './partials/login/form-content-start.liquid',
+            },
+          ],
+          signup: [
+            {
+              name: 'form-content-end',
+              template: './partials/signup/form-content-end.liquid',
+            },
+          ],
+        }),
       },
     };
 
-    const repoDir = path.join(testDataDir, 'directory', 'prompts');
+    const repoDir = path.join(testDataDir, 'directory');
+
     createDir(repoDir, files);
+
+    const partialsDir = path.join(
+      repoDir,
+      constants.PROMPTS_DIRECTORY,
+      'partials'
+    );
+    const partialsFiles = {
+      login: { 'form-content-start.liquid': '<div>TEST</div>' },
+      signup: { 'form-content-end.liquid': '<div>TEST AGAIN</div>' },
+    };
+
+    createDir(partialsDir, partialsFiles);
 
     const config = {
       AUTH0_INPUT_FILE: repoDir,
@@ -64,6 +92,20 @@ describe('#directory context prompts', () => {
     expect(context.assets.prompts).to.deep.equal({
       universal_login_experience: 'classic',
       identifier_first: true,
+      partials: {
+        login: [
+          {
+            name: 'form-content-start',
+            template: '<div>TEST</div>',
+          },
+        ],
+        signup: [
+          {
+            name: 'form-content-end',
+            template: '<div>TEST AGAIN</div>',
+          },
+        ],
+      },
       customText: {
         en: {
           login: {
@@ -91,7 +133,7 @@ describe('#directory context prompts', () => {
     });
   });
 
-  describe('should parse prompts even if one or both files are absent', async () => {
+  describe('should parse prompts even if one or more files are absent', async () => {
     it('should parse even if custom text file is absent', async () => {
       cleanThenMkdir(promptsDirectory);
       const mockPromptsSettings = {
@@ -101,6 +143,7 @@ describe('#directory context prompts', () => {
       const promptsDirectoryNoCustomTextFile = {
         [constants.PROMPTS_DIRECTORY]: {
           [promptsSettingsFile]: JSON.stringify(mockPromptsSettings),
+          [partialsFile]: JSON.stringify({}),
         },
       };
 
@@ -112,10 +155,42 @@ describe('#directory context prompts', () => {
       const context = new Context(config, mockMgmtClient());
       await context.loadAssetsFromLocal();
 
-      expect(context.assets.prompts).to.deep.equal({ ...mockPromptsSettings, customText: {} });
+      expect(context.assets.prompts).to.deep.equal({
+        ...mockPromptsSettings,
+        customText: {},
+        partials: {},
+      });
     });
 
-    it('should parse even if both files are absent', async () => {
+    it('should parse even if custom prompts file is absent', async () => {
+      cleanThenMkdir(promptsDirectory);
+      const mockPromptsSettings = {
+        universal_login_experience: 'classic',
+        identifier_first: true,
+      };
+      const promptsDirectoryNoPartialsFile = {
+        [constants.PROMPTS_DIRECTORY]: {
+          [promptsSettingsFile]: JSON.stringify(mockPromptsSettings),
+          [customTextFile]: JSON.stringify({}),
+        },
+      };
+
+      createDir(promptsDirectory, promptsDirectoryNoPartialsFile);
+
+      const config = {
+        AUTH0_INPUT_FILE: promptsDirectory,
+      };
+      const context = new Context(config, mockMgmtClient());
+      await context.loadAssetsFromLocal();
+
+      expect(context.assets.prompts).to.deep.equal({
+        ...mockPromptsSettings,
+        customText: {},
+        partials: {},
+      });
+    });
+
+    it('should parse even if all files are absent', async () => {
       cleanThenMkdir(promptsDirectory);
       const emptyPromptsDirectory = {
         [constants.PROMPTS_DIRECTORY]: {},
@@ -129,7 +204,7 @@ describe('#directory context prompts', () => {
       const context = new Context(config, mockMgmtClient());
       await context.loadAssetsFromLocal();
 
-      expect(context.assets.prompts).to.deep.equal({ customText: {} });
+      expect(context.assets.prompts).to.deep.equal({ customText: {}, partials: {} });
     });
   });
 
@@ -182,6 +257,20 @@ describe('#directory context prompts', () => {
           },
         },
       },
+      partials: {
+        login: [
+          {
+            name: 'form-content-start',
+            template: './partials/login/form-content-start.liquid',
+          },
+        ],
+        signup: [
+          {
+            name: 'form-content-end',
+            template: './partials/signup/form-content-end.liquid',
+          },
+        ],
+      },
     };
 
     await promptsHandler.dump(context);
@@ -190,11 +279,15 @@ describe('#directory context prompts', () => {
 
     expect(dumpedFiles).to.deep.equal([
       path.join(promptsDirectory, customTextFile),
+      path.join(promptsDirectory, partialsFile),
       path.join(promptsDirectory, promptsSettingsFile),
     ]);
 
     expect(loadJSON(path.join(promptsDirectory, customTextFile), {})).to.deep.equal(
-      context.assets.prompts.customText
+      context.assets.prompts?.customText
+    );
+    expect(loadJSON(path.join(promptsDirectory, partialsFile), {})).to.deep.equal(
+      context.assets.prompts?.partials
     );
     expect(loadJSON(path.join(promptsDirectory, promptsSettingsFile), {})).to.deep.equal({
       universal_login_experience: context.assets.prompts.universal_login_experience,

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -282,6 +282,7 @@ describe('#YAML context validation', () => {
       logStreams: [],
       prompts: {
         customText: {},
+        partials: {},
       },
       customDomains: [],
       themes: [],
@@ -394,6 +395,7 @@ describe('#YAML context validation', () => {
       logStreams: [],
       prompts: {
         customText: {},
+        partials: {},
       },
       customDomains: [],
       themes: [],
@@ -507,6 +509,7 @@ describe('#YAML context validation', () => {
       logStreams: [],
       prompts: {
         customText: {},
+        partials: {},
       },
       customDomains: [],
       themes: [],

--- a/test/context/yaml/prompts.test.ts
+++ b/test/context/yaml/prompts.test.ts
@@ -62,6 +62,13 @@ describe('#YAML context prompts', () => {
                 passwordSecurityText: 'Your password must contain:'
                 title: Create Your Account!
                 usernamePlaceholder: Username
+        customPrompts:
+          login:
+            - name: form-content-start
+              template: ./templatePartials/login/form-content-start.liquid
+          signup:
+            - name: form-content-end
+              template:  ./templatePartials/signup/form-content-end.liquid
     `;
 
     const yamlFile = path.join(dir, 'config.yaml');
@@ -131,6 +138,20 @@ describe('#YAML context prompts', () => {
       },
       identifier_first: true,
       universal_login_experience: 'classic',
+      customPrompts: {
+        login: [
+          {
+            name: 'form-content-start',
+            template: './templatePartials/login/form-content-start.liquid',
+          },
+        ],
+        signup: [
+          {
+            name: 'form-content-end',
+            template: './templatePartials/signup/form-content-end.liquid',
+          },
+        ],
+      },
     });
   });
 
@@ -170,6 +191,20 @@ describe('#YAML context prompts', () => {
             },
           },
         },
+      },
+      customPrompts: {
+        login: [
+          {
+            name: 'form-content-start',
+            template: './templatePartials/login/form-content-start.liquid',
+          },
+        ],
+        signup: [
+          {
+            name: 'form-content-end',
+            template: './templatePartials/signup/form-content-end.liquid',
+          },
+        ],
       },
     };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -124,6 +124,7 @@ export function mockMgmtClient() {
         new Promise((res) => {
           res({});
         }),
+      getPartials: async () => ({}),
       getSettings: () => {},
     },
     customDomains: { getAll: () => [] },


### PR DESCRIPTION
### 🔧 Changes

- This PR adds support for importing/exporting custom prompts partials ([feature docs](https://auth0.com/docs/customize/universal-login-pages/customize-signup-and-login-prompts)). This feature allows customers to add HTML/Liquid to various extensibility points in the Login/Signup prompts.
- We add a new `prompts/partials.json` config, and a `partials` directory for the actual partials (see example below)

**Note:**
- we should consider implementing a flat structure and just naming our templates `{prompt}/{screen}/{insertion_point}.liquid`
- otherwise, we'll need to add another layer of directory nesting to capture the screen (the one below is missing a subdirectory for login and for signup
![image](https://github.com/auth0/auth0-deploy-cli/assets/12899024/cba43ab9-612f-4f79-8913-cfa72f51fefc)


### 📚 References

[ULX-1596](https://auth0team.atlassian.net/browse/ULX-1596)

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)



[ULX-1596]: https://auth0team.atlassian.net/browse/ULX-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ