### PR TITLE
fix: remove husky prepare script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "dev": "npx tsc --watch",
     "prepublishOnly": "npm run build",
     "preversion": "kacl prerelease",
-    "version": "kacl release && git add CHANGELOG.md",
-    "prepare": "husky || true"
+    "version": "kacl release && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This pull request updates the `package.json` file to simplify the npm script configuration by removing the `prepare` script.

Simplification of npm scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R21): Removed the `prepare` script (`"prepare": "husky || true"`) to streamline the configuration.

### 📚 References

- #1100 
- #1099

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
