### PR TITLE
fix: adjust method execution order for form-flow-vault

### DIFF
--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -14,6 +14,11 @@ import { calculateChanges } from '../../calculateChanges';
 import { Asset, Assets, Auth0APIClient, CalculatedChanges } from '../../../types';
 import { ConfigFunction } from '../../../configFactory';
 
+/**
+ * Decorator to set the order of a method.
+ * Lower numbers are executed first.
+ * @param value The order value.
+ */
 export function order(value) {
   return function decorator(t, n, descriptor) {
     descriptor.value.order = value; // eslint-disable-line

--- a/src/tools/auth0/handlers/flowVaultConnections.ts
+++ b/src/tools/auth0/handlers/flowVaultConnections.ts
@@ -57,7 +57,7 @@ export default class FlowVaultHandler extends DefaultHandler {
     return this.existing;
   }
 
-  @order('50')
+  @order('80')
   async processChanges(assets: Assets): Promise<void> {
     const { flowVaultConnections } = assets;
 

--- a/src/tools/auth0/handlers/flows.ts
+++ b/src/tools/auth0/handlers/flows.ts
@@ -71,7 +71,7 @@ export default class FlowHandler extends DefaultHandler {
     return this.existing;
   }
 
-  @order('60')
+  @order('70')
   async processChanges(assets: Assets): Promise<void> {
     const { flows } = assets;
 

--- a/src/tools/auth0/handlers/forms.ts
+++ b/src/tools/auth0/handlers/forms.ts
@@ -128,7 +128,7 @@ export default class FormsHandler extends DefaultHandler {
     return forms;
   }
 
-  @order('70')
+  @order('60')
   async processChanges(assets: Assets): Promise<void> {
     const { forms } = assets;
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This pull request introduces a new `@order` decorator to manage the execution order of methods and updates the order values for several `processChanges` methods across different handler classes. These changes aim to improve the clarity and control of method execution priorities for form-flow-vault.



### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing
Test pass ✅ 
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
