### PR TITLE
feat: sanitise client fields for resource_server app type

### DIFF
--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -209,11 +209,29 @@ export default class ClientHandler extends DefaultAPIHandler {
       return list.filter((item) => item.client_id !== currentClient);
     };
 
+    // Sanitize client fields
+    const sanitizeClientFields = (list) =>
+      list.map((item) => {
+        // For resourceServers app type `resource_server`, don't include `oidc_backchannel_logout`, `oidc_logout`, `refresh_token`
+        if (item.app_type === 'resource_server') {
+          if ('oidc_backchannel_logout' in item) {
+            delete item.oidc_backchannel_logout;
+          }
+          if ('oidc_logout' in item) {
+            delete item.oidc_logout;
+          }
+          if ('refresh_token' in item) {
+            delete item.refresh_token;
+          }
+        }
+        return item;
+      });
+
     const changes = {
-      del: filterClients(del),
-      update: filterClients(update),
-      create: filterClients(create),
-      conflicts: filterClients(conflicts),
+      del: sanitizeClientFields(filterClients(del)),
+      update: sanitizeClientFields(filterClients(update)),
+      create: sanitizeClientFields(filterClients(create)),
+      conflicts: sanitizeClientFields(filterClients(conflicts)),
     };
 
     await super.processChanges(assets, {


### PR DESCRIPTION
### 🔧 Changes
sanitisation step for client objects to ensure that certain fields are removed from clients of the `resource_server` app type before processing changes. This helps prevent inappropriate fields from being included for resource server clients.

### 📚 References
 - https://github.com/auth0/auth0-deploy-cli/pull/1158

### 🔬 Testing
 - Unit test pass ✅ 
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
