### PR TITLE
Fix: a0deploy keyword replacement mappings not applied to theme.json  

### DIFF
--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -429,6 +429,7 @@ export default class ThemesHandler extends DefaultHandler {
       ...options,
       type: 'themes',
       id: 'themeId',
+      identifiers: ['themeId'],
     });
   }
 

--- a/test/tools/auth0/handlers/themes.tests.js
+++ b/test/tools/auth0/handlers/themes.tests.js
@@ -2,6 +2,7 @@ const { expect, assert, use } = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { omit, cloneDeep } = require('lodash');
 const { default: ThemesHandler } = require('../../../../src/tools/auth0/handlers/themes');
+const { preserveKeywords } = require('../../../../src/keywordPreservation');
 
 use(chaiAsPromised);
 
@@ -320,6 +321,51 @@ describe('#themes handler', () => {
     expect(auth0.branding.themes.delete.called).to.equal(false);
     expect(auth0.branding.themes.update.called).to.equal(false);
     expect(auth0.branding.themes.create.called).to.equal(false);
+  });
+});
+
+describe('#themes keyword preservation', () => {
+  const CDN_URL = 'https://cdn.example.com';
+  const themeId = 'my-theme-id';
+
+  const localThemeWithKeywords = {
+    themeId,
+    fonts: { font_url: '##CDN_URL##/fonts/custom.woff2' },
+    widget: { logo_url: '##CDN_URL##/logo.png' },
+  };
+
+  const remoteThemeWithResolvedUrls = {
+    themeId,
+    fonts: { font_url: `${CDN_URL}/fonts/custom.woff2` },
+    widget: { logo_url: `${CDN_URL}/logo.png` },
+  };
+
+  it('should preserve keyword placeholders in theme fields when themeId is in handler identifiers', () => {
+    const result = preserveKeywords({
+      localAssets: { themes: [localThemeWithKeywords] },
+      remoteAssets: { themes: [remoteThemeWithResolvedUrls] },
+      keywordMappings: { CDN_URL },
+      auth0Handlers: [{ id: 'themeId', identifiers: ['themeId'], type: 'themes' }],
+    });
+
+    expect(result.themes[0].fonts.font_url).to.equal('##CDN_URL##/fonts/custom.woff2');
+    expect(result.themes[0].widget.logo_url).to.equal('##CDN_URL##/logo.png');
+  });
+
+  it('should NOT preserve keyword placeholders when themeId is absent from handler identifiers', () => {
+    // Regression: prior to the fix, ThemesHandler used identifiers ['id', 'name'].
+    // getPreservableFieldsFromAssets looks for the identifier field on each array item to build
+    // a dot-notation address; if the field is missing (themes have themeId, not id/name),
+    // it silently returns no addresses and the raw remote URLs are returned unchanged.
+    const result = preserveKeywords({
+      localAssets: { themes: [localThemeWithKeywords] },
+      remoteAssets: { themes: [remoteThemeWithResolvedUrls] },
+      keywordMappings: { CDN_URL },
+      auth0Handlers: [{ id: 'themeId', identifiers: ['id', 'name'], type: 'themes' }],
+    });
+
+    expect(result.themes[0].fonts.font_url).to.equal(`${CDN_URL}/fonts/custom.woff2`);
+    expect(result.themes[0].widget.logo_url).to.equal(`${CDN_URL}/logo.png`);
   });
 });
 


### PR DESCRIPTION
Prior to this fix, keyword placeholder substitution (e.g. `##CDN_URL##`) was silently skipped for theme assets during export. The root cause was that ThemesHandler did not declare an identifiers array, so the keyword-preservation logic - which uses identifiers to build dot-notation lookup paths for each array item - found no matching fields and returned the raw resolved remote URLs instead of preserving the original placeholders.

### 🔧 Changes

Added `identifiers: ['themeId']` to the DefaultHandler options in ThemesHandler, aligning it with how other handlers expose their identifier field so that getPreservableFieldsFromAssets can correctly locate each theme record.


### 🔬 Testing

 New unit tests added under describe('#themes keyword preservation') in test/tools/auth0/handlers/themes.tests.js:

  1. Positive case – verifies that when themeId is included in identifiers, keyword placeholders (e.g. `##CDN_URL##`) in nested theme fields (fonts.font_url, widget.logo_url) are preserved after export.
  2. Regression case – verifies that when identifiers does not include themeId (the pre-fix state), placeholders are not preserved and raw URLs are returned, documenting exactly why the bug occurred.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
