### PR TITLE
feat: add support for relying_party_identifier in custom domains

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -500,6 +500,78 @@ For `universal_login` template `templates/` will be created.
 }
 ```
 
+## Custom Domains
+
+Custom domains allow you to use your own domain for authentication instead of the default Auth0 domain. The Deploy CLI supports managing custom domains in both directory and YAML modes.
+
+Custom domains have the following key properties:
+
+- `domain`: The custom domain name (required)
+- `type`: Certificate management type - either `auth0_managed_certs` or `self_managed_certs` (required)
+- `custom_client_ip_header`: Header to use for client IP detection (optional, one of: `true-client-ip`, `cf-connecting-ip`, `x-forwarded-for`, or `null`)
+- `tls_policy`: TLS policy to use (defaults to `recommended`)
+- `verification_method`: Domain verification method (defaults to `txt`)
+- `domain_metadata`: Metadata associated with the custom domain (optional, max 10 properties)
+- `relying_party_identifier`: Relying Party ID (rpId) to be used for Passkeys on this custom domain. If not provided or set to null, the full domain will be used. (optional)
+
+**Note**: The `relying_party_identifier` should be a suffix of the domain name. For example, if your domain is `auth.example.com`, the `relying_party_identifier` could be `example.com`.
+
+**YAML Example**
+
+```yaml
+# Contents of ./tenant.yaml
+customDomains:
+  - domain: 'auth.example.com'
+    type: 'auth0_managed_certs'
+    tls_policy: 'recommended'
+    custom_client_ip_header: 'cf-connecting-ip'
+    domain_metadata:
+      environment: 'production'
+      team: 'platform'
+    relying_party_identifier: 'example.com'
+  - domain: 'login.myapp.com'
+    type: 'self_managed_certs'
+    verification_method: 'txt'
+```
+
+**Directory Example**
+
+```
+Folder structure when in directory mode.
+
+./customDomains/
+    ./auth.example.com.json
+    ./login.myapp.com.json
+```
+
+Contents of `auth.example.com.json`:
+
+```json
+{
+  "domain": "auth.example.com",
+  "type": "auth0_managed_certs",
+  "tls_policy": "recommended",
+  "custom_client_ip_header": "cf-connecting-ip",
+  "domain_metadata": {
+    "environment": "production",
+    "team": "platform"
+  },
+  "relying_party_identifier": "example.com"
+}
+```
+
+Contents of `login.myapp.com.json`:
+
+```json
+{
+  "domain": "login.myapp.com",
+  "type": "self_managed_certs",
+  "verification_method": "txt"
+}
+```
+
+For more details, see the [Management API documentation](https://auth0.com/docs/api/management/v2#!/Custom_Domains).
+
 ## NetworkACL
 
 Tenant Network Access Control Lists (NetworkACLs) allow you to configure rules that control access to your Auth0 tenant based on IP addresses, geographical locations, and other network criteria. The Deploy CLI supports managing NetworkACLs in both directory and YAML modes.Refer [more](https://auth0.com/docs/secure/tenant-access-control-list/configure-rules) on this.

--- a/examples/directory/custom-domains/custom-domains.json
+++ b/examples/directory/custom-domains/custom-domains.json
@@ -5,6 +5,7 @@
     "tls_policy": "recommended",
     "domain_metadata": {
       "myKey": "value"
-    }
+    },
+    "relying_party_identifier": "domain.com"
   }
 ]

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -373,6 +373,7 @@ customDomains:
     tls_policy: 'recommended'
     domain_metadata:
       myKey: value
+    relying_party_identifier: domain.com
 
 attackProtection:
   botDetection:

--- a/src/tools/auth0/handlers/customDomains.ts
+++ b/src/tools/auth0/handlers/customDomains.ts
@@ -35,6 +35,11 @@ export const schema = {
         description: 'Custom domain verification method. Must be `txt`.',
         defaultValue: 'txt',
       },
+      relying_party_identifier: {
+        type: ['string'],
+        description:
+          'Relying Party ID (rpId) to be used for Passkeys on this custom domain. If not provided or set to null, the full domain will be used.',
+      },
     },
     required: ['domain', 'type'],
   },

--- a/test/tools/auth0/handlers/customDomains.test.ts
+++ b/test/tools/auth0/handlers/customDomains.test.ts
@@ -550,4 +550,93 @@ describe('#customDomains handler', () => {
       owner: 'platform-team',
     });
   });
+
+  it('should create custom domains with relying_party_identifier field', async () => {
+    let didCreateFunctionGetCalled = false;
+    let createCallArgs = null;
+
+    const customDomainWithRelyingPartyId = {
+      domain: 'auth.example.com',
+      type: 'auth0_managed_certs',
+      relying_party_identifier: 'example.com',
+    };
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        list: async () => [],
+        create: async (args) => {
+          didCreateFunctionGetCalled = true;
+          createCallArgs = args;
+          return customDomainWithRelyingPartyId;
+        },
+        update: async () => {},
+        delete: async () => {},
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    // @ts-ignore
+    const handler = new customDomainsHandler({
+      config: () => {},
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: [customDomainWithRelyingPartyId] });
+
+    expect(didCreateFunctionGetCalled).to.equal(true);
+    expect(createCallArgs).to.have.property('relying_party_identifier', 'example.com');
+  });
+
+  it('should update custom domains with relying_party_identifier field', async () => {
+    let didUpdateFunctionGetCalled = false;
+    let updateCallData = null;
+
+    const existingCustomDomain = {
+      custom_domain_id: 'cd_456',
+      domain: 'auth.test.com',
+      type: 'auth0_managed_certs',
+      status: 'ready',
+    };
+
+    const updatedCustomDomainWithRelyingPartyId = {
+      custom_domain_id: 'cd_456',
+      domain: 'auth.test.com',
+      type: 'auth0_managed_certs',
+      relying_party_identifier: 'test.com',
+    };
+
+    const auth0ApiClientMock = {
+      customDomains: {
+        list: async () => [existingCustomDomain],
+        create: async () => {},
+        update: async (args, data) => {
+          didUpdateFunctionGetCalled = true;
+          updateCallData = data;
+          expect(args).to.equal('cd_456');
+          return updatedCustomDomainWithRelyingPartyId;
+        },
+        delete: async () => {},
+      },
+      pool: new PromisePoolExecutor({
+        concurrencyLimit: 3,
+        frequencyLimit: 8,
+        frequencyWindow: 1000, // 1 sec
+      }),
+    };
+
+    // @ts-ignore
+    const handler = new customDomainsHandler({
+      config: () => {},
+      client: auth0ApiClientMock as unknown as Auth0APIClient,
+    });
+
+    await handler.processChanges({ customDomains: [updatedCustomDomainWithRelyingPartyId] });
+
+    expect(didUpdateFunctionGetCalled).to.equal(true);
+    expect(updateCallData).to.have.property('relying_party_identifier', 'test.com');
+  });
 });


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Added support for the relying_party_identifier property in Custom Domains, which specifies the Relying Party ID (rpId) to be used for Passkeys on the custom domain

**YAML Example**

```yaml
# Contents of ./tenant.yaml
customDomains:
  - domain: 'auth.example.com'
    type: 'auth0_managed_certs'
    relying_party_identifier: 'example.com'
    ###
```

**JSON Example**

```json
{
  "domain": "auth.example.com",
  "type": "auth0_managed_certs",
  "relying_party_identifier": "example.com"
}
```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- https://auth0.com/docs/api/management/v2/custom-domains/post-custom-domains
- https://auth0.com/docs/api/management/v2/custom-domains/patch-custom-domains-by-id

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Added unit tests

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
