### PR TITLE
Support keyword replacement for custom prompts when using the directory format

### DIFF
--- a/src/context/directory/handlers/prompts.ts
+++ b/src/context/directory/handlers/prompts.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
-import { constants } from '../../../tools';
+import { ensureDirSync, writeFileSync } from 'fs-extra';
+import { constants, loadFileAndReplaceKeywords } from '../../../tools';
 import { dumpJSON, existsMustBeDir, isFile, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
@@ -67,7 +67,10 @@ function parse(context: DirectoryContext): ParsedPrompts {
             (insertionAcc, { name, template }) => {
               const templateFilePath = path.join(promptsDirectory, template);
               insertionAcc[name] = isFile(templateFilePath)
-                ? readFileSync(templateFilePath, 'utf8').trim()
+                ? loadFileAndReplaceKeywords(templateFilePath, {
+                  mappings: context.mappings,
+                  disableKeywordReplacement: context.disableKeywordReplacement,
+                }).trim()
                 : '';
               return insertionAcc;
             },

--- a/test/context/directory/prompts.test.ts
+++ b/test/context/directory/prompts.test.ts
@@ -94,7 +94,7 @@ describe('#directory context prompts', () => {
       },
       signup: {
         signup: {
-          'form-content-end.liquid': '<div>TEST AGAIN</div>',
+          'form-content-end.liquid': '<div>Hello, ##SOME_REPLACED_KEYWORD##!</div>',
         },
       },
     };
@@ -106,6 +106,7 @@ describe('#directory context prompts', () => {
       AUTH0_KEYWORD_REPLACE_MAPPINGS: {
         BUTTON_TEXT_FRENCH: 'French button text',
         BUTTON_TEXT_ENGLISH: 'English button text',
+        SOME_REPLACED_KEYWORD: 'world',
       },
     };
     const context = new Context(config, mockMgmtClient());
@@ -121,7 +122,7 @@ describe('#directory context prompts', () => {
         },
         signup: {
           signup: {
-            'form-content-end': '<div>TEST AGAIN</div>',
+            'form-content-end': '<div>Hello, world!</div>',
           },
         },
       },

--- a/test/context/yaml/prompts.test.ts
+++ b/test/context/yaml/prompts.test.ts
@@ -70,13 +70,20 @@ describe('#YAML context prompts', () => {
           login-id:
             login-id:
               form-content-end: >-
-                <div>TEST</div>
+                <div>Hello, ##SOME_REPLACED_KEYWORD##!</div>
     `;
 
     const yamlFile = path.join(dir, 'config.yaml');
     fs.writeFileSync(yamlFile, yaml);
 
-    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const mappings = {
+      SOME_REPLACED_KEYWORD: 'world',
+    };
+
+    const config = {
+      AUTH0_INPUT_FILE: yamlFile,
+      AUTH0_KEYWORD_REPLACE_MAPPINGS: mappings,
+    };
     const context = new Context(config, mockMgmtClient());
     await context.loadAssetsFromLocal();
 
@@ -147,7 +154,7 @@ describe('#YAML context prompts', () => {
         },
         'login-id': {
           'login-id': {
-            'form-content-end': '<div>TEST</div>',
+            'form-content-end': '<div>Hello, world!</div>',
           },
         },
       },


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
 
This updates the prompt parser for the directory structure to support dynamic keyword replacement within the template file of a custom prompt partial. This was already handled by the basic mechanism for handling YAML, but not the other way around.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Addresses #962

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

1. Create a custom prompt partial with a given keyword:

```html
<!-- resources/prompts/partials/signup/signup/form-content-end.html -->
<div>Hello, ##SOME_KEYWORD##</div>
```

2. Deploy it, having configured the respective keyword mapping:

In your config:

```json
{
  "SOME_KEYWORD": "world"
}
```

```sh
a0deploy import -c=config.json --input_file=resources
```

I tend to deploy using the method exported from the module, so the above may need adjustment to compensate for use of the CLI.

3. Fetch the content of the prompt partial from Auth0. The expectation is:

```html
<div>Hello, world!</div>
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- (N/A) I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
