### PR TITLE
feat: add Deploy CLI support for ACR authorization_policy on Auth0 My Account API resource server

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -411,6 +411,43 @@ resourceServers:
 }
 ```
 
+### Auth0 My Account API — `authorization_policy`
+
+The `authorization_policy` field can be set on the **Auth0 My Account API** resource server (the system resource server with identifier `https://<tenant-domain>/me/`) when the `acr` feature flag is enabled on the tenant. It specifies an Authentication Context Class Reference (ACR) policy that controls the authentication assurance requirements for access tokens issued to that API.
+
+**YAML Example**
+
+```yaml
+resourceServers:
+  - name: Auth0 My Account API
+    identifier: https://your-tenant.auth0.com/me/
+    authorization_policy:
+      policy_id: "019b76da-a800-73c9-b656-b349ae415c17"
+```
+
+To clear the policy, set it to `null`:
+
+```yaml
+resourceServers:
+  - name: Auth0 My Account API
+    identifier: https://your-tenant.auth0.com/me/
+    authorization_policy: null
+```
+
+**Directory Example**
+
+```json
+{
+  "name": "Auth0 My Account API",
+  "identifier": "https://your-tenant.auth0.com/me/",
+  "authorization_policy": {
+    "policy_id": "019b76da-a800-73c9-b656-b349ae415c17"
+  }
+}
+```
+
+> **Note:** `authorization_policy` is only accepted by the Auth0 API for the My Account resource server and only when the `acr` feature flag is enabled on the tenant.
+
 ## Universal Login
 
 ### Pages

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -422,7 +422,7 @@ resourceServers:
   - name: Auth0 My Account API
     identifier: https://your-tenant.auth0.com/me/
     authorization_policy:
-      policy_id: "019b76da-a800-73c9-b656-b349ae415c17"
+      policy_id: '019b76da-a800-73c9-b656-b349ae415c17'
 ```
 
 To clear the policy, set it to `null`:

--- a/examples/directory/resource-servers/Auth0 My Account API.json
+++ b/examples/directory/resource-servers/Auth0 My Account API.json
@@ -1,0 +1,9 @@
+{
+  "name": "Auth0 My Account API",
+  "identifier": "https://##AUTH0_DOMAIN##/me/",
+  "token_lifetime": 86400,
+  "skip_consent_for_verifiable_first_party_clients": true,
+  "authorization_policy": {
+    "policy_id": "019b76da-a800-73c9-b656-b349ae415c17"
+  }
+}

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -191,6 +191,12 @@ resourceServers:
         description: "read account"
     # client_id: "if linked to a resource server client (readonly)"
     # Add other resource server settings (https://auth0.com/docs/api/management/v2#!/Resource_Servers/post_resource_servers)
+  -
+    name: "Auth0 My Account API"
+    identifier: "https://##AUTH0_DOMAIN##/me/"
+    # authorization_policy is only applicable to the My Account API when the acr feature flag is enabled
+    authorization_policy:
+      policy_id: "019b76da-a800-73c9-b656-b349ae415c17"
 
 tokenExchangeProfiles:
   - name: "Custom Authentication Profile"

--- a/src/tools/auth0/handlers/resourceServers.ts
+++ b/src/tools/auth0/handlers/resourceServers.ts
@@ -132,6 +132,7 @@ export default class ResourceServersHandler extends DefaultHandler {
             'identifier',
             'id',
             'is_system',
+            'authorization_policy',
           ];
           const sanitized: any = {};
           allowedKeys.forEach((key) => {
@@ -204,6 +205,7 @@ export default class ResourceServersHandler extends DefaultHandler {
         skip_consent_for_verifiable_first_party_clients:
           update.skip_consent_for_verifiable_first_party_clients,
         subject_type_authorization: update.subject_type_authorization,
+        authorization_policy: update.authorization_policy,
       };
 
       return this.client.resourceServers.update(id, updateFields);

--- a/test/tools/auth0/handlers/resourceServers.tests.js
+++ b/test/tools/auth0/handlers/resourceServers.tests.js
@@ -784,6 +784,122 @@ describe('#resourceServers handler', () => {
       });
     });
 
+    it('should preserve authorization_policy on system resource server export (getType)', async () => {
+      const systemResourceServer = {
+        id: 'rs_system',
+        identifier: 'https://api.system.com/me/',
+        name: 'Auth0 My Account API',
+        is_system: true,
+        token_lifetime: 86400,
+        skip_consent_for_verifiable_first_party_clients: true,
+        authorization_policy: { policy_id: '019b76da-a800-73c9-b656-b349ae415c17' },
+        scopes: [{ value: 'read:users' }], // Should be removed
+        signing_alg: 'RS256', // Should be removed
+      };
+
+      const auth0 = {
+        resourceServers: {
+          list: (params) => mockPagedData(params, 'resource_servers', [systemResourceServer]),
+        },
+        pool,
+      };
+
+      const handler = new resourceServers.default({ client: pageClient(auth0), config });
+      const result = await handler.getType();
+
+      expect(result[0]).to.have.property('authorization_policy');
+      expect(result[0].authorization_policy).to.deep.equal({
+        policy_id: '019b76da-a800-73c9-b656-b349ae415c17',
+      });
+      expect(result[0]).to.not.have.property('scopes');
+      expect(result[0]).to.not.have.property('signing_alg');
+    });
+
+    it('should include authorization_policy in update payload for Auth0 My Account API', async () => {
+      let updateCalledWith = null;
+      const existingResourceServer = {
+        id: 'rs_my_account',
+        identifier: 'https://auth0.com/my-account/me/',
+        name: 'Auth0 My Account API',
+        is_system: true,
+      };
+
+      const auth0 = {
+        resourceServers: {
+          create: () => Promise.resolve({ data: [] }),
+          update: function (id, data) {
+            updateCalledWith = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'resource_servers', [existingResourceServer]),
+        },
+        pool,
+      };
+
+      const handler = new resourceServers.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          resourceServers: [
+            {
+              name: 'Auth0 My Account API',
+              identifier: 'https://auth0.com/my-account/me/',
+              authorization_policy: { policy_id: '019b76da-a800-73c9-b656-b349ae415c17' },
+            },
+          ],
+        },
+      ]);
+
+      expect(updateCalledWith).to.not.equal(null);
+      expect(updateCalledWith.authorization_policy).to.deep.equal({
+        policy_id: '019b76da-a800-73c9-b656-b349ae415c17',
+      });
+    });
+
+    it('should include authorization_policy: null in update payload for Auth0 My Account API (clearing the policy)', async () => {
+      let updateCalledWith = null;
+      const existingResourceServer = {
+        id: 'rs_my_account',
+        identifier: 'https://auth0.com/my-account/me/',
+        name: 'Auth0 My Account API',
+        is_system: true,
+        authorization_policy: { policy_id: '019b76da-a800-73c9-b656-b349ae415c17' },
+      };
+
+      const auth0 = {
+        resourceServers: {
+          create: () => Promise.resolve({ data: [] }),
+          update: function (id, data) {
+            updateCalledWith = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'resource_servers', [existingResourceServer]),
+        },
+        pool,
+      };
+
+      const handler = new resourceServers.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          resourceServers: [
+            {
+              name: 'Auth0 My Account API',
+              identifier: 'https://auth0.com/my-account/me/',
+              authorization_policy: null,
+            },
+          ],
+        },
+      ]);
+
+      expect(updateCalledWith).to.not.equal(null);
+      expect(updateCalledWith.authorization_policy).to.equal(null);
+    });
+
     it('should update "Auth0 My Account API" without name and is_system', async () => {
       let updateCalled = false;
       const existingResourceServer = {


### PR DESCRIPTION
### 🔧 Changes

Add Deploy CLI support for ACR `authorization_policy` on Auth0 My Account API resource server.
                                                                                                                                                                                
  - Added `authorization_policy` to the `allowedKeys` list in `getType()` so the field is preserved when exporting the My Account API (previously stripped silently, causing the next import to always attempt to clear it)                                                                                                                                   
  - Added `authorization_policy` to the hard-coded update payload in `updateResourceServer()` so the field is included in PATCH calls for system resource servers (previously never sent, making it impossible to set or clear via Deploy CLI)                                                                                                            
  - Updated docs and examples for both YAML and directory formats


YAML format:    

```yaml                                                                                                                                                              
  resourceServers:                                                                                                                                                              
    - name: "Auth0 My Account API"                                                                                                                                              
      identifier: "https://your-tenant.auth0.com/me/"
      authorization_policy:
        policy_id: "019b76da-a800-73c9-b656-b349ae415c17"
```

  To clear the policy:

```yaml 
  resourceServers:
    - name: "Auth0 My Account API"
      identifier: "https://your-tenant.auth0.com/me/"
      authorization_policy: null
```

  Directory (JSON) format - resource-servers/Auth0 My Account API.json:
```yaml 
  {
    "name": "Auth0 My Account API",
    "identifier": "https://your-tenant.auth0.com/me/",
    "authorization_policy": {
      "policy_id": "019b76da-a800-73c9-b656-b349ae415c17"
    }
  }
```

### 📚 References

### 🔬 Testing

Three new unit tests added to `test/tools/auth0/handlers/resourceServers.tests.js`:

  - `should preserve authorization_policy on system resource server export (getType)` - verifies field is not stripped on export
  - `should include authorization_policy in update payload for Auth0 My Account API` - verifies field is sent in PATCH body when setting a policy
  - `should include authorization_policy: null in update payload for Auth0 My Account API` - verifies `null` is passed through correctly to clear the policy

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
