### PR TITLE
Temp fix for entity-bound triggers error

### DIFF
--- a/src/tools/auth0/handlers/triggers.ts
+++ b/src/tools/auth0/handlers/triggers.ts
@@ -86,6 +86,11 @@ export default class TriggersHandler extends DefaultHandler {
         return {};
       }
 
+      if (err.message === "cannot list action bindings for an entity-bound trigger") {
+          logger_1.default.warn(`${err.message.charAt(0).toUpperCase()}${err.message.slice(1)} (${triggerId})`);
+          return {};
+      }
+
       throw err;
     }
   }


### PR DESCRIPTION
### 🔧 Changes

Just a quick fix for the issue introduced with custom-token-exchange being returned when calling the triggers API. 
This will continue even if the API responds with the "cannot list action bindings for an entity-bound trigger" response (400 response code). May be a cleaner way to do this, but it does the job for now!

All it does is adds a new check in the catch section of the try-catch that makes a call to the triggerBindings endpoint.

### 📚 References

- https://github.com/auth0/auth0-deploy-cli/issues/988

### 🔬 Testing

Try running a full export with debug mode enabled. Without this "fix" the export will break and not complete successfully. With this fix, it'll just "warn" about the issue.

### 📝 Checklist

- [ X ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ X ] I have added documentation for all new/changed functionality (or N/A)
