### PR TITLE
fix: handle undefined enabled_clients in getEnabledClients

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -157,9 +157,10 @@ export function getEnabledClients(
 
   const excludedClientsByNames = (assets.exclude && assets.exclude.clients) || [];
   const excludedClients = convertClientNamesToIds(excludedClientsByNames, clients);
+  const allExcluded = [...excludedClientsByNames, ...excludedClients];
   const enabledClients = [
     ...convertClientNamesToIds(connection.enabled_clients || [], clients).filter(
-      (item) => ![...excludedClientsByNames, ...excludedClients].includes(item)
+      (item) => !allExcluded.includes(item)
     ),
   ];
   // If client is excluded and in the existing connection this client is enabled, it should keep enabled
@@ -167,7 +168,7 @@ export function getEnabledClients(
   existing.forEach((conn) => {
     if (conn.name === connection.name) {
       excludedClients.forEach((excludedClient) => {
-        if (conn.enabled_clients.includes(excludedClient)) {
+        if (conn.enabled_clients?.includes(excludedClient)) {
           enabledClients.push(excludedClient);
         }
       });

--- a/test/tools/utils.test.ts
+++ b/test/tools/utils.test.ts
@@ -47,6 +47,24 @@ describe('#getEnabledClients', () => {
     expect(enabledClients).to.deep.equal(expectedEnabledClients);
   });
 
+  it('should not crash when existing connection has undefined enabled_clients and excluded clients are configured', () => {
+    // When the legacy "Management of Connection's Enabled Clients" toggle is off,
+    // the API no longer returns enabled_clients on connection objects, so it may be undefined.
+    const clients = [{ name: 'Client 1', client_id: 'client-1-id' }];
+    const mockConnection = {
+      enabled_clients: ['Client 1'],
+      name: 'Existing connection',
+    };
+    const assets = {
+      exclude: { clients: ['Client 1'] },
+    };
+    const existing = [{ name: 'Existing connection', enabled_clients: undefined }];
+
+    const enabledClients = getEnabledClients(assets, mockConnection, existing, clients);
+
+    expect(enabledClients).to.deep.equal([]);
+  });
+
   it('should return undefined when enable clients is not defined', () => {
     const mockConnection = {
       enabled_clients: undefined, // This connection has no defined clients enabled. See: GH issue #523


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
                                                                                                                          
  - Fixed a bug in the getEnabledClients function where enabled_clients could be undefined, leading to potential runtime errors         
  - Added a null/undefined check to safely handle cases where enabled_clients is not present in the client configuration                
  - Prevents TypeError exceptions and ensures graceful handling of client configurations without the property                           


### 📚 References
  - Resolves issue #1363  
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

  - Unit tests covering scenarios where enabled_clients is undefined                                                                    
  - Integration tests verifying client configs without enabled_clients are processed without errors                                     
  - Manual testing: Deploy configs with clients that don't have enabled_clients defined    

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
