### PR TITLE
fix: resolve 400 error when switching between flexible and legacy password policy on database connections

### DIFF
--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -289,6 +289,26 @@ export default class DatabaseHandler extends DefaultAPIHandler {
             delete connection.options?.attributes;
           }
 
+          // When switching between flexible and legacy password policy, remove the conflicting
+          // group from the existing state before merging to avoid a 400 from the API.
+          const passwordOptions = payload?.options?.password_options;
+          const legacyPasswordSettings =
+            payload?.options?.passwordPolicy ||
+            payload?.options?.password_complexity_options ||
+            payload?.options?.password_history ||
+            payload?.options?.password_no_personal_info ||
+            payload?.options?.password_dictionary;
+
+          if (passwordOptions) {
+            delete connection.options?.passwordPolicy;
+            delete connection.options?.password_complexity_options;
+            delete connection.options?.password_history;
+            delete connection.options?.password_no_personal_info;
+            delete connection.options?.password_dictionary;
+          } else if (legacyPasswordSettings) {
+            delete connection.options?.password_options;
+          }
+
           payload.options = { ...connection.options, ...payload.options };
 
           if (payload.options && Object.keys(payload.options).length === 0) {


### PR DESCRIPTION
### 🔧 Changes

When switching a database connection's password policy between flexible (`password_options`) and legacy (`passwordPolicy`, `password_complexity_options`, `password_history`, `password_no_personal_info`, `password_dictionary`), the deploy would fail with a 400 error from the Management API.                                                    
   
The databases handler fetches the existing connection state before updating and shallow-merges it with the desired payload. This caused both policy groups to appear in the PATCH body simultaneously, which Auth0 rejects. The fix strips the conflicting group from the existing connection state before the merge, following the same pattern already used for the attributes vs `requires_username/validation` conflict in the same method.                                                               

  Both transitions are fixed:
  - Legacy → Flexible: deploying `password_options `when connection has `passwordPolicy` set
  - Flexible → Legacy: deploying `passwordPolicy` when connection has `password_options` set
### 📚 References

N/A

### 🔬 Testing

- Covered unit test cases
- Tested with real tenant data 

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
