### PR TITLE
fix: improved_signup_bot_detection_in_classic is added in allowed tenant flags

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -98,6 +98,7 @@ export const allowedTenantFlags = [
   'disable_fields_map_fix',
   'require_pushed_authorization_requests',
   'mfa_show_factor_list_on_enrollment',
+  'improved_signup_bot_detection_in_classic',
 ];
 
 export const removeUnallowedTenantFlags = (


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This pull request addresses an issue where the `improved_signup_bot_detection_in_classic` tenant flag was being ignored by the Deploy CLI, resulting in the following:

`The following tenant flag has not been updated because deemed incompatible with the target tenant: improved_signup_bot_detection_in_classic`

The flag is supported by both the Auth0 Management API and the Auth0 Dashboard. The issue was that the flag was missing from the `allowedTenantFlags` list in `src/tools/auth0/handlers/tenant.ts`


### 📚 References

* Related Auth0 documentation: https://auth0.com/docs/secure/attack-protection/bot-detection
* Source reference for missing flag: https://github.com/auth0/auth0-deploy-cli/blob/master/src/tools/auth0/handlers/tenant.ts#L75 (Current file before PR)

### 🔬 Testing

This can be tested by:

1.  Using Auth0 Deploy CLI with the change applied.
2.  Creating a `tenant.yaml` file with the flag set:
    ```yaml
    tenant:
      flags:
        improved_signup_bot_detection_in_classic: false
    ```
3.  Running the Deploy CLI against a Classic tenant.
4.  **Expected:** The flag should be applied to the tenant settings via the Management API, and the warning message regarding the flag being ignored should no longer be displayed.

### 📝 Checklist

- [x] Checked importing and exporting via local yaml

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
