### PR TITLE
fix: preserve keyword markers in themes for default export configuration

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -81,10 +81,7 @@ export const getPreservableFieldsFromAssets = (
         );
 
         if (specificAddress.length === 0) {
-          // If identifiers are registered for this resource type but none were found on the
-          // local array item (e.g. themeId stripped by default export), fall back to positional
-          // index so keyword markers are still preserved. Safe for singletons like themes.
-          // If no identifiers are registered at all (unrecognized nested arrays), skip.
+          // No identifiers registered: skip. Identifiers registered but absent from item: fall back to positional index.
           if (resourceIdentifiers.length === 0) {
             return [];
           }

--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -66,10 +66,10 @@ export const getPreservableFieldsFromAssets = (
         const specificAddress = resourceIdentifiers.reduce(
           (aggregateAddress, resourceIdentifier) => {
             resourceSpecificIdentifiers[address];
-            if (resourceIdentifier === undefined) return ''; // See if this specific resource type has an identifier
+            if (resourceIdentifier === undefined) return aggregateAddress; // See if this specific resource type has an identifier
 
             const identifierFieldValue = arrayItem[resourceIdentifier];
-            if (identifierFieldValue === undefined) return ''; // See if this specific array item possess the resource-specific identifier
+            if (identifierFieldValue === undefined) return aggregateAddress; // See if this specific array item possess the resource-specific identifier
 
             if (aggregateAddress === '') {
               return `${resourceIdentifier}=${identifierFieldValue}`;
@@ -81,7 +81,20 @@ export const getPreservableFieldsFromAssets = (
         );
 
         if (specificAddress.length === 0) {
-          return [];
+          // If identifiers are registered for this resource type but none were found on the
+          // local array item (e.g. themeId stripped by default export), fall back to positional
+          // index so keyword markers are still preserved. Safe for singletons like themes.
+          // If no identifiers are registered at all (unrecognized nested arrays), skip.
+          if (resourceIdentifiers.length === 0) {
+            return [];
+          }
+          const arrayIndex = (asset as any[]).indexOf(arrayItem);
+          return getPreservableFieldsFromAssets(
+            arrayItem,
+            keywordMappings,
+            resourceSpecificIdentifiers,
+            `${address}${shouldRenderDot ? '.' : ''}${arrayIndex}`
+          );
         }
 
         return getPreservableFieldsFromAssets(

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -429,7 +429,7 @@ export default class ThemesHandler extends DefaultHandler {
       ...options,
       type: 'themes',
       id: 'themeId',
-      identifiers: ['themeId', 'displayName'],
+      identifiers: ['themeId'],
     });
   }
 

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -429,7 +429,7 @@ export default class ThemesHandler extends DefaultHandler {
       ...options,
       type: 'themes',
       id: 'themeId',
-      identifiers: ['themeId'],
+      identifiers: ['themeId', 'displayName'],
     });
   }
 

--- a/test/tools/auth0/handlers/themes.tests.js
+++ b/test/tools/auth0/handlers/themes.tests.js
@@ -352,16 +352,68 @@ describe('#themes keyword preservation', () => {
     expect(result.themes[0].widget.logo_url).to.equal('##CDN_URL##/logo.png');
   });
 
-  it('should NOT preserve keyword placeholders when themeId is absent from handler identifiers', () => {
-    // Regression: prior to the fix, ThemesHandler used identifiers ['id', 'name'].
-    // getPreservableFieldsFromAssets looks for the identifier field on each array item to build
-    // a dot-notation address; if the field is missing (themes have themeId, not id/name),
-    // it silently returns no addresses and the raw remote URLs are returned unchanged.
+  it('should preserve keyword placeholders in theme fields when themeId is absent from local file (default export without AUTH0_EXPORT_IDENTIFIERS)', () => {
+    // Real-world scenario: exported with AUTH0_EXPORT_IDENTIFIERS: false (the default),
+    // so themeId is stripped from the local file. Keyword preservation must still work
+    // using displayName as a fallback identifier.
+    const localThemeWithoutThemeId = {
+      displayName: 'Default theme',
+      fonts: { font_url: '##CDN_URL##/fonts/custom.woff2' },
+      widget: { logo_url: '##CDN_URL##/logo.png' },
+    };
+
+    const remoteThemeWithThemeId = {
+      themeId,
+      displayName: 'Default theme',
+      fonts: { font_url: `${CDN_URL}/fonts/custom.woff2` },
+      widget: { logo_url: `${CDN_URL}/logo.png` },
+    };
+
+    const result = preserveKeywords({
+      localAssets: { themes: [localThemeWithoutThemeId] },
+      remoteAssets: { themes: [remoteThemeWithThemeId] },
+      keywordMappings: { CDN_URL },
+      auth0Handlers: [{ id: 'themeId', identifiers: ['themeId', 'displayName'], type: 'themes' }],
+    });
+
+    expect(result.themes[0].fonts.font_url).to.equal('##CDN_URL##/fonts/custom.woff2');
+    expect(result.themes[0].widget.logo_url).to.equal('##CDN_URL##/logo.png');
+  });
+
+  it('should preserve keyword placeholders using index fallback when neither themeId nor displayName is in local file', () => {
+    // The exact customer scenario: AUTH0_EXPORT_IDENTIFIERS defaults to false AND no displayName
+    // is set on the theme. The local file has no identifier fields at all — only keyword markers.
+    // The index-based fallback should still preserve the keywords.
+    const localThemeNoIdentifiers = {
+      fonts: { font_url: '##CDN_URL##/fonts/custom.woff2' },
+      widget: { logo_url: '##CDN_URL##/logo.png' },
+    };
+
+    const remoteThemeWithThemeId = {
+      themeId,
+      fonts: { font_url: `${CDN_URL}/fonts/custom.woff2` },
+      widget: { logo_url: `${CDN_URL}/logo.png` },
+    };
+
+    const result = preserveKeywords({
+      localAssets: { themes: [localThemeNoIdentifiers] },
+      remoteAssets: { themes: [remoteThemeWithThemeId] },
+      keywordMappings: { CDN_URL },
+      auth0Handlers: [{ id: 'themeId', identifiers: ['themeId', 'displayName'], type: 'themes' }],
+    });
+
+    expect(result.themes[0].fonts.font_url).to.equal('##CDN_URL##/fonts/custom.woff2');
+    expect(result.themes[0].widget.logo_url).to.equal('##CDN_URL##/logo.png');
+  });
+
+  it('should NOT preserve keyword placeholders for unregistered array types (no identifiers configured)', () => {
+    // When identifiers is empty, the handler has not registered this array type for preservation.
+    // No index fallback should apply — raw remote values are returned unchanged.
     const result = preserveKeywords({
       localAssets: { themes: [localThemeWithKeywords] },
       remoteAssets: { themes: [remoteThemeWithResolvedUrls] },
       keywordMappings: { CDN_URL },
-      auth0Handlers: [{ id: 'themeId', identifiers: ['id', 'name'], type: 'themes' }],
+      auth0Handlers: [{ id: 'themeId', identifiers: [], type: 'themes' }],
     });
 
     expect(result.themes[0].fonts.font_url).to.equal(`${CDN_URL}/fonts/custom.woff2`);


### PR DESCRIPTION
### 🔧 Changes

 Fixes keyword preservation for themes when `AUTH0_EXPORT_IDENTIFIERS` is `false` (the default configuration).
                                                                                                                                                                               
  **Root cause:** `ThemesHandler` used `identifiers: ['themeId']` to match local theme entries during keyword preservation. However, `themeId` is stripped from exported files by default (`AUTH0_EXPORT_IDENTIFIERS: false`), so the preservation logic could never find a matching identifier and silently skipped preservation, causing keyword markers 
  like `##CDN_URL##` to be overwritten with raw values on re-export.                                                                                                         
                                         
  **Changes:**
  - `ThemesHandler`: Added `displayName` as a secondary identifier alongside `themeId`, providing a match path for users who have named their theme but do not use `AUTH0_EXPORT_IDENTIFIERS`
  - `getPreservableFieldsFromAssets` in `keywordPreservation.ts`:
    - Fixed the identifier `reduce` to skip missing identifiers instead of resetting the accumulator, allowing multi-identifier fallback to work correctly
    - Added positional index fallback when registered identifiers are absent from the local file, safe for themes since Auth0 supports only one theme per tenant

### 📚 References

 - Related: #1379 (partial fix - only covered `AUTH0_EXPORT_IDENTIFIERS: true`)

### 🔬 Testing

Unit tests added covering the following scenarios:

  1. `themeId` present in local file (`AUTH0_EXPORT_IDENTIFIERS: true`) - preserved via `themeId` identifier
  2. `displayName` present but not `themeId` - preserved via `displayName` identifier
  3. Neither `themeId` nor `displayName` present (default export, exact customer scenario) - preserved via positional index fallback
  4. `identifiers: []` (no identifiers registered for array type) - NOT preserved, confirming the fallback does not apply to unrecognized arrays

  **Manual end-to-end test:**
  1. Set `AUTH0_PRESERVE_KEYWORDS: false` in config, run export to get a baseline `tenant.yaml`
  2. Edit `tenant.yaml` - replace raw URLs with quoted keyword markers e.g. `font_url: '##CDN_URL##/fonts/custom.woff2'`
  3. Set `AUTH0_PRESERVE_KEYWORDS: true`, re-run export
  4. Confirm `tenant.yaml` still contains `##CDN_URL##` markers instead of resolved URLs

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
