### PR TITLE
fix make `captcha_widget_theme` non-mandatory field in `colors` property within `themes` schema

### DIFF
--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -293,7 +293,6 @@ export const schema = {
           'success',
           'widget_background',
           'widget_border',
-          'captcha_widget_theme'
         ],
         type: 'object',
       },
@@ -526,7 +525,7 @@ export interface Colors {
   links_focused_components: string;
   header: string;
   body_text: string;
-  captcha_widget_theme:string;
+  captcha_widget_theme: string;
   widget_background: string;
   widget_border: string;
   input_labels_placeholders: string;


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
- fix make `captcha_widget_theme` non-mandatory field in `colors` property within `themes` schema
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
