### PR TITLE
feat: Add Google Workspace inbound group sync support to directory provisioning

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -213,6 +213,8 @@ The Deploy CLI supports managing the `directory_provisioning_configuration` for 
 
 The `mapping` array pairs Auth0 user fields with IdP fields, and `synchronize_automatically` controls whether Auth0 runs scheduled sync jobs for the connection.
 
+The `synchronize_groups` field controls group provisioning.
+
 **YAML Example**
 
 ```yaml
@@ -233,6 +235,10 @@ connections:
         - auth0: name
           idp: displayName
       synchronize_automatically: false
+      synchronize_groups: selected
+      synchronized_groups:
+        - id: 'group-id-1'
+        - id: 'group-id-2'
 ```
 
 **Directory Example**
@@ -259,7 +265,9 @@ connections:
       { "auth0": "email", "idp": "mail" },
       { "auth0": "name", "idp": "displayName" }
     ],
-    "synchronize_automatically": false
+    "synchronize_automatically": false,
+    "synchronize_groups": "selected",
+    "synchronized_groups": [{ "id": "group-id-1" }, { "id": "group-id-2" }]
   }
 }
 ```

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -224,6 +224,7 @@ connections:
       tenant_domain: example.com
       client_id: 'some_client_id'
       client_secret: 'some_client_secret'
+      api_enable_groups: true
       api_enable_users: true
     directory_provisioning_configuration:
       mapping:
@@ -250,6 +251,7 @@ connections:
     "tenant_domain": "example.com",
     "client_id": "some_client_id",
     "client_secret": "some_client_secret",
+    "api_enable_groups": true,
     "api_enable_users": true
   },
   "directory_provisioning_configuration": {

--- a/examples/directory/connections/google-apps.json
+++ b/examples/directory/connections/google-apps.json
@@ -9,6 +9,7 @@
     "tenant_domain": "example.com",
     "client_id": "some_client_id",
     "client_secret": "some_client_secret",
+    "api_enable_groups": true,
     "api_enable_users": true
   },
   "directory_provisioning_configuration": {

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -142,6 +142,7 @@ connections:
       tenant_domain: "example.com"
       client_id: 'some_client_id'
       client_secret: 'some_client_secret'
+      api_enable_groups: true
       api_enable_users: true
     directory_provisioning_configuration:
       mapping:

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -21,6 +21,9 @@ const connectionOptionsSchema = {
   type: 'object',
   additionalProperties: true,
   properties: {
+    api_enable_groups: {
+      type: 'boolean',
+    },
     dpop_signing_alg: {
       type: 'string',
     },
@@ -108,6 +111,20 @@ export const schema = {
             type: 'boolean',
             description: 'The field whether periodic automatic synchronization is enabled',
           },
+          synchronize_groups: {
+            type: 'string',
+            enum: Object.values(Management.SynchronizeGroupsEnum),
+          },
+          synchronized_groups: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+              required: ['id'],
+            },
+          },
         },
       },
     },
@@ -121,8 +138,10 @@ export type Connection = Management.ConnectionForList & {
   enabled_clients?: string[];
   directory_provisioning_configuration?: Pick<
     DirectoryProvisioningConfig,
-    'mapping' | 'synchronize_automatically'
-  >;
+    'mapping' | 'synchronize_automatically' | 'synchronize_groups'
+  > & {
+    synchronized_groups?: Array<{ id: string }>;
+  };
 };
 
 // addExcludedConnectionPropertiesToChanges superimposes excluded properties on the `options` object. The Auth0 API
@@ -495,6 +514,7 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     const createPayload: Management.CreateDirectoryProvisioningRequestContent = {
       mapping: payload.mapping,
       synchronize_automatically: payload.synchronize_automatically,
+      ...(payload.synchronize_groups && { synchronize_groups: payload.synchronize_groups }),
     };
     await this.client.connections.directoryProvisioning.create(connectionId, createPayload);
     log.debug(`Created directory provisioning for connection '${connectionId}'`);
@@ -514,6 +534,7 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     const updatePayload: Management.UpdateDirectoryProvisioningRequestContent = {
       mapping: payload.mapping,
       synchronize_automatically: payload.synchronize_automatically,
+      ...(payload.synchronize_groups && { synchronize_groups: payload.synchronize_groups }),
     };
 
     await this.client.connections.directoryProvisioning.update(connectionId, updatePayload);
@@ -529,6 +550,48 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     }
     await this.client.connections.directoryProvisioning.delete(connectionId);
     log.debug(`Deleted directory provisioning for connection '${connectionId}'`);
+  }
+
+  /**
+   * Retrieves all synchronized groups for a connection using checkpoint pagination.
+   */
+  async getConnectionSynchronizedGroups(
+    connectionId: string
+  ): Promise<Array<{ id: string }> | null> {
+    try {
+      const groups: Array<{ id: string }> = [];
+      let page = await this.client.connections.directoryProvisioning.listSynchronizedGroups(
+        connectionId,
+        {}
+      );
+      for (const g of page.data ?? []) groups.push({ id: g.id });
+      while (page.hasNextPage?.()) {
+        page = await page.getNextPage();
+        for (const g of page.data ?? []) groups.push({ id: g.id });
+      }
+      return groups;
+    } catch (error) {
+      const errLog = `Unable to fetch synchronized groups for connection '${connectionId}'. `;
+      const statusCode = (error as any)?.statusCode;
+      if (statusCode != null && [403, 404, 501].includes(statusCode)) {
+        const bodyMessage =
+          error instanceof ManagementError ? (error.body as any)?.message : error.message;
+        log.warn(errLog + bodyMessage);
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Replaces the synchronized groups for a connection (PUT replace-all semantics).
+   */
+  private async updateConnectionSynchronizedGroups(
+    connectionId: string,
+    groups: Array<{ id: string }>
+  ): Promise<void> {
+    await this.client.connections.directoryProvisioning.set(connectionId, { groups });
+    log.debug(`Updated synchronized groups for connection '${connectionId}'`);
   }
 
   /**
@@ -631,6 +694,31 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
           .join('\n')}`
       );
     }
+
+    // Process synchronized groups for connections where synchronize_groups === 'selected'
+    const connectionsToSyncGroups = [
+      ...directoryConnectionsToCreate,
+      ...directoryConnectionsToUpdate,
+    ].filter(
+      (conn) =>
+        conn.directory_provisioning_configuration?.synchronize_groups === 'selected' &&
+        conn.directory_provisioning_configuration?.synchronized_groups !== undefined
+    );
+
+    await this.client.pool
+      .addEachTask({
+        data: connectionsToSyncGroups,
+        generator: (conn) =>
+          this.updateConnectionSynchronizedGroups(
+            conn.id!,
+            conn.directory_provisioning_configuration!.synchronized_groups!
+          ).catch((err) => {
+            throw new Error(
+              `Failed to update synchronized groups for connection '${conn.id}':\n${err}`
+            );
+          }),
+      })
+      .promise();
   }
 
   async getType(): Promise<Asset[] | null> {
@@ -685,7 +773,18 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
               connection.directory_provisioning_configuration = {
                 mapping: dirProvConfig.mapping,
                 synchronize_automatically: dirProvConfig.synchronize_automatically,
+                ...(dirProvConfig.synchronize_groups && {
+                  synchronize_groups: dirProvConfig.synchronize_groups,
+                }),
               };
+
+              if (dirProvConfig.synchronize_groups === 'selected') {
+                const syncedGroups = await this.getConnectionSynchronizedGroups(con.id);
+                if (syncedGroups?.length) {
+                  connection.directory_provisioning_configuration.synchronized_groups =
+                    syncedGroups;
+                }
+              }
             }
           }
 

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -22,6 +22,7 @@ describe('#YAML context connections', () => {
           domain: somedomain.com
           waad_protocol: "openid-connect"
           api_enable_users: true
+          api_enable_groups: true
           basic_profile: true
           ext_profile: true
           ext_groups: true
@@ -46,6 +47,7 @@ describe('#YAML context connections', () => {
       {
         name: 'test-waad',
         options: {
+          api_enable_groups: true,
           api_enable_users: true,
           basic_profile: true,
           client_id: 'my_client_id',

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -862,9 +862,7 @@ describe('#connections handler', () => {
         const setSyncGroupsStub = sinon
           .stub(handler, 'updateConnectionSynchronizedGroups')
           .resolves();
-        const createStub = sinon
-          .stub(handler, 'createConnectionDirectoryProvisioning')
-          .resolves();
+        const createStub = sinon.stub(handler, 'createConnectionDirectoryProvisioning').resolves();
 
         await handler.processConnectionDirectoryProvisioning({
           create: [
@@ -885,9 +883,7 @@ describe('#connections handler', () => {
         });
 
         expect(createStub.calledOnce).to.be.true;
-        expect(
-          setSyncGroupsStub.calledOnceWith('con1', [{ id: 'group1' }])
-        ).to.be.true;
+        expect(setSyncGroupsStub.calledOnceWith('con1', [{ id: 'group1' }])).to.be.true;
       });
 
       it('should not call set() when synchronize_groups is not selected', async () => {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -380,6 +380,48 @@ describe('#connections handler', () => {
         .that.deep.equals(dirProvConfig);
     });
 
+    it('should include synchronized_groups in export when synchronize_groups is selected', async () => {
+      const auth0 = {
+        connections: {
+          list: (params) =>
+            mockPagedData(params, 'connections', [
+              { id: 'con1', strategy: 'google-apps', name: 'gsuite', options: {} },
+            ]),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      sinon.stub(connections, 'getConnectionEnabledClients').resolves(undefined);
+      const dirProvConfigs = [
+        {
+          connection_id: 'con1',
+          mapping: [{ auth0: 'email', idp: 'mail' }],
+          synchronize_automatically: false,
+          synchronize_groups: 'selected',
+        },
+      ];
+      const syncedGroups = [{ id: 'group1' }, { id: 'group2' }];
+      sinon.stub(handler, 'getConnectionDirectoryProvisionings').resolves(dirProvConfigs);
+      sinon.stub(handler, 'getConnectionSynchronizedGroups').resolves(syncedGroups);
+      handler.scimHandler.applyScimConfiguration = sinon.stub().resolves();
+
+      const data = await handler.getType();
+
+      expect(handler.getConnectionSynchronizedGroups.calledOnceWith('con1')).to.be.true;
+      expect(data[0])
+        .to.have.property('directory_provisioning_configuration')
+        .that.deep.equals({
+          mapping: [{ auth0: 'email', idp: 'mail' }],
+          synchronize_automatically: false,
+          synchronize_groups: 'selected',
+          synchronized_groups: syncedGroups,
+        });
+    });
+
     it('should update connection', async () => {
       const auth0 = {
         connections: {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -32,9 +32,16 @@ describe('#connections handler', () => {
   };
 
   describe('#connections schema', () => {
-    it('should allow supported dpop_signing_alg values', () => {
+    it('should allow explicitly supported connection option fields', () => {
       const ajv = new Ajv({ useDefaults: true, nullable: true });
       const assets = [
+        {
+          name: 'google-workspace',
+          strategy: 'google-apps',
+          options: {
+            api_enable_groups: true,
+          },
+        },
         {
           name: 'oidc-connection',
           strategy: 'oidc',
@@ -223,6 +230,81 @@ describe('#connections handler', () => {
 
       await stageFn.apply(handler, [
         { connections: [{ name: 'someConnection', enabled_clients: ['client1'] }] },
+      ]);
+    });
+
+    it('should preserve api_enable_groups in connection options', async () => {
+      const auth0 = {
+        connections: {
+          create: function (data) {
+            (() => expect(this).to.not.be.undefined)();
+            expect(data).to.be.an('object');
+            expect(data).to.deep.equal({
+              name: 'google-workspace',
+              strategy: 'google-apps',
+              options: {
+                domain: 'example.com',
+                api_enable_groups: true,
+              },
+            });
+            return Promise.resolve({ data: { ...data, id: 'con_google' } });
+          },
+          get: () =>
+            Promise.resolve({
+              id: 'con_google',
+              name: 'google-workspace',
+              strategy: 'google-apps',
+              options: { domain: 'example.com', api_enable_groups: true },
+            }),
+          update: () => Promise.resolve({ data: [] }),
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => {
+            if (params.name === 'google-workspace') {
+              return mockPagedData(params, 'connections', [
+                {
+                  id: 'con_google',
+                  name: 'google-workspace',
+                  strategy: 'google-apps',
+                  options: { domain: 'example.com', api_enable_groups: true },
+                },
+              ]);
+            }
+
+            return mockPagedData(params, 'connections', []);
+          },
+          _getRestClient: () => ({}),
+          clients: {
+            get: () => Promise.resolve(mockPagedData({}, 'clients', [])),
+            update: (connectionId) => {
+              expect(connectionId).to.equal('con_google');
+              return Promise.resolve({});
+            },
+          },
+        },
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ name: 'client1', client_id: 'client_id_1' }]),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          connections: [
+            {
+              name: 'google-workspace',
+              strategy: 'google-apps',
+              enabled_clients: ['client1'],
+              options: {
+                domain: 'example.com',
+                api_enable_groups: true,
+              },
+            },
+          ],
+        },
       ]);
     });
 
@@ -624,6 +706,231 @@ describe('#connections handler', () => {
         await handler.deleteConnectionDirectoryProvisioning('con-del');
 
         expect(deleteStub.calledOnceWith('con-del')).to.be.true;
+      });
+
+      it('should include synchronize_groups in create payload', async () => {
+        const createStub = sinon.stub().resolves();
+        const auth0 = {
+          connections: { directoryProvisioning: { create: createStub } },
+          pool,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        await handler.createConnectionDirectoryProvisioning('con1', {
+          mapping: sampleMapping,
+          synchronize_groups: 'selected',
+        });
+
+        expect(
+          createStub.calledOnceWith(
+            'con1',
+            sinon.match({ mapping: sampleMapping, synchronize_groups: 'selected' })
+          )
+        ).to.be.true;
+      });
+
+      it('should omit synchronize_groups from create payload when not provided', async () => {
+        const createStub = sinon.stub().resolves();
+        const auth0 = {
+          connections: { directoryProvisioning: { create: createStub } },
+          pool,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        await handler.createConnectionDirectoryProvisioning('con1', { mapping: sampleMapping });
+
+        const calledPayload = createStub.firstCall.args[1];
+        expect(calledPayload).to.not.have.property('synchronize_groups');
+      });
+
+      it('should include synchronize_groups in update payload', async () => {
+        const updateStub = sinon.stub().resolves();
+        const auth0 = { connections: { directoryProvisioning: { update: updateStub } } };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        await handler.updateConnectionDirectoryProvisioning('con1', {
+          mapping: sampleMapping,
+          synchronize_automatically: true,
+          synchronize_groups: 'all',
+        });
+
+        expect(
+          updateStub.calledOnceWith(
+            'con1',
+            sinon.match({ synchronize_groups: 'all', synchronize_automatically: true })
+          )
+        ).to.be.true;
+      });
+
+      it('should omit synchronize_groups from update payload when not provided', async () => {
+        const updateStub = sinon.stub().resolves();
+        const auth0 = { connections: { directoryProvisioning: { update: updateStub } } };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        await handler.updateConnectionDirectoryProvisioning('con1', {
+          mapping: sampleMapping,
+          synchronize_automatically: false,
+        });
+
+        const calledPayload = updateStub.firstCall.args[1];
+        expect(calledPayload).to.not.have.property('synchronize_groups');
+      });
+
+      it('should fetch and paginate synchronized groups', async () => {
+        const page1 = {
+          data: [{ id: 'group1' }, { id: 'group2' }],
+          hasNextPage: sinon.stub().onFirstCall().returns(true).onSecondCall().returns(false),
+        };
+        page1.getNextPage = sinon.stub().resolves({
+          data: [{ id: 'group3' }],
+          hasNextPage: sinon.stub().returns(false),
+        });
+
+        const auth0 = {
+          connections: {
+            directoryProvisioning: {
+              listSynchronizedGroups: sinon.stub().resolves(page1),
+            },
+          },
+          pool,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        const result = await handler.getConnectionSynchronizedGroups('con1');
+
+        expect(result).to.deep.equal([{ id: 'group1' }, { id: 'group2' }, { id: 'group3' }]);
+      });
+
+      it('should return null and log warning when listSynchronizedGroups returns 403', async () => {
+        const err = new Error('Forbidden');
+        err.statusCode = 403;
+        err.body = { message: 'Feature not enabled' };
+
+        const auth0 = {
+          connections: {
+            directoryProvisioning: {
+              listSynchronizedGroups: sinon.stub().rejects(err),
+            },
+          },
+          pool,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        const result = await handler.getConnectionSynchronizedGroups('con1');
+
+        expect(result).to.be.null;
+      });
+
+      it('should call set() when updating synchronized groups', async () => {
+        const setStub = sinon.stub().resolves();
+        const auth0 = {
+          connections: { directoryProvisioning: { set: setStub } },
+          pool,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        await handler.updateConnectionSynchronizedGroups('con1', [
+          { id: 'group1' },
+          { id: 'group2' },
+        ]);
+
+        expect(
+          setStub.calledOnceWith('con1', {
+            groups: [{ id: 'group1' }, { id: 'group2' }],
+          })
+        ).to.be.true;
+      });
+
+      it('should call set() for connections with synchronize_groups === selected in processConnectionDirectoryProvisioning', async () => {
+        const poolExecutor = {
+          addEachTask: ({ data, generator }) => ({
+            promise: async () => {
+              for (const item of data || []) await generator(item);
+            },
+          }),
+        };
+
+        const auth0 = {
+          connections: { directoryProvisioning: {} },
+          clients: { list: (params) => mockPagedData(params, 'clients', []) },
+          pool: poolExecutor,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        handler.existing = [];
+
+        const setSyncGroupsStub = sinon
+          .stub(handler, 'updateConnectionSynchronizedGroups')
+          .resolves();
+        const createStub = sinon
+          .stub(handler, 'createConnectionDirectoryProvisioning')
+          .resolves();
+
+        await handler.processConnectionDirectoryProvisioning({
+          create: [
+            {
+              id: 'con1',
+              name: 'gsuite-new',
+              strategy: 'google-apps',
+              directory_provisioning_configuration: {
+                mapping: sampleMapping,
+                synchronize_groups: 'selected',
+                synchronized_groups: [{ id: 'group1' }],
+              },
+            },
+          ],
+          update: [],
+          conflicts: [],
+          del: [],
+        });
+
+        expect(createStub.calledOnce).to.be.true;
+        expect(
+          setSyncGroupsStub.calledOnceWith('con1', [{ id: 'group1' }])
+        ).to.be.true;
+      });
+
+      it('should not call set() when synchronize_groups is not selected', async () => {
+        const poolExecutor = {
+          addEachTask: ({ data, generator }) => ({
+            promise: async () => {
+              for (const item of data || []) await generator(item);
+            },
+          }),
+        };
+
+        const auth0 = {
+          connections: { directoryProvisioning: {} },
+          clients: { list: (params) => mockPagedData(params, 'clients', []) },
+          pool: poolExecutor,
+        };
+
+        const handler = new connections.default({ client: pageClient(auth0), config });
+        handler.existing = [];
+
+        const setSyncGroupsStub = sinon
+          .stub(handler, 'updateConnectionSynchronizedGroups')
+          .resolves();
+        sinon.stub(handler, 'createConnectionDirectoryProvisioning').resolves();
+
+        await handler.processConnectionDirectoryProvisioning({
+          create: [
+            {
+              id: 'con1',
+              name: 'gsuite-new',
+              strategy: 'google-apps',
+              directory_provisioning_configuration: {
+                mapping: sampleMapping,
+                synchronize_groups: 'all',
+              },
+            },
+          ],
+          update: [],
+          conflicts: [],
+          del: [],
+        });
+
+        expect(setSyncGroupsStub.called).to.be.false;
       });
     });
 


### PR DESCRIPTION
### 🔧 Changes

- Add support for `api_enable_groups` on connection options so Google Workspace connections can preserve inbound group provisioning settings during import and export.
- `directory_provisioning_configuration.synchronize_groups` and `synchronized_groups`, which lets Deploy CLI describe whether all groups or only selected groups should sync.
- Update directory provisioning create and update flows to pass `synchronize_groups` through to the Management API, and add synchronized-group replacement logic when the connection uses `synchronize_groups: selected`.


### Examples

#### YAML format

```yaml
connections:
  - name: google-apps
    strategy: google-apps
    options:
      domain: example.com
      tenant_domain: example.com
      client_id: some_client_id
      client_secret: some_client_secret
      api_enable_groups: true
      api_enable_users: true
    directory_provisioning_configuration:
      synchronize_groups: selected
      synchronized_groups:
        - id: group_123
```

#### JSON format

```json
{
  "name": "google-apps",
  "strategy": "google-apps",
  "options": {
    "domain": "example.com",
    "tenant_domain": "example.com",
    "client_id": "some_client_id",
    "client_secret": "some_client_secret",
    "api_enable_groups": true,
    "api_enable_users": true
  },
  "directory_provisioning_configuration": {
    "synchronize_groups": "selected",
    "synchronized_groups": [
      {
        "id": "group_123"
      }
    ]
  }
}
```

### 🔬 Testing

- Run `npm test` to validate the new schema fields, connection option passthrough, directory provisioning payloads, synchronized-group pagination, and YAML parsing updates.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
