### PR TITLE
fix: add support for ephemeral session lifetimes in tenant handling

### DIFF
--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -91,6 +91,7 @@ Boolean. When enabled, will allow the tool to delete resources. Default: `false`
 Array of strings. Specifies which connections should be managed by the Deploy CLI. When configured, only the connections listed by name will be included in export and import operations. All other connections in the tenant will be completely ignored.
 
 This is particularly useful for:
+
 - Managing only specific connections while preserving others (e.g., self-service SSO connections, third-party integrations)
 - Preventing accidental modifications to connections managed by other systems
 - Isolating connection management to specific subsets of your tenant

--- a/src/context/directory/handlers/tenant.ts
+++ b/src/context/directory/handlers/tenant.ts
@@ -28,10 +28,14 @@ function parse(context: DirectoryContext): ParsedTenant {
   const {
     session_lifetime,
     idle_session_lifetime,
+    idle_ephemeral_session_lifetime,
+    ephemeral_session_lifetime,
     ...tenant
   }: {
     session_lifetime?: number;
     idle_session_lifetime?: number;
+    idle_ephemeral_session_lifetime?: number;
+    ephemeral_session_lifetime?: number;
     [key: string]: any;
   } = loadJSON(tenantFile, {
     mappings: context.mappings,
@@ -40,7 +44,12 @@ function parse(context: DirectoryContext): ParsedTenant {
 
   clearTenantFlags(tenant);
 
-  const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
+  const sessionDurations = sessionDurationsToMinutes({
+    session_lifetime,
+    idle_session_lifetime,
+    idle_ephemeral_session_lifetime,
+    ephemeral_session_lifetime,
+  });
 
   return {
     //@ts-ignore

--- a/src/context/yaml/handlers/tenant.ts
+++ b/src/context/yaml/handlers/tenant.ts
@@ -13,16 +13,25 @@ async function parse(context: YAMLContext): Promise<ParsedTenant> {
   const {
     session_lifetime,
     idle_session_lifetime,
+    idle_ephemeral_session_lifetime,
+    ephemeral_session_lifetime,
     ...tenant
   }: {
     session_lifetime?: number;
     idle_session_lifetime?: number;
+    idle_ephemeral_session_lifetime?: number;
+    ephemeral_session_lifetime?: number;
     [key: string]: any;
   } = context.assets.tenant;
 
   clearTenantFlags(tenant);
 
-  const sessionDurations = sessionDurationsToMinutes({ session_lifetime, idle_session_lifetime });
+  const sessionDurations = sessionDurationsToMinutes({
+    session_lifetime,
+    idle_session_lifetime,
+    idle_ephemeral_session_lifetime,
+    ephemeral_session_lifetime,
+  });
 
   return {
     tenant: {

--- a/src/sessionDurationsToMinutes.ts
+++ b/src/sessionDurationsToMinutes.ts
@@ -5,19 +5,37 @@ function hoursToMinutes(hours: number): number {
 export const sessionDurationsToMinutes = ({
   session_lifetime,
   idle_session_lifetime,
+  idle_ephemeral_session_lifetime,
+  ephemeral_session_lifetime,
 }: {
   session_lifetime?: number;
   idle_session_lifetime?: number;
-}): { session_lifetime_in_minutes?: number; idle_session_lifetime_in_minutes?: number } => {
+  idle_ephemeral_session_lifetime?: number;
+  ephemeral_session_lifetime?: number;
+}): {
+  session_lifetime_in_minutes?: number;
+  idle_session_lifetime_in_minutes?: number;
+  idle_ephemeral_session_lifetime_in_minutes?: number;
+  ephemeral_session_lifetime_in_minutes?: number;
+} => {
   const sessionDurations: {
     session_lifetime_in_minutes?: number;
     idle_session_lifetime_in_minutes?: number;
+    idle_ephemeral_session_lifetime_in_minutes?: number;
+    ephemeral_session_lifetime_in_minutes?: number;
   } = {};
 
   if (!!session_lifetime)
     sessionDurations.session_lifetime_in_minutes = hoursToMinutes(session_lifetime);
   if (!!idle_session_lifetime)
     sessionDurations.idle_session_lifetime_in_minutes = hoursToMinutes(idle_session_lifetime);
-
+  if (!!idle_ephemeral_session_lifetime)
+    sessionDurations.idle_ephemeral_session_lifetime_in_minutes = hoursToMinutes(
+      idle_ephemeral_session_lifetime
+    );
+  if (!!ephemeral_session_lifetime)
+    sessionDurations.ephemeral_session_lifetime_in_minutes = hoursToMinutes(
+      ephemeral_session_lifetime
+    );
   return sessionDurations;
 };

--- a/test/sessionDurationsAsMinutes.test.ts
+++ b/test/sessionDurationsAsMinutes.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import { sessionDurationsToMinutes } from '../src/sessionDurationsToMinutes';
 
 describe('#sessionDurationsToMinutes', () => {
@@ -8,19 +7,25 @@ describe('#sessionDurationsToMinutes', () => {
 
     expect(sessionDurations.idle_session_lifetime_in_minutes).to.be.undefined;
     expect(sessionDurations.session_lifetime_in_minutes).to.be.undefined;
+    expect(sessionDurations.idle_ephemeral_session_lifetime_in_minutes).to.be.undefined;
+    expect(sessionDurations.ephemeral_session_lifetime_in_minutes).to.be.undefined;
   });
 
-  it('should convert session durations to minutes durations are defined', () => {
+  it('should convert all session durations to minutes when all are defined', () => {
     const sessionDurations = sessionDurationsToMinutes({
       session_lifetime: 1,
-      idle_session_lifetime: 1,
+      idle_session_lifetime: 2,
+      ephemeral_session_lifetime: 1.5,
+      idle_ephemeral_session_lifetime: 0.5,
     });
 
-    expect(sessionDurations.idle_session_lifetime_in_minutes).to.equal(60);
     expect(sessionDurations.session_lifetime_in_minutes).to.equal(60);
+    expect(sessionDurations.idle_session_lifetime_in_minutes).to.equal(120);
+    expect(sessionDurations.ephemeral_session_lifetime_in_minutes).to.equal(90);
+    expect(sessionDurations.idle_ephemeral_session_lifetime_in_minutes).to.equal(30);
   });
 
-  it('should convert session durations to minutes durations are partially defined', () => {
+  it('should convert session durations to minutes when durations are partially defined', () => {
     const sessionDurations1 = sessionDurationsToMinutes({
       session_lifetime: undefined,
       idle_session_lifetime: 1,
@@ -28,6 +33,7 @@ describe('#sessionDurationsToMinutes', () => {
 
     expect(sessionDurations1.idle_session_lifetime_in_minutes).to.equal(60);
     expect(sessionDurations1.session_lifetime_in_minutes).to.be.undefined;
+    expect(sessionDurations1.ephemeral_session_lifetime_in_minutes).to.be.undefined;
 
     const sessionDurations2 = sessionDurationsToMinutes({
       session_lifetime: 1,
@@ -36,5 +42,13 @@ describe('#sessionDurationsToMinutes', () => {
 
     expect(sessionDurations2.idle_session_lifetime_in_minutes).to.be.undefined;
     expect(sessionDurations2.session_lifetime_in_minutes).to.equal(60);
+
+    const sessionDurations3 = sessionDurationsToMinutes({
+      ephemeral_session_lifetime: 1,
+    });
+
+    expect(sessionDurations3.ephemeral_session_lifetime_in_minutes).to.equal(60);
+    expect(sessionDurations3.idle_ephemeral_session_lifetime_in_minutes).to.be.undefined;
+    expect(sessionDurations3.session_lifetime_in_minutes).to.be.undefined;
   });
 });


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fixed a bug where importing tenant configurations failed when session lifetimes were set to fractional hours (e.g., 5 minutes = 0.0833 hours).
Introduced sessionDurationsToMinutes to convert session duration fields from hours (float) to minutes (integer).
Ensures the API receives the expected integer format, preventing Payload validation error during import.

### 📚 References


- Auth0 Management API: [Update Tenant Settings (PATCH)](https://auth0.com/docs/api/management/v2/tenants/patch-settings)

### 🔬 Testing

1. Set Idle Session Lifetime (Non Persistent) to 5 minutes in an Auth0 tenant.

2. Export the tenant configuration (YAML).

3. Attempt to import the generated YAML back into the tenant.

4. Success: The import should now complete without throwing a 400 BadRequestError.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)



[ESD-55278]: https://auth0team.atlassian.net/browse/ESD-55278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ