### PR TITLE
feat: configurable ignoreDryRunFields via AUTH0_IGNORE_DRY_RUN_FIELDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AUTH0_IGNORE_DRY_RUN_FIELDS` configuration option, a map of handler type → field paths to exclude from `--dry-run` diff comparisons. Merges additively with each handler's built-in defaults so users can suppress noise from fields the Management API never returns (e.g. `client_secret`, action `secrets`, email provider `credentials.api_key`) without losing the curated defaults.
+
 ## [8.34.0] - 2026-05-11
 
 ### Added

--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -191,6 +191,25 @@ Provides ability to exclude any unwanted properties from management.
 }
 ```
 
+### `AUTH0_IGNORE_DRY_RUN_FIELDS`
+
+Object keyed by resource handler type, with values that are arrays of field paths to exclude from `--dry-run` diff comparisons. Useful for suppressing noisy diffs on fields the Management API never returns (e.g. secret values), so dry-run output focuses on changes you can actually verify.
+
+User-supplied fields are merged with the handler's built-in defaults; they do not replace them. Field paths support exact match, `.endsWith('.<field>')` suffix match, and `.endsWith('[<field>]')` suffix match (see `calculateDryRunChanges#shouldIgnoreDryRunField`).
+
+This option only affects `--dry-run` reporting. A non-dry-run import still sends every local field to the Management API.
+
+#### Example
+
+```json
+{
+  "clients": ["client_secret"],
+  "connections": ["options.client_secret"],
+  "actions": ["secrets"],
+  "emailProvider": ["credentials.api_key"]
+}
+```
+
 ### `AUTH0_AUDIENCE`
 
 String. Separate value from audience value while retrieving an access token for management API. Useful when default Management API endpoints are not publicly exposed.

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -171,6 +171,29 @@ export default class APIHandler {
     this.deleted = 0;
   }
 
+  /**
+   * Returns the effective `ignoreDryRunFields` for this handler, merging the
+   * handler's hardcoded defaults with any user-supplied entries from the
+   * `AUTH0_IGNORE_DRY_RUN_FIELDS[<type>]` config key. Read lazily so that the
+   * constructor remains free of config-provider invocations.
+   */
+  getEffectiveIgnoreDryRunFields(): string[] {
+    let configured: string[] = [];
+    try {
+      const map = this.config('AUTH0_IGNORE_DRY_RUN_FIELDS') as
+        | { [handlerType: string]: string[] }
+        | undefined;
+      if (map && Array.isArray(map[this.type])) {
+        configured = map[this.type];
+      }
+    } catch {
+      configured = [];
+    }
+    return [...this.ignoreDryRunFields, ...configured].filter(
+      (field, index, allFields) => allFields.indexOf(field) === index
+    );
+  }
+
   getClientFN(fn: ApiMethodOverride): Function {
     if (typeof fn === 'string') {
       const client = this.client[this.type];
@@ -290,7 +313,7 @@ export default class APIHandler {
         // @ts-ignore TODO: investigate what happens when `existing` is null
         existing,
         identifiers: this.identifiers,
-        ignoreDryRunFields: this.ignoreDryRunFields,
+        ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
       });
     }
 
@@ -328,7 +351,7 @@ export default class APIHandler {
       // @ts-ignore TODO: investigate what happens when `existing` is null
       existing,
       identifiers: this.identifiers,
-      ignoreDryRunFields: this.ignoreDryRunFields,
+      ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,9 @@ export type Config = {
   AUTH0_DRY_RUN?: boolean | 'preview';
   AUTH0_DRY_RUN_INTERACTIVE?: boolean;
   AUTH0_DRY_RUN_APPLY?: boolean;
+  AUTH0_IGNORE_DRY_RUN_FIELDS?: {
+    [handlerType: string]: string[];
+  };
   EXCLUDED_PROPS?: {
     [key: string]: string[];
   };

--- a/test/tools/auth0/handlers/default.tests.ts
+++ b/test/tools/auth0/handlers/default.tests.ts
@@ -230,4 +230,97 @@ describe('#default handler', () => {
       })
     ).to.be.rejectedWith(/Unresolved placeholder/);
   });
+
+  describe('AUTH0_IGNORE_DRY_RUN_FIELDS', () => {
+    it('should merge user-configured ignore fields with handler defaults', () => {
+      const configWithIgnore = ((key: string) => {
+        if (key === 'AUTH0_IGNORE_DRY_RUN_FIELDS') {
+          return { [mockAssetType]: ['user.added.field', 'another_user_field'] };
+        }
+        return undefined;
+      }) as any;
+
+      const handler = new mockHandler({
+        client: mockApiClient,
+        config: configWithIgnore,
+        type: mockAssetType,
+        ignoreDryRunFields: ['handler.default.field'],
+        functions: {},
+      });
+
+      expect(handler.getEffectiveIgnoreDryRunFields()).to.have.members([
+        'handler.default.field',
+        'user.added.field',
+        'another_user_field',
+      ]);
+    });
+
+    it('should dedupe overlapping ignore fields between config and handler defaults', () => {
+      const configWithIgnore = ((key: string) => {
+        if (key === 'AUTH0_IGNORE_DRY_RUN_FIELDS') {
+          return { [mockAssetType]: ['shared.field', 'user.only.field'] };
+        }
+        return undefined;
+      }) as any;
+
+      const handler = new mockHandler({
+        client: mockApiClient,
+        config: configWithIgnore,
+        type: mockAssetType,
+        ignoreDryRunFields: ['shared.field', 'handler.only.field'],
+        functions: {},
+      });
+
+      const effective = handler.getEffectiveIgnoreDryRunFields();
+      expect(effective).to.have.members(['shared.field', 'handler.only.field', 'user.only.field']);
+      expect(effective.filter((f) => f === 'shared.field')).to.have.length(1);
+    });
+
+    it('should ignore config entries for other handler types', () => {
+      const configWithIgnore = ((key: string) => {
+        if (key === 'AUTH0_IGNORE_DRY_RUN_FIELDS') {
+          return { 'some-other-type': ['unrelated.field'] };
+        }
+        return undefined;
+      }) as any;
+
+      const handler = new mockHandler({
+        client: mockApiClient,
+        config: configWithIgnore,
+        type: mockAssetType,
+        ignoreDryRunFields: ['handler.default.field'],
+        functions: {},
+      });
+
+      expect(handler.getEffectiveIgnoreDryRunFields()).to.deep.equal(['handler.default.field']);
+    });
+
+    it('should default to handler-only fields when config returns undefined', () => {
+      const handler = new mockHandler({
+        client: mockApiClient,
+        config,
+        type: mockAssetType,
+        ignoreDryRunFields: ['handler.default.field'],
+        functions: {},
+      });
+
+      expect(handler.getEffectiveIgnoreDryRunFields()).to.deep.equal(['handler.default.field']);
+    });
+
+    it('should tolerate a config provider that throws (e.g. uninitialized configFactory)', () => {
+      const throwingConfig = (() => {
+        throw new Error('A configuration provider has not been set');
+      }) as any;
+
+      const handler = new mockHandler({
+        client: mockApiClient,
+        config: throwingConfig,
+        type: mockAssetType,
+        ignoreDryRunFields: ['handler.default.field'],
+        functions: {},
+      });
+
+      expect(handler.getEffectiveIgnoreDryRunFields()).to.deep.equal(['handler.default.field']);
+    });
+  });
 });


### PR DESCRIPTION
### 🔧 Changes

Adds `AUTH0_IGNORE_DRY_RUN_FIELDS`, a new optional config key mapping handler type to an array of field paths to exclude from `--dry-run` diff comparisons. User-supplied entries are merged additively with each handler's built-in `ignoreDryRunFields` defaults, so the curated defaults (`smtp.credentials.smtp_pass`, `mandrill.credentials.api_key`, `_clientName`, etc.) cannot be accidentally dropped.

**Motivation.** The Management API does not echo secret values on read — `client_secret` on clients, `options.client_secret` on connections, action `secrets[].value`, and the email provider's `credentials.api_key` for non-SMTP/Mandrill providers (notably Mailgun). The corresponding local YAML fields therefore always surface as diffs in `--dry-run` output, drowning out signal on every run. Today the only knob is per-handler hardcoded arrays; the goal here is to let tenant configs silence the known-noisy fields for their setup without forking the CLI.

**Shape.** New optional config key, identical in shape to `EXCLUDED_PROPS`/`INCLUDED_PROPS`:

```jsonc
{
  "AUTH0_IGNORE_DRY_RUN_FIELDS": {
    "clients": ["client_secret"],
    "connections": ["options.client_secret"],
    "actions": ["secrets"],
    "emailProvider": ["credentials.api_key"]
  }
}
```

This only affects `--dry-run` reporting; a real import still sends every local field to the API as before.

**Backwards compatibility.** When the key is absent the handler behavior is byte-identical to today. The constructor read is wrapped in a `try/catch` so handlers constructed against an uninitialized `configFactory()` (as some unit tests do) continue to work.

**Files touched.** `src/types.ts`, `src/tools/auth0/handlers/default.ts`, `test/tools/auth0/handlers/default.tests.ts`, `docs/configuring-the-deploy-cli.md`, `CHANGELOG.md`. 119 LOC.

### 📚 References

N/A — no linked issue. Validated against a real tenant (Mailgun email provider, OIDC connection with `client_secret`, action with five `secrets[]` entries) where it cleanly suppresses the previously-noisy diff lines.

### 🔬 Testing

- New unit tests in `test/tools/auth0/handlers/default.tests.ts` covering: (1) merge of user-configured fields with handler defaults, (2) dedupe of overlapping entries, (3) isolation across handler types, (4) fallback when the config provider returns undefined.
- Full suite: `npm test` → 1228 passing / 1 pending (unchanged from main).
- `npm run lint`, `npm run format:check`, `npm run build`, `npx kacl lint` all clean.

Manual verification: ran `a0deploy import --dry-run --debug -c <stage.json> -i tenant.yaml` against a real Auth0 tenant; before this change, every dry-run logged a `found in 'localObj' but not in 'remoteObj'` line for `mailgun.credentials.api_key` and each entry of `handle-post-login.secrets`. With the config set, those become `Ignoring key … due to ignoreDryRunFields configuration` debug lines instead, and the noise disappears at non-debug levels.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
