### PR TITLE
fix: resolve silent process exit when deploying 3+ organizations with discovery domains

### DIFF
--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -20,7 +20,7 @@ const connectionOptionsSchema = {
   type: 'object',
   properties: {
     dpop_signing_alg: {
-      type: 'string'
+      type: 'string',
     },
   },
 };

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -16,12 +16,15 @@ import ScimHandler from './scimHandler';
 import log from '../../../logger';
 import { Client } from './clients';
 
+// @ts-ignore - ConnectionDpopSigningAlgEnum may not exist in older SDK versions
+const dpopSigningAlgValues: string[] = Object.values((Management as any).ConnectionDpopSigningAlgEnum ?? {});
+
 const connectionOptionsSchema = {
   type: 'object',
   properties: {
     dpop_signing_alg: {
       type: 'string',
-      enum: Object.values(Management.ConnectionDpopSigningAlgEnum),
+      ...(dpopSigningAlgValues.length > 0 && { enum: dpopSigningAlgValues }),
     },
   },
 };

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -16,9 +16,6 @@ import ScimHandler from './scimHandler';
 import log from '../../../logger';
 import { Client } from './clients';
 
-// @ts-ignore - ConnectionDpopSigningAlgEnum may not exist in older SDK versions
-const dpopSigningAlgValues: string[] = Object.values((Management as any).ConnectionDpopSigningAlgEnum ?? {});
-
 const connectionOptionsSchema = {
   type: 'object',
   properties: {

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -167,12 +167,9 @@ export default class OrganizationsHandler extends DefaultHandler {
     }
 
     if (typeof org.discovery_domains !== 'undefined' && org.discovery_domains.length > 0) {
-      await this.client.pool
-        .addEachTask({
-          data: org.discovery_domains,
-          generator: (
-            discoveryDomain: Management.CreateOrganizationDiscoveryDomainRequestContent
-          ) =>
+      await Promise.all(
+        org.discovery_domains.map(
+          (discoveryDomain: Management.CreateOrganizationDiscoveryDomainRequestContent) =>
             this.createOrganizationDiscoveryDomain(created.id, {
               domain: discoveryDomain?.domain,
               status: discoveryDomain?.status,
@@ -181,9 +178,9 @@ export default class OrganizationsHandler extends DefaultHandler {
               throw new Error(
                 `Problem creating discovery domain ${discoveryDomain?.domain} for organization ${created.id}\n${err}`
               );
-            }),
-        })
-        .promise();
+            })
+        )
+      );
     }
     return created;
   }
@@ -664,15 +661,10 @@ export default class OrganizationsHandler extends DefaultHandler {
     log.debug(
       `Creating discovery domain ${discoveryDomain.domain} for organization ${organizationId}`
     );
-    const orgDiscoveryDomain = await this.client.pool
-      .addSingleTask({
-        data: {
-          id: organizationId,
-        },
-        generator: (args) =>
-          this.client.organizations.discoveryDomains.create(args.id, discoveryDomain),
-      })
-      .promise();
+    const orgDiscoveryDomain = await this.client.organizations.discoveryDomains.create(
+      organizationId,
+      discoveryDomain
+    );
     return orgDiscoveryDomain;
   }
 
@@ -692,19 +684,14 @@ export default class OrganizationsHandler extends DefaultHandler {
       )}`
     );
 
-    const discoveryDomainUpdated = await this.client.pool
-      .addSingleTask({
-        data: {
-          id: organizationId,
-          discoveryDomainId: discoveryDomainId,
-        },
-        generator: (args) =>
-          this.client.organizations.discoveryDomains.update(args.id, args.discoveryDomainId, {
-            status: discoveryDomainUpdate.status,
-            use_for_organization_discovery: discoveryDomainUpdate.use_for_organization_discovery,
-          }),
-      })
-      .promise();
+    const discoveryDomainUpdated = await this.client.organizations.discoveryDomains.update(
+      organizationId,
+      discoveryDomainId,
+      {
+        status: discoveryDomainUpdate.status,
+        use_for_organization_discovery: discoveryDomainUpdate.use_for_organization_discovery,
+      }
+    );
     return discoveryDomainUpdated;
   }
 
@@ -714,15 +701,6 @@ export default class OrganizationsHandler extends DefaultHandler {
     discoveryDomainId: string
   ): Promise<void> {
     log.debug(`Deleting discovery domain ${discoveryDomain} for organization ${organizationId}`);
-    await this.client.pool
-      .addSingleTask({
-        data: {
-          id: organizationId,
-          discoveryDomainId: discoveryDomainId,
-        },
-        generator: (args) =>
-          this.client.organizations.discoveryDomains.delete(args.id, args.discoveryDomainId),
-      })
-      .promise();
+    await this.client.organizations.discoveryDomains.delete(organizationId, discoveryDomainId);
   }
 }

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -178,7 +178,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       await Promise.all(
         org.discovery_domains.map(
           (discoveryDomain: Management.CreateOrganizationDiscoveryDomainRequestContent) =>
-            this.createOrganizationDiscoveryDomain(created.id, {
+            this.createOrganizationDiscoveryDomain(createdId, {
               domain: discoveryDomain?.domain,
               status: discoveryDomain?.status,
               use_for_organization_discovery: discoveryDomain?.use_for_organization_discovery,

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -1238,7 +1238,7 @@ describe('#organizations handler', () => {
         organizations: {
           create: (data) => {
             data.id = `org_${data.name}`;
-            return Promise.resolve({ data });
+            return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
           delete: () => Promise.resolve([]),

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -1226,5 +1226,67 @@ describe('#organizations handler', () => {
         },
       ]);
     });
+
+    it('REPRO: creating 3 orgs with discovery_domains deadlocks the pool', async function () {
+      this.timeout(5000); // test FAILS with timeout = deadlock reproduced
+
+      const createdDomains = [];
+
+      const auth0 = {
+        organizations: {
+          create: (data) => {
+            data.id = `org_${data.name}`;
+            return Promise.resolve({ data });
+          },
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          list: (params) => mockPagedData(params, 'organizations', []),
+          enabledConnections: {
+            add: () => Promise.resolve(),
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            create: () => Promise.resolve(),
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            create: (_orgId, domain) => {
+              createdDomains.push(domain.domain);
+              return Promise.resolve({ data: { id: `dd_${domain.domain}`, ...domain } });
+            },
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+        },
+        connections: {
+          list: (params) => mockPagedData(params, 'connections', []),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', []),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: ['a', 'b', 'c'].map((x) => ({
+            name: `org-${x}`,
+            display_name: `Org ${x}`,
+            client_grants: [],
+            connections: [],
+            discovery_domains: [
+              { domain: `${x}test.io`, status: 'pending', use_for_organization_discovery: false },
+            ],
+          })),
+        },
+      ]);
+
+      expect(createdDomains).to.have.lengthOf(3);
+    });
   });
 });


### PR DESCRIPTION
When a tenant configuration includes 3 or more organizations that each have `discovery_domains`, running `a0deploy import` silently exits mid-run without error. No discovery domains are created or updated, and the "Import Successful" message never appears.

This affects both first-time deploys (create path) and subsequent deploys (update path). The process exits after the delete-warning phase, before any organization changes are applied.

### 🔧 Changes

 - organizations.ts: Discovery domain create/update/delete operations no longer route through the shared request pool. They now use Promise.all and direct API calls, consistent with how connections and `client_grants` sub-operations are handled in the same handler.
  - connections.ts: Fixed a crash at module load time when ConnectionDpopSigningAlgEnum is not present in the installed auth0 SDK version. The schema validation for `dpop_signing_alg` now gracefully omits the enum constraint when the SDK does not provide it.

  **Backward Compatibility**

  No breaking changes. Behavior is identical for:

  - Tenants with fewer than 3 organizations with discovery domains (the deadlock condition was never triggered).
  - Tenants without the Organization Discovery Domains feature enabled.
  - All other resource types — only the discovery domain sub-operations inside OrganizationsHandler are affected.

### 📚 References


### 🔬 Testing

-  Added a regression test that reproduces the deadlock condition directly
- Tested with real tenant data as well

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
