### PR TITLE
unbreaks the yaml template loader

### DIFF
--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -36,8 +36,7 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
         context.basePath,
         constants.BRANDING_TEMPLATES_YAML_DIRECTORY
       );
-      const file = `${templateDefinition.template}.html`;
-      const markupFile = path.join(brandingTemplatesFolder, file);
+      const markupFile = path.join(brandingTemplatesFolder, templateDefinition.body);
       return {
         template: templateDefinition.template,
         body: loadFileAndReplaceKeywords(markupFile, {


### PR DESCRIPTION


### 🔧 Changes

Partially reverts the change that PR #939 introduced on which it limits the name and format of the branding template filename.

### 📚 References

- Issue #941
- PR #939 

### 🔬 Testing

- With the updated package deploy a tenant from a yaml configuration file on which the branding template is different from the `templateDefinition.template`

### 📝 Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [N/A] I have added documentation for all new/changed functionality (or N/A)
