### PR TITLE
fix: add `read_only_background` property to schema for `themes`

### DIFF
--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -277,6 +277,11 @@ export const schema = {
             pattern: '^#(([0-9a-fA-F]{3}){1,2}|([0-9a-fA-F]{4}){1,2})$',
             type: 'string',
           },
+          read_only_background: {
+            description: 'Read only background',
+            pattern: '^#(([0-9a-fA-F]{3}){1,2}|([0-9a-fA-F]{4}){1,2})$',
+            type: 'string',
+          },
         },
         required: [
           'body_text',

--- a/src/tools/auth0/handlers/userAttributeProfiles.ts
+++ b/src/tools/auth0/handlers/userAttributeProfiles.ts
@@ -210,12 +210,15 @@ export default class UserAttributeProfilesHandler extends DefaultAPIHandler {
     if (this.existing) return this.existing;
 
     try {
-      this.existing = await paginate<UserAttributeProfile>(this.client.userAttributeProfiles.getAll, {
-        checkpoint: true,
-        include_totals: true,
-        is_global: false,
-        take: 10,
-      });
+      this.existing = await paginate<UserAttributeProfile>(
+        this.client.userAttributeProfiles.getAll,
+        {
+          checkpoint: true,
+          include_totals: true,
+          is_global: false,
+          take: 10,
+        }
+      );
 
       return this.existing;
     } catch (err) {


### PR DESCRIPTION

### 🔧 Changes

- **Schema Validation Fix**: Added `read_only_background` property to the theme colors schema.

### 📚 References

- Fixes #1179

### 🔬 Testing
Manual testing steps:

1. Export a tenant configuration: `a0deploy export -c ./config.json -f yaml -o ./output`
2. If the tenant has themes with `read_only_background` colors defined, verify the exported YAML includes them
3. Re-import the exported configuration without modifications: `a0deploy import -c ./config.json -i ./output/tenant.yaml`
4. Verify the import succeeds without schema validation errors

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
