### PR TITLE
feat: add deprecation warnings for external file path references in config handlers  

### DIFF
--- a/src/context/directory/handlers/actionModules.ts
+++ b/src/context/directory/handlers/actionModules.ts
@@ -31,6 +31,11 @@ function parse(context: DirectoryContext): ParsedActionModules {
       // It can be a relative path, so we need to handle both cases.
       const unixPath = module.code.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
       if (fs.existsSync(unixPath)) {
+        log.warn(
+          `Deprecation notice: action module code path "${module.code}" is resolved as an absolute or external path. ` +
+            `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
+            `Please update your configuration to use paths relative to the config directory.`
+        );
         module.code = context.loadFile(unixPath, moduleFolder);
       } else {
         module.code = context.loadFile(path.join(context.filePath, module.code), moduleFolder);

--- a/src/context/directory/handlers/actionModules.ts
+++ b/src/context/directory/handlers/actionModules.ts
@@ -32,9 +32,9 @@ function parse(context: DirectoryContext): ParsedActionModules {
       const unixPath = module.code.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
       if (fs.existsSync(unixPath)) {
         log.warn(
-          `Deprecation notice: action module code path "${module.code}" is resolved as an absolute or external path. ` +
-            `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
-            `Please update your configuration to use paths relative to the config directory.`
+          `Support for absolute paths and paths outside the config root will be deprecated in a future version to improve the security of the tool. ` +
+            `Please update your configuration to use paths relative to the config directory. ` +
+            `Current absolute path used: ["${module.code}"]`
         );
         module.code = context.loadFile(unixPath, moduleFolder);
       } else {

--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -32,6 +32,11 @@ function parse(context: DirectoryContext): ParsedActions {
       const unixPath = action.code.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '');
       if (fs.existsSync(unixPath)) {
         // If the Unix-style path exists, load the file from that path
+        log.warn(
+          `Deprecation notice: action code path "${action.code}" is resolved as an absolute or external path. ` +
+            `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
+            `Please update your configuration to use paths relative to the config directory.`
+        );
         action.code = context.loadFile(unixPath, actionFolder);
       } else {
         // Otherwise, load the file from the context's file path

--- a/src/context/directory/handlers/actions.ts
+++ b/src/context/directory/handlers/actions.ts
@@ -33,9 +33,9 @@ function parse(context: DirectoryContext): ParsedActions {
       if (fs.existsSync(unixPath)) {
         // If the Unix-style path exists, load the file from that path
         log.warn(
-          `Deprecation notice: action code path "${action.code}" is resolved as an absolute or external path. ` +
-            `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
-            `Please update your configuration to use paths relative to the config directory.`
+          `Support for absolute paths and paths outside the config root will be deprecated in a future version to improve the security of the tool. ` +
+            `Please update your configuration to use paths relative to the config directory. ` +
+            `Current absolute path used: ["${action.code}"]`
         );
         action.code = context.loadFile(unixPath, actionFolder);
       } else {

--- a/src/context/directory/handlers/databases.ts
+++ b/src/context/directory/handlers/databases.ts
@@ -73,9 +73,9 @@ function getDatabase(
         const toLoad = path.resolve(folder, script);
         if (!toLoad.startsWith(resolvedBase + path.sep)) {
           log.warn(
-            `Deprecation notice: database custom script "${name}" references file "${script}" which resolves outside the config directory. ` +
-              `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
-              `Please update your configuration to use paths relative to the config directory.`
+            `Support for absolute paths and paths outside the config root will be deprecated in a future version to improve the security of the tool. ` +
+              `Please update your configuration to use paths relative to the config directory. ` +
+              `Current absolute path used: ["${script}"]`
           );
         }
         database.options.customScripts[name] = loadFileAndReplaceKeywords(toLoad, mappingOpts);

--- a/src/context/directory/handlers/databases.ts
+++ b/src/context/directory/handlers/databases.ts
@@ -33,6 +33,7 @@ type DatabaseMetadata = {
 
 function getDatabase(
   folder: string,
+  configRoot: string,
   mappingOpts: { mappings: KeywordMappings; disableKeywordReplacement: boolean }
 ): {} {
   const metaFile = path.join(folder, 'database.json');
@@ -68,10 +69,16 @@ function getDatabase(
         // skip invalid keys in customScripts object
         log.warn('Skipping invalid database configuration: ' + name);
       } else {
-        database.options.customScripts[name] = loadFileAndReplaceKeywords(
-          path.join(folder, script),
-          mappingOpts
-        );
+        const resolvedBase = path.resolve(configRoot);
+        const toLoad = path.resolve(folder, script);
+        if (!toLoad.startsWith(resolvedBase + path.sep)) {
+          log.warn(
+            `Deprecation notice: database custom script "${name}" references file "${script}" which resolves outside the config directory. ` +
+              `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
+              `Please update your configuration to use paths relative to the config directory.`
+          );
+        }
+        database.options.customScripts[name] = loadFileAndReplaceKeywords(toLoad, mappingOpts);
       }
     });
   }
@@ -90,7 +97,7 @@ function parse(context: DirectoryContext): ParsedDatabases {
 
   const databases = folders
     .map((f) =>
-      getDatabase(f, {
+      getDatabase(f, context.filePath, {
         mappings: context.mappings,
         disableKeywordReplacement: context.disableKeywordReplacement,
       })

--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -52,6 +52,11 @@ export default class DirectoryContext {
     if (!isFile(toLoad)) {
       // try load not relative to yaml file
       toLoad = f;
+      log.warn(
+        `Deprecation notice: file reference "${f}" could not be resolved relative to the config directory and fell back to an absolute or external path. ` +
+          `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
+          `Please update your configuration to use paths relative to the config directory.`
+      );
     }
     return loadFileAndReplaceKeywords(toLoad, {
       mappings: this.mappings,

--- a/src/context/directory/index.ts
+++ b/src/context/directory/index.ts
@@ -53,9 +53,9 @@ export default class DirectoryContext {
       // try load not relative to yaml file
       toLoad = f;
       log.warn(
-        `Deprecation notice: file reference "${f}" could not be resolved relative to the config directory and fell back to an absolute or external path. ` +
-          `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
-          `Please update your configuration to use paths relative to the config directory.`
+        `Support for absolute paths and paths outside the config root will be deprecated in a future version to improve the security of the tool. ` +
+          `Please update your configuration to use paths relative to the config directory. ` +
+          `Current absolute path used: ["${f}"]`
       );
     }
     return loadFileAndReplaceKeywords(toLoad, {

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -63,9 +63,9 @@ export default class YAMLContext {
       // try load not relative to yaml file
       toLoad = f;
       log.warn(
-        `Deprecation notice: file reference "${f}" could not be resolved relative to the config directory and fell back to an absolute or external path. ` +
-          `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
-          `Please update your configuration to use paths relative to the config directory.`
+        `Support for absolute paths and paths outside the config root will be deprecated in a future version to improve the security of the tool. ` +
+          `Please update your configuration to use paths relative to the config directory. ` +
+          `Current absolute path used: ["${f}"]`
       );
     }
     return loadFileAndReplaceKeywords(path.resolve(toLoad), {

--- a/src/context/yaml/index.ts
+++ b/src/context/yaml/index.ts
@@ -62,6 +62,11 @@ export default class YAMLContext {
     if (!isFile(toLoad)) {
       // try load not relative to yaml file
       toLoad = f;
+      log.warn(
+        `Deprecation notice: file reference "${f}" could not be resolved relative to the config directory and fell back to an absolute or external path. ` +
+          `Support for absolute paths and paths outside the config root will be removed in a future major version. ` +
+          `Please update your configuration to use paths relative to the config directory.`
+      );
     }
     return loadFileAndReplaceKeywords(path.resolve(toLoad), {
       mappings: this.mappings,


### PR DESCRIPTION
### 🔧 Changes

Added deprecation warnings across all config file loading paths to notify customers ahead of a planned breaking change (tracked in #1388) that will remove support for absolute paths and paths resolving outside the config root directory.                                                                                                                      

  Affected locations:
  - `src/context/directory/index.ts` - `loadFile` fallback when relative path cannot be resolved
  - `src/context/yaml/index.ts` - same for YAML context
  - `src/context/directory/handlers/actions.ts` - action `code` path resolved via `fs.existsSync` as an absolute/external path
  - `src/context/directory/handlers/actionModules.ts` - same for action modules
  - `src/context/directory/handlers/databases.ts` - `customScripts` path resolving outside the config root

Existing behavior is fully preserved - files still load successfully. A `warn`-level log is emitted to prompt customers to migrate to relative paths before the breaking change lands.

### 📚 References

  - #1388 (breaking change deferred to a future major version)

### 🔬 Testing

No new unit tests added as behavior is unchanged. Warnings can be verified manually by referencing a file outside the config directory in any of the affected asset types (actions, action modules, databases, pages) - a deprecation `warn` log is emitted and the file continues to load normally.

All 1231 existing tests pass with no regressions.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
