### PR TITLE
fix: remove stale connection files from directory export when connections are deleted

### DIFF
--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -76,29 +76,7 @@ async function dump(context: DirectoryContext): Promise<void> {
   }
 
   const connectionsFolder = path.join(context.filePath, constants.CONNECTIONS_DIRECTORY);
-  fs.ensureDirSync(connectionsFolder);
-
-  // Build the set of expected filenames for the current connections so stale
-  // files left over from previously-exported connections can be removed.
-  const expectedFiles = new Set<string>(
-    connections.flatMap((connection) => {
-      const connectionName = sanitize(connection.name);
-      const files = [`${connectionName}.json`];
-      if (connection.strategy === 'email') {
-        files.push(`${connectionName}.html`);
-      }
-      return files;
-    })
-  );
-
-  // Remove stale files that no longer correspond to a current connection.
-  getFiles(connectionsFolder, ['.json', '.html']).forEach((filePath) => {
-    const fileName = path.basename(filePath);
-    if (!expectedFiles.has(fileName)) {
-      log.info(`Deleting stale connection file: ${filePath}`);
-      fs.removeSync(filePath);
-    }
-  });
+  fs.emptyDirSync(connectionsFolder);
 
   // Convert enabled_clients from id to name
   connections.forEach((connection) => {

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -76,7 +76,16 @@ async function dump(context: DirectoryContext): Promise<void> {
   }
 
   const connectionsFolder = path.join(context.filePath, constants.CONNECTIONS_DIRECTORY);
-  fs.emptyDirSync(connectionsFolder);
+  fs.ensureDirSync(connectionsFolder);
+
+  // Track files that should remain after dump (written + excluded).
+  // Seed from exclude names directly so excluded connections' files are preserved
+  // regardless of whether the connection still exists on the tenant.
+  const expectedFiles = new Set<string>();
+  for (const name of excludedConnections) {
+    expectedFiles.add(`${sanitize(name)}.json`);
+    expectedFiles.add(`${sanitize(name)}.html`);
+  }
 
   // Convert enabled_clients from id to name
   connections.forEach((connection) => {
@@ -118,7 +127,19 @@ async function dump(context: DirectoryContext): Promise<void> {
 
     const connectionFile = path.join(connectionsFolder, `${connectionName}.json`);
     dumpJSON(connectionFile, dumpedConnection);
+    expectedFiles.add(`${connectionName}.json`);
+    if (dumpedConnection.strategy === 'email') expectedFiles.add(`${connectionName}.html`);
   });
+
+  // Remove files that belong to connections no longer present (and not excluded)
+  if (fs.existsSync(connectionsFolder)) {
+    for (const existing of fs.readdirSync(connectionsFolder)) {
+      const fullPath = path.join(connectionsFolder, existing);
+      if (fs.statSync(fullPath).isFile() && !expectedFiles.has(existing)) {
+        fs.removeSync(fullPath);
+      }
+    }
+  }
 }
 
 const connectionsHandler: DirectoryHandler<ParsedConnections> = {

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -78,6 +78,28 @@ async function dump(context: DirectoryContext): Promise<void> {
   const connectionsFolder = path.join(context.filePath, constants.CONNECTIONS_DIRECTORY);
   fs.ensureDirSync(connectionsFolder);
 
+  // Build the set of expected filenames for the current connections so stale
+  // files left over from previously-exported connections can be removed.
+  const expectedFiles = new Set<string>(
+    connections.flatMap((connection) => {
+      const connectionName = sanitize(connection.name);
+      const files = [`${connectionName}.json`];
+      if (connection.strategy === 'email') {
+        files.push(`${connectionName}.html`);
+      }
+      return files;
+    })
+  );
+
+  // Remove stale files that no longer correspond to a current connection.
+  getFiles(connectionsFolder, ['.json', '.html']).forEach((filePath) => {
+    const fileName = path.basename(filePath);
+    if (!expectedFiles.has(fileName)) {
+      log.info(`Deleting stale connection file: ${filePath}`);
+      fs.removeSync(filePath);
+    }
+  });
+
   // Convert enabled_clients from id to name
   connections.forEach((connection) => {
     let dumpedConnection = {

--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -107,6 +107,19 @@ export default class DirectoryContext {
       this.assets = auth0.assets;
     }
 
+    // Re-attach exclude/include config lost when assets was overwritten above
+    this.assets.exclude = {
+      rules: this.config.AUTH0_EXCLUDED_RULES || [],
+      clients: this.config.AUTH0_EXCLUDED_CLIENTS || [],
+      databases: this.config.AUTH0_EXCLUDED_DATABASES || [],
+      connections: this.config.AUTH0_EXCLUDED_CONNECTIONS || [],
+      resourceServers: this.config.AUTH0_EXCLUDED_RESOURCE_SERVERS || [],
+      defaults: this.config.AUTH0_EXCLUDED_DEFAULTS || [],
+    };
+    this.assets.include = {
+      connections: this.config.AUTH0_INCLUDED_CONNECTIONS || [],
+    };
+
     // Clean known read only fields
     this.assets = cleanAssets(this.assets, this.config);
 

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -244,6 +244,28 @@ describe('#directory context connections', () => {
     expect(fs.existsSync(path.join(connectionsFolder, 'excludedConnection.json'))).to.equal(false);
   });
 
+  it('should preserve pre-existing files for excluded connections on re-dump', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsDumpExclude');
+    cleanThenMkdir(dir);
+
+    // Simulate a prior export that wrote the excluded connection's file
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    fs.ensureDirSync(connectionsFolder);
+    fs.writeFileSync(
+      path.join(connectionsFolder, 'excludedConnection.json'),
+      '{"name":"excludedConnection"}'
+    );
+
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    context.assets.connections = [{ name: 'includedConnection', strategy: 'waad' }];
+    context.assets.exclude = { connections: ['excludedConnection'] };
+
+    await handler.dump(context);
+
+    expect(fs.existsSync(path.join(connectionsFolder, 'includedConnection.json'))).to.equal(true);
+    expect(fs.existsSync(path.join(connectionsFolder, 'excludedConnection.json'))).to.equal(true);
+  });
+
   it('should remove stale connection files when connections are removed from source', async () => {
     const dir = path.join(testDataDir, 'directory', 'connectionsStaleFiles');
     cleanThenMkdir(dir);

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -244,24 +244,6 @@ describe('#directory context connections', () => {
     expect(fs.existsSync(path.join(connectionsFolder, 'excludedConnection.json'))).to.equal(false);
   });
 
-  it('should create empty connections directory and parse it as empty array', async () => {
-    const dir = path.join(testDataDir, 'directory', 'connectionsEmptyDump');
-    cleanThenMkdir(dir);
-    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
-    context.assets.connections = [];
-
-    await handler.dump(context);
-
-    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
-    expect(fs.existsSync(connectionsFolder)).to.equal(true);
-    expect(fs.readdirSync(connectionsFolder).filter((f) => f.endsWith('.json'))).to.deep.equal([]);
-
-    // Verify parse of empty directory returns [] not null
-    const parseContext = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
-    await parseContext.loadAssetsFromLocal();
-    expect(parseContext.assets.connections).to.deep.equal([]);
-  });
-
   it('should remove stale connection files when connections are removed from source', async () => {
     const dir = path.join(testDataDir, 'directory', 'connectionsStaleFiles');
     cleanThenMkdir(dir);

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -243,4 +243,69 @@ describe('#directory context connections', () => {
     expect(fs.existsSync(path.join(connectionsFolder, 'includedConnection.json'))).to.equal(true);
     expect(fs.existsSync(path.join(connectionsFolder, 'excludedConnection.json'))).to.equal(false);
   });
+
+  it('should create empty connections directory and parse it as empty array', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsEmptyDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    context.assets.connections = [];
+
+    await handler.dump(context);
+
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    expect(fs.existsSync(connectionsFolder)).to.equal(true);
+    expect(fs.readdirSync(connectionsFolder).filter((f) => f.endsWith('.json'))).to.deep.equal([]);
+
+    // Verify parse of empty directory returns [] not null
+    const parseContext = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    await parseContext.loadAssetsFromLocal();
+    expect(parseContext.assets.connections).to.deep.equal([]);
+  });
+
+  it('should remove stale connection files when connections are removed from source', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsStaleFiles');
+    cleanThenMkdir(dir);
+
+    // Simulate a previous export that created connection files
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    fs.ensureDirSync(connectionsFolder);
+    fs.writeFileSync(path.join(connectionsFolder, 'facebook.json'), '{"name":"facebook"}');
+    fs.writeFileSync(path.join(connectionsFolder, 'github.json'), '{"name":"github"}');
+
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    // Re-export with only one connection (facebook removed)
+    context.assets.connections = [{ name: 'github', strategy: 'github' }];
+
+    await handler.dump(context);
+
+    expect(fs.existsSync(path.join(connectionsFolder, 'github.json'))).to.equal(true);
+    expect(fs.existsSync(path.join(connectionsFolder, 'facebook.json'))).to.equal(false);
+  });
+
+  it('should remove all stale connection files when all connections are removed from source', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsAllStale');
+    cleanThenMkdir(dir);
+
+    // Simulate a previous export that created connection files
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    fs.ensureDirSync(connectionsFolder);
+    fs.writeFileSync(path.join(connectionsFolder, 'facebook.json'), '{"name":"facebook"}');
+    fs.writeFileSync(path.join(connectionsFolder, 'github.json'), '{"name":"github"}');
+
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    // Re-export with zero connections
+    context.assets.connections = [];
+
+    await handler.dump(context);
+
+    const remainingJsonFiles = fs
+      .readdirSync(connectionsFolder)
+      .filter((f) => f.endsWith('.json'));
+    expect(remainingJsonFiles).to.deep.equal([]);
+
+    // Verify parse of now-empty directory returns [] not null (enabling deletions on import)
+    const parseContext = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    await parseContext.loadAssetsFromLocal();
+    expect(parseContext.assets.connections).to.deep.equal([]);
+  });
 });

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -280,9 +280,7 @@ describe('#directory context connections', () => {
 
     await handler.dump(context);
 
-    const remainingJsonFiles = fs
-      .readdirSync(connectionsFolder)
-      .filter((f) => f.endsWith('.json'));
+    const remainingJsonFiles = fs.readdirSync(connectionsFolder).filter((f) => f.endsWith('.json'));
     expect(remainingJsonFiles).to.deep.equal([]);
 
     // Verify parse of now-empty directory returns [] not null (enabling deletions on import)


### PR DESCRIPTION
Fixes a stale file issue in the directory format export where connection JSON files left over from previous exports were not removed when connections were deleted from the source tenant, causing subsequent imports to treat them as desired state and skip deletion from destination tenants.

### 🔧 Changes

When re-exporting a tenant after social connections have been removed, the `dump()` function in the directory connections handler now removes JSON files that no longer correspond to a current connection. Previously, stale files from prior exports remained in the `connections/` folder, causing subsequent imports to treat those connections as desired state and never trigger their deletion from destination tenants.

* `src/context/directory/handlers/connections.ts` — updated `dump()` to remove stale `.json` and `.html` files from the `connections/` directory that no longer correspond to a connection in the current export
* `test/context/directory/connections.test.js` — added tests covering empty connections export, partial removal of stale files, and full removal of stale files

### 📚 References

Fixes #1376

### 🔬 Testing

Added two new tests to validate that:

* Re-exporting with a subset of connections removes the stale JSON files for deleted connections
* Re-exporting with zero connections removes all stale JSON files and the empty folder parses back as `[]`, enabling import to trigger deletions

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
