### PR TITLE
Support signing up with organization membership

### DIFF
--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -21,6 +21,7 @@ export const schema = {
             connection_id: { type: 'string' },
             assign_membership_on_login: { type: 'boolean' },
             show_as_button: { type: 'boolean' },
+            is_signup_enabled: { type: 'boolean' }
           },
         },
       },
@@ -127,8 +128,11 @@ export default class OrganizationsHandler extends DefaultHandler {
       existingConnections.find(
         (x) =>
           x.connection_id === c.connection_id &&
-          (x.assign_membership_on_login !== c.assign_membership_on_login ||
-            x.show_as_button !== c.show_as_button)
+          (
+            x.assign_membership_on_login !== c.assign_membership_on_login ||
+            x.show_as_button !== c.show_as_button ||
+            x.is_signup_enabled !== c.is_signup_enabled
+          )
       )
     );
 
@@ -141,6 +145,7 @@ export default class OrganizationsHandler extends DefaultHandler {
             {
               assign_membership_on_login: conn.assign_membership_on_login,
               show_as_button: conn.show_as_button,
+              is_signup_enabled: conn.is_signup_enabled
             }
           )
           .catch(() => {

--- a/test/context/directory/organizations.test.js
+++ b/test/context/directory/organizations.test.js
@@ -15,6 +15,8 @@ describe('#directory context organizations', () => {
           '{ "name": "acme", "display_name": "acme", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "name": "google", "assign_membership_on_login": false, "show_as_button": false }]}',
         'contoso.json':
           '{ "name": "contoso", "display_name": "contoso", "branding": { "colors": { "primary": "#3678e2", "page_background": "#9c4949" } }, "connections":[{ "name": "google", "assign_membership_on_login": false, "show_as_button": false }]}',
+        'tast-org.json':
+          '{ "name": "atko", "display_name": "Atko", "branding": { "colors": { "primary": "#ededed", "page_background": "#191919" } }, "connections":[{ "name": "Username-Password-Authentication", "assign_membership_on_login": true, "show_as_button": true, "is_signup_enabled": true }]}',
       },
     };
 
@@ -58,6 +60,24 @@ describe('#directory context organizations', () => {
             assign_membership_on_login: false,
             show_as_button: false,
           },
+        ],
+      },
+      {
+        name: 'atko',
+        display_name: 'Atko',
+        branding: {
+          colors: {
+            primary: '#ededed',
+            page_background: '#191919',
+          },
+        },
+        connections: [
+          {
+            name: 'Username-Password-Authentication',
+            assign_membership_on_login: true,
+            show_as_button: true,
+            is_signup_enabled: true,
+          }
         ],
       },
     ];
@@ -135,6 +155,24 @@ describe('#directory context organizations', () => {
           },
         ],
       },
+      {
+        name: 'atko',
+        display_name: 'Atko',
+        branding: {
+          colors: {
+            primary: '#ededed',
+            page_background: '#191919',
+          },
+        },
+        connections: [
+          {
+            name: 'Username-Password-Authentication',
+            assign_membership_on_login: true,
+            show_as_button: true,
+            is_signup_enabled: true,
+          },
+        ],
+      },
     ];
 
     await handler.dump(context);
@@ -144,6 +182,9 @@ describe('#directory context organizations', () => {
     );
     expect(loadJSON(path.join(organizationsFolder, 'contoso.json'))).to.deep.equal(
       context.assets.organizations[1]
+    );
+    expect(loadJSON(path.join(organizationsFolder, 'atko.json'))).to.deep.equal(
+      context.assets.organizations[2]
     );
   });
 });

--- a/test/context/yaml/organizations.test.js
+++ b/test/context/yaml/organizations.test.js
@@ -23,6 +23,7 @@ describe('#YAML context organizations', () => {
           - connection_id: con_123
             assign_membership_on_login: false
             show_as_button: false
+            is_signup_enabled: false
         display_name: acme
       - name: contoso
         branding:
@@ -33,6 +34,7 @@ describe('#YAML context organizations', () => {
           - connection_id: con_456
             assign_membership_on_login: true
             show_as_button: true
+            is_signup_enabled: true
         display_name: contoso
     `;
 
@@ -51,6 +53,7 @@ describe('#YAML context organizations', () => {
             connection_id: 'con_123',
             assign_membership_on_login: false,
             show_as_button: false,
+            is_signup_enabled: false
           },
         ],
       },
@@ -68,6 +71,7 @@ describe('#YAML context organizations', () => {
             connection_id: 'con_456',
             assign_membership_on_login: true,
             show_as_button: true,
+            is_signup_enabled: true
           },
         ],
       },
@@ -99,6 +103,7 @@ describe('#YAML context organizations', () => {
             connection_id: 'con_123',
             assign_membership_on_login: false,
             show_as_button: false,
+            is_signup_enabled: false,
             connection: {
               name: 'foo',
               strategy: 'auth0',

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -19,6 +19,7 @@ const sampleEnabledConnection = {
   connection_id: 'con_123',
   assign_membership_on_login: true,
   show_as_button: false,
+  is_signup_enabled: true,
   connection: {
     name: 'Username-Password-Login',
     strategy: 'auth0',
@@ -135,6 +136,7 @@ describe('#organizations handler', () => {
             expect(connection.connection_id).to.equal('con_123');
             expect(connection.assign_membership_on_login).to.equal(true);
             expect(connection.show_as_button).to.equal(false);
+            expect(connection.is_signup_enabled).to.equal(true);
             return Promise.resolve(connection);
           },
         },
@@ -169,6 +171,7 @@ describe('#organizations handler', () => {
                   name: 'Username-Password-Login',
                   assign_membership_on_login: true,
                   show_as_button: false,
+                  is_signup_enabled: true
                 },
               ],
             },
@@ -333,6 +336,7 @@ describe('#organizations handler', () => {
               expect(data).to.be.an('object');
               expect(data.assign_membership_on_login).to.equal(false);
               expect(data.show_as_button).to.equal(true);
+              expect(data.is_signup_enabled).to.equal(false);
             } else {
               expect(params).to.be.an('object');
               expect(params.id).to.equal('123');
@@ -377,6 +381,7 @@ describe('#organizations handler', () => {
                   name: 'Username-Password-Login',
                   assign_membership_on_login: false,
                   show_as_button: true,
+                  is_signup_enabled: false
                 },
                 { name: 'facebook', assign_membership_on_login: true, show_as_button: false },
               ],
@@ -409,6 +414,7 @@ describe('#organizations handler', () => {
             expect(data.connection_id).to.equal('con_123');
             expect(data.assign_membership_on_login).to.equal(false);
             expect(data.show_as_button).to.equal(false);
+            expect(data.is_signup_enabled).to.equal(false);
             return Promise.resolve(data);
           },
         },
@@ -445,6 +451,7 @@ describe('#organizations handler', () => {
                   name: 'Username-Password-Login',
                   assign_membership_on_login: false,
                   show_as_button: false,
+                  is_signup_enabled: false
                 },
               ],
             },


### PR DESCRIPTION
### 🔧 Changes

- A new property `is_signup_enabled` is added to the organization connections.

### 🔬 Testing

Create a `config.json` file similar to:

```
{
    "AUTH0_DOMAIN": "<YOUR_DOMAIN>",
    "AUTH0_CLIENT_ID": "<CLIENT_ID>",
    "AUTH0_CLIENT_SECRET": "<CLIENT_SECRET>",
    "AUTH0_INCLUDED_ONLY": ["organizations"],
    "AUTH0_ALLOW_DELETE": false
}
 ```
 
Use the following commands to `import` or `export` configs.

Export yaml: `node lib/index.js export -c config.json -o ./local -f yaml`
Import yaml: `node lib/index.js import -c config.json --input_file ./local/tenant.yaml`

`is_signup_enabled` is exported.
`is_signup_enabled` is imported on creation.
`is_signup_enabled` changes to existing enabled connections are detected and it is updated.

Important use-cases related to this change:

- `is_signup_enabled` is valid only when the `strategy` is `auth0`.  i.e `is_signup_enabled` will not available in non db connections.
- `is_signup_enabled` can be set to `true` only when `assign_membership_on_login` is set `true`. However, you can set `is_signup_enabled` to `false` when `assign_membership_on_login` is set to `false`.

Continue the same test or json format as well.

### 🔬 Change Verification

- With this PR changes, `is_signup_enabled` property value can be manipulated and changes can be seen on the auth0 dashboard.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
