### PR TITLE
Remove "migrations" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The Auth0 Deploy CLI is a tool that helps you manage your Auth0 tenant configuration. It integrates into your development workflows as a standalone CLI or as a node module.
 
-**Supported resource types:** actions, branding, client grants, clients (applications), connections, custom domains, email templates, emails, grants, guardian, hook secrets, log streams, migrations, organizations, pages, prompts, resource servers (APIs), roles, tenant settings, themes, forms, flows, self-service profiles, network ACLs.
+**Supported resource types:** actions, branding, client grants, clients (applications), connections, custom domains, email templates, emails, grants, guardian, hook secrets, log streams, organizations, pages, prompts, resource servers (APIs), roles, tenant settings, themes, forms, flows, self-service profiles, network ACLs.
 
 🎢 [Highlights](#highlights) • 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • 💬 [Feedback](#feedback)
 


### PR DESCRIPTION
The resource is not managed since this version:

https://github.com/auth0/auth0-deploy-cli/releases/tag/v8.0.0

The failure is also not as silent as the documentation would suggest it [here](https://github.com/auth0/auth0-deploy-cli/blob/v8.0.0/docs/v8_MIGRATION_GUIDE.md#migrations) as proven by this error:

```text
2025-06-02T13:49:12.743Z - error: Schema validation failed loading [
    {
        "keyword": "additionalProperties",
        "dataPath": "",
        "schemaPath": "#/additionalProperties",
        "params": {
            "additionalProperty": "migrations"
        },
        "message": "should NOT have additional properties"
    }
]
```

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Small change to the README as the migration resource is now deprecated.
