### PR TITLE
fix(userAttributeProfiles): handle 403 if feature is not enabled

### DIFF
--- a/src/tools/auth0/handlers/userAttributeProfiles.ts
+++ b/src/tools/auth0/handlers/userAttributeProfiles.ts
@@ -209,14 +209,27 @@ export default class UserAttributeProfilesHandler extends DefaultAPIHandler {
   async getType() {
     if (this.existing) return this.existing;
 
-    this.existing = await paginate<UserAttributeProfile>(this.client.userAttributeProfiles.getAll, {
-      checkpoint: true,
-      include_totals: true,
-      is_global: false,
-      take: 10,
-    });
+    try {
+      this.existing = await paginate<UserAttributeProfile>(this.client.userAttributeProfiles.getAll, {
+        checkpoint: true,
+        include_totals: true,
+        is_global: false,
+        take: 10,
+      });
 
-    return this.existing;
+      return this.existing;
+    } catch (err) {
+      if (err.statusCode === 404 || err.statusCode === 501) {
+        return null;
+      }
+      if (err.statusCode === 403) {
+        log.debug(
+          'User Attribute Profile with Self-Service SSO is not enabled for this tenant. Please verify `scope` or contact Auth0 support to enable this feature.'
+        );
+        return null;
+      }
+      throw err;
+    }
   }
 
   @order('50')

--- a/test/tools/auth0/handlers/userAttributeProfiles.tests.js
+++ b/test/tools/auth0/handlers/userAttributeProfiles.tests.js
@@ -267,5 +267,18 @@ describe('#userAttributeProfiles handler', () => {
 
       await stageFn.apply(handler, [{ userAttributeProfiles: [] }]);
     });
+
+    it('should handle 403 error when not enabled on tenant', async () => {
+      const auth0 = {
+        userAttributeProfiles: {
+          getAll: () => Promise.reject(Object.assign(new Error('Forbidden'), { statusCode: 403 })),
+        },
+      };
+
+      const handler = new userAttributeProfiles.default({ client: pageClient(auth0), config });
+
+      const data = await handler.getType();
+      expect(data).to.equal(null);
+    });
   });
 });


### PR DESCRIPTION
### 🔧 Changes

Implements a check as to whether the call to retrieve user attribute profiles returns a 403 and return null if so to ensure that tenants without the feature enabled still function without ignoring this resource type.

I have not added the check onto the call in `selfServiceProfiles` because that explicitly requires adding the property which feels fair to fail on to me.

### 📚 References

### 🔬 Testing

Added test and tested manually against tenant 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
