### PR TITLE
fix: client grants pagination to use checkpoint  and tests

### DIFF
--- a/src/tools/auth0/handlers/clientGrants.ts
+++ b/src/tools/auth0/handlers/clientGrants.ts
@@ -68,7 +68,7 @@ export default class ClientGrantsHandler extends DefaultHandler {
     }
 
     const clientGrants = await paginate<ClientGrant>(this.client.clientGrants.list, {
-      paginate: true,
+      checkpoint: true,
     });
 
     this.existing = clientGrants;


### PR DESCRIPTION
### 🔧 Changes

- Switched the clientGrants handler to checkpoint-based pagination for the v5 SDK list API so all grants are fetched and existing grants aren’t misclassified as creates (prevents 409 conflicts).
- Added regression coverage for multi-page clientGrants retrieval using the shared mockPagedData helper.
- Enhanced mockPagedData to simulate multi-page responses, improving test fidelity for paginated resources.

### 📚 References

- Resolves: [#1237](https://github.com/auth0/auth0-deploy-cli/issues/1237)

### 🔬 Testing

- unit test added

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)