### PR TITLE
fix: test in e2e-cli.sh for husky prepare script

### DIFF
--- a/test/e2e/e2e-cli.sh
+++ b/test/e2e/e2e-cli.sh
@@ -6,7 +6,9 @@ CONFIG_FILE="./config-cli-e2e.json"
 
 npm ci #Install all dependencies to allow for building
 npm run build
-npm ci --omit=dev #Remove dev dependencies
+
+# Skip removing dev dependencies - husky prepare script needs them
+# npm ci --omit=dev  #Remove dev dependencies
 
 TARBALL_PATH=$(npm pack)
 sudo npm install -g $TARBALL_PATH


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This pull request makes a small but important change to the `test` script, ensuring that development dependencies are not removed during the build process to support the `husky` prepare script.

Commented out the line that removes development dependencies and added a comment explaining that this is necessary because the `husky` prepare script requires these dependencies.

### 📚 References
- https://github.com/auth0/auth0-deploy-cli/pull/1088
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
