### PR TITLE
feat: add organization_id support to connected_accounts schema for Token Vault org binding

### DIFF
--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -90,7 +90,7 @@ export const schema = {
         type: 'object',
         properties: {
           active: { type: 'boolean' },
-          organization_id: { type: 'string' },
+          organization_name: { type: 'string' },
         },
         required: ['active'],
         additionalProperties: false,
@@ -142,6 +142,10 @@ export type Connection = Management.ConnectionForList & {
     'mapping' | 'synchronize_automatically' | 'synchronize_groups'
   > & {
     synchronized_groups?: Array<{ id: string }>;
+  };
+  connected_accounts?: Management.ConnectionConnectedAccountsPurpose & {
+    organization_id?: string;
+    organization_name?: string;
   };
 };
 
@@ -725,11 +729,14 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
   async getType(): Promise<Asset[] | null> {
     if (this.existing) return this.existing;
 
-    const [connections, directoryProvisioningConfigs] = await Promise.all([
+    const [connections, directoryProvisioningConfigs, organizations] = await Promise.all([
       paginate<Connection>(this.client.connections.list, {
         checkpoint: true,
       }),
       this.getConnectionDirectoryProvisionings(),
+      paginate<Management.Organization>(this.client.organizations.list, {
+        checkpoint: true,
+      }).catch(() => [] as Management.Organization[]),
     ]);
     // Filter out database connections as we have separate handler for it
     const filteredConnections = connections.filter((c) => c.strategy !== 'auth0');
@@ -763,6 +770,15 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
 
           if (enabledClients?.length) {
             connection.enabled_clients = enabledClients;
+          }
+
+          const connectedAccounts = connection.connected_accounts;
+          if (connectedAccounts?.organization_id) {
+            const org = organizations.find((o) => o.id === connectedAccounts.organization_id);
+            if (org?.name) {
+              const { organization_id, ...rest } = connectedAccounts;
+              connection.connected_accounts = { ...rest, organization_name: org.name };
+            }
           }
 
           if (connection.strategy === 'google-apps' && directoryProvisioningConfigs) {
@@ -817,15 +833,19 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
       };
 
     // Convert enabled_clients by name to the id
-    const clients = await paginate<Client>(this.client.clients.list, {
-      paginate: true,
-      include_totals: true,
-    });
-
-    const existingConnections = await paginate<Connection>(this.client.connections.list, {
-      checkpoint: true,
-      include_totals: true,
-    });
+    const [clients, existingConnections, organizations] = await Promise.all([
+      paginate<Client>(this.client.clients.list, {
+        paginate: true,
+        include_totals: true,
+      }),
+      paginate<Connection>(this.client.connections.list, {
+        checkpoint: true,
+        include_totals: true,
+      }),
+      paginate<Management.Organization>(this.client.organizations.list, {
+        checkpoint: true,
+      }).catch(() => [] as Management.Organization[]),
+    ]);
 
     // Prepare an id map. We'll use this map later to get the `strategy` and SCIM enable status of the connections.
     await this.scimHandler.createIdMap(existingConnections);
@@ -833,10 +853,20 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
     const formatted = connections.map((connection) => {
       const enabledClients = getEnabledClients(assets, connection, existingConnections, clients);
 
+      let connected_accounts = connection.connected_accounts;
+      if (connected_accounts?.organization_name) {
+        const org = organizations.find((o) => o.name === connected_accounts.organization_name);
+        if (org?.id) {
+          const { organization_name, ...rest } = connected_accounts;
+          connected_accounts = { ...rest, organization_id: org.id };
+        }
+      }
+
       return {
         ...connection,
         ...this.getFormattedOptions(connection, clients),
         ...(enabledClients !== undefined && { enabled_clients: enabledClients }),
+        ...(connected_accounts !== connection.connected_accounts && { connected_accounts }),
       };
     });
 
@@ -863,25 +893,39 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
       };
     }
 
-    const clients = await paginate<Client>(this.client.clients.list, {
-      paginate: true,
-      include_totals: true,
-    });
-
-    const existingConnections = await paginate<Connection>(this.client.connections.list, {
-      checkpoint: true,
-      include_totals: true,
-    });
+    const [clients, existingConnections, organizations] = await Promise.all([
+      paginate<Client>(this.client.clients.list, {
+        paginate: true,
+        include_totals: true,
+      }),
+      paginate<Connection>(this.client.connections.list, {
+        checkpoint: true,
+        include_totals: true,
+      }),
+      paginate<Management.Organization>(this.client.organizations.list, {
+        checkpoint: true,
+      }).catch(() => [] as Management.Organization[]),
+    ]);
 
     await this.scimHandler.createIdMap(existingConnections);
 
     const formatted = connections.map((connection) => {
       const enabledClients = getEnabledClients(assets, connection, existingConnections, clients);
 
+      let connected_accounts = connection.connected_accounts;
+      if (connected_accounts?.organization_name) {
+        const org = organizations.find((o) => o.name === connected_accounts.organization_name);
+        if (org?.id) {
+          const { organization_name, ...rest } = connected_accounts;
+          connected_accounts = { ...rest, organization_id: org.id };
+        }
+      }
+
       return {
         ...connection,
         ...this.getFormattedOptions(connection, clients),
         ...(enabledClients !== undefined && { enabled_clients: enabledClients }),
+        ...(connected_accounts !== connection.connected_accounts && { connected_accounts }),
       };
     });
 

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -90,6 +90,7 @@ export const schema = {
         type: 'object',
         properties: {
           active: { type: 'boolean' },
+          organization_id: { type: 'string' },
         },
         required: ['active'],
         additionalProperties: false,

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -488,7 +488,7 @@ describe('#connections handler', () => {
       await stageFn.apply(handler, [{ connections: data }]);
     });
 
-    it('should update connection with organization_id in connected_accounts', async () => {
+    it('should resolve organization_name to organization_id in connected_accounts on import', async () => {
       const auth0 = {
         connections: {
           create: function (data) {
@@ -500,9 +500,9 @@ describe('#connections handler', () => {
             (() => expect(this).to.not.be.undefined)();
             expect(id).to.equal('con1');
             expect(data).to.not.have.property('enabled_clients');
-            expect(data).to.deep.equal({
-              options: { passwordPolicy: 'testPolicy' },
-              connected_accounts: { active: true, organization_id: 'org_abc123' },
+            expect(data.connected_accounts).to.deep.equal({
+              active: true,
+              organization_id: 'org_abc123',
             });
             return Promise.resolve({ ...data, id });
           },
@@ -525,6 +525,12 @@ describe('#connections handler', () => {
               { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' },
             ]),
         },
+        organizations: {
+          list: (params) =>
+            mockPagedData(params, 'organizations', [
+              { id: 'org_abc123', name: 'My Org' },
+            ]),
+        },
         pool,
       };
 
@@ -535,17 +541,51 @@ describe('#connections handler', () => {
           name: 'someConnection',
           strategy: 'custom',
           enabled_clients: ['client1'],
-          options: {
-            passwordPolicy: 'testPolicy',
-          },
+          options: { passwordPolicy: 'testPolicy' },
           connected_accounts: {
             active: true,
-            organization_id: 'org_abc123',
+            organization_name: 'My Org',
           },
         },
       ];
 
       await stageFn.apply(handler, [{ connections: data }]);
+    });
+
+    it('should resolve organization_id to organization_name in connected_accounts on export', async () => {
+      const auth0 = {
+        connections: {
+          list: (params) =>
+            mockPagedData(params, 'connections', [
+              {
+                id: 'con1',
+                strategy: 'github',
+                name: 'github',
+                connected_accounts: { active: true, organization_id: 'org_abc123' },
+              },
+            ]),
+          clients: {
+            get: () => Promise.resolve(mockPagedData({}, 'clients', [])),
+          },
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        organizations: {
+          list: (params) =>
+            mockPagedData(params, 'organizations', [{ id: 'org_abc123', name: 'My Org' }]),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      sinon.stub(connections, 'getConnectionEnabledClients').resolves(undefined);
+      handler.scimHandler.applyScimConfiguration = sinon.stub().resolves();
+
+      const data = await handler.getType();
+
+      expect(data[0].connected_accounts).to.deep.equal({ active: true, organization_name: 'My Org' });
+      expect(data[0].connected_accounts).to.not.have.property('organization_id');
     });
 
     it('should convert client name with ID in idpinitiated.client_id', async () => {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -488,6 +488,66 @@ describe('#connections handler', () => {
       await stageFn.apply(handler, [{ connections: data }]);
     });
 
+    it('should update connection with organization_id in connected_accounts', async () => {
+      const auth0 = {
+        connections: {
+          create: function (data) {
+            (() => expect(this).to.not.be.undefined)();
+            expect(data).to.be.an('undefined');
+            return Promise.resolve({ data });
+          },
+          update: function (id, data) {
+            (() => expect(this).to.not.be.undefined)();
+            expect(id).to.equal('con1');
+            expect(data).to.not.have.property('enabled_clients');
+            expect(data).to.deep.equal({
+              options: { passwordPolicy: 'testPolicy' },
+              connected_accounts: { active: true, organization_id: 'org_abc123' },
+            });
+            return Promise.resolve({ ...data, id });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) =>
+            mockPagedData(params, 'connections', [
+              { name: 'someConnection', id: 'con1', strategy: 'custom' },
+            ]),
+          _getRestClient: () => ({}),
+          clients: {
+            update: (connectionId) => {
+              expect(connectionId).to.equal('con1');
+              return Promise.resolve({});
+            },
+          },
+        },
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [
+              { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' },
+            ]),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'someConnection',
+          strategy: 'custom',
+          enabled_clients: ['client1'],
+          options: {
+            passwordPolicy: 'testPolicy',
+          },
+          connected_accounts: {
+            active: true,
+            organization_id: 'org_abc123',
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ connections: data }]);
+    });
+
     it('should convert client name with ID in idpinitiated.client_id', async () => {
       const auth0 = {
         connections: {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

* Added `organization_id` as an optional string property to the `connected_accounts` schema in the connections handler. 
   * This prevents schema validation from rejecting or stripping the `organization_id` field returned by the Management API (`GET /v2/users/{id}/connected-accounts`) for accounts linked under an organization.

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
* Added a unit test verifying that a connection with `connected_accounts: { active: true, organization_id: 'org_abc123' }` correctly flows through `processChanges` and reaches the API update payload without being stripped or rejected.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
