### PR TITLE
feat: add optional flag to skip secret masking during export

### DIFF
--- a/docs/configuring-the-deploy-cli.md
+++ b/docs/configuring-the-deploy-cli.md
@@ -179,6 +179,12 @@ Boolean. When enabled, will return identifiers of all resources. May be useful f
 
 Boolean. When enabled, exports JSON and YAML resources with keys sorted alphabetically, producing stable and deterministic output. Useful for reducing noise in diffs when keys would otherwise appear in non-deterministic order. Default: `false`.
 
+### `AUTH0_EXPORT_SECRETS`
+
+Boolean. When enabled, exports actual secret values (e.g. connection `client_secret`, log stream tokens, email provider credentials, attack protection CAPTCHA secrets) instead of replacing them with placeholder markers like `##CONNECTIONS_OAUTH2_SECRET##`. Useful for backup and restore scenarios where secrets need to be preserved. Default: `false`.
+
+> **Warning:** Enabling this option will write real credentials to exported files. Use with caution in shared or version-controlled environments.
+
 ### `EXCLUDED_PROPS`
 
 Provides ability to exclude any unwanted properties from management.

--- a/docs/using-as-cli.md
+++ b/docs/using-as-cli.md
@@ -29,6 +29,10 @@ Boolean. When enabled, will export the identifier fields for each resource. Defa
 
 Boolean. When enabled, exports resource configuration files with keys sorted alphabetically, producing stable and deterministic output. Useful for reducing noise in diffs. Default: `false`.
 
+### `--export_secrets`
+
+Boolean. When enabled, exports actual secret values instead of replacing them with placeholder markers (e.g. `##SMTP_PASS##`). Useful for backup and restore scenarios. **Warning:** real credentials will be written to exported files. Default: `false`.
+
 ### `--env`
 
 Boolean. Indicates if the tool should ingest environment variables or not. Default: `true`.

--- a/docs/using-as-cli.md
+++ b/docs/using-as-cli.md
@@ -60,6 +60,9 @@ a0deploy export -c=config.json --format=directory --output_folder=local
 
 # Fetching Auth0 tenant configurations with IDs of all assets
 a0deploy export -c=config.json --format=yaml --output_folder=local --export_ids=true
+
+# Fetching Auth0 tenant configurations including real secret values
+a0deploy export -c=config.json --format=directory --output_folder=local --export_secrets
 ```
 
 ## `import` command

--- a/src/args.ts
+++ b/src/args.ts
@@ -26,6 +26,7 @@ type ExportSpecificParams = {
   output_folder: string;
   export_ids?: boolean;
   export_ordered?: boolean;
+  export_secrets?: boolean;
 };
 
 export type ExportParams = ExportSpecificParams & SharedParams;
@@ -137,6 +138,11 @@ function getParams(): CliParams {
         alias: 's',
         describe: 'Order keys in exported JSON files for consistent diffs.',
         type: 'boolean',
+      },
+      export_secrets: {
+        describe: 'Export actual secret values instead of placeholder markers.',
+        type: 'boolean',
+        default: false,
       },
     })
     .example(

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -16,6 +16,7 @@ export default async function exportCMD(params: ExportParams) {
     config: configObj,
     export_ids: exportIds,
     export_ordered: exportOrdered,
+    export_secrets: exportSecrets,
     secret: clientSecret,
     env: shouldInheritEnv = false,
     experimental_ea: experimentalEA,
@@ -49,6 +50,11 @@ export default async function exportCMD(params: ExportParams) {
   // Allow passed in export_ordered to override the configured one
   if (exportOrdered) {
     overrides.AUTH0_EXPORT_ORDERED = exportOrdered;
+  }
+
+  // Allow passed in export_secrets to override the configured one
+  if (exportSecrets) {
+    overrides.AUTH0_EXPORT_SECRETS = exportSecrets;
   }
 
   // Overrides AUTH0_INCLUDE_EXPERIMENTAL_EA is experimental_ea passed in command line

--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -4,11 +4,16 @@ import { Config } from '../types';
 
 // env vars arrive as strings, so check both forms
 function isExportSecrets(config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>): boolean {
-  return config?.AUTH0_EXPORT_SECRETS === true || (config?.AUTH0_EXPORT_SECRETS as unknown) === 'true';
+  return (
+    config?.AUTH0_EXPORT_SECRETS === true || (config?.AUTH0_EXPORT_SECRETS as unknown) === 'true'
+  );
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function emailProviderDefaults(emailProvider, config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>) {
+export function emailProviderDefaults(
+  emailProvider,
+  config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>
+) {
   // eslint-disable-line
   if (isExportSecrets(config)) return emailProvider;
 

--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -1,9 +1,17 @@
 import { AttackProtection } from '../tools/auth0/handlers/attackProtection';
 import { maskSecretAtPath } from '../tools/utils';
+import { Config } from '../types';
+
+// env vars arrive as strings, so check both forms
+function isExportSecrets(config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>): boolean {
+  return config?.AUTH0_EXPORT_SECRETS === true || (config?.AUTH0_EXPORT_SECRETS as unknown) === 'true';
+}
 
 // eslint-disable-next-line import/prefer-default-export
-export function emailProviderDefaults(emailProvider) {
+export function emailProviderDefaults(emailProvider, config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>) {
   // eslint-disable-line
+  if (isExportSecrets(config)) return emailProvider;
+
   const updated = { ...emailProvider };
 
   const apiKeyProviders = ['mailgun', 'mandrill', 'sendgrid', 'sparkpost'];
@@ -111,8 +119,8 @@ export function phoneTemplatesDefaults(phoneTemplate) {
   return updated;
 }
 
-export function connectionDefaults(connection) {
-  if (connection.options) {
+export function connectionDefaults(connection, config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>) {
+  if (!isExportSecrets(config) && connection.options) {
     // Mask secret for key: connection.options.client_secret
     maskSecretAtPath({
       resourceTypeName: 'connections',
@@ -124,7 +132,9 @@ export function connectionDefaults(connection) {
   return connection;
 }
 
-export function logStreamDefaults(logStreams) {
+export function logStreamDefaults(logStreams, config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>) {
+  if (isExportSecrets(config)) return logStreams;
+
   // masked sensitive fields
   const sensitiveKeys = [
     'httpAuthorization',
@@ -152,7 +162,12 @@ export function logStreamDefaults(logStreams) {
   return maskedLogStreams;
 }
 
-export function attackProtectionDefaults(attackProtection: AttackProtection) {
+export function attackProtectionDefaults(
+  attackProtection: AttackProtection,
+  config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>
+) {
+  if (isExportSecrets(config)) return attackProtection;
+
   const { captcha } = attackProtection;
 
   if (captcha) {

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -85,7 +85,7 @@ async function dump(context: DirectoryContext): Promise<void> {
   const files = attackProtectionFiles(context.filePath);
   fs.ensureDirSync(files.directory);
 
-  const maskedAttackProtection = attackProtectionDefaults(attackProtection);
+  const maskedAttackProtection = attackProtectionDefaults(attackProtection, context.config);
 
   if (maskedAttackProtection.botDetection) {
     dumpJSON(files.botDetection, maskedAttackProtection.botDetection);

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -100,7 +100,7 @@ async function dump(context: DirectoryContext): Promise<void> {
     const connectionName = sanitize(dumpedConnection.name);
 
     // Mask secrets
-    dumpedConnection = connectionDefaults(dumpedConnection);
+    dumpedConnection = connectionDefaults(dumpedConnection, context.config);
 
     if (dumpedConnection.strategy === 'email') {
       ensureProp(dumpedConnection, 'options.email.body');

--- a/src/context/directory/handlers/emailProvider.ts
+++ b/src/context/directory/handlers/emailProvider.ts
@@ -36,7 +36,7 @@ async function dump(context: DirectoryContext): Promise<void> {
     const excludedDefaults = context.assets.exclude?.defaults || [];
     if (!excludedDefaults.includes('emailProvider')) {
       // Add placeholder for credentials as they cannot be exported
-      return emailProviderDefaults(context.assets.emailProvider);
+      return emailProviderDefaults(context.assets.emailProvider, context.config);
     }
     return context.assets.emailProvider;
   })();

--- a/src/context/directory/handlers/logStreams.ts
+++ b/src/context/directory/handlers/logStreams.ts
@@ -40,7 +40,7 @@ async function dump(context: DirectoryContext): Promise<void> {
   fs.ensureDirSync(logStreamsDirectory);
 
   // masked sensitive fields
-  const maskedLogStreams = logStreamDefaults(logStreams);
+  const maskedLogStreams = logStreamDefaults(logStreams, context.config);
 
   maskedLogStreams.forEach((logStream) => {
     const ruleFile = path.join(logStreamsDirectory, `${sanitize(logStream.name)}.json`);

--- a/src/context/yaml/handlers/attackProtection.ts
+++ b/src/context/yaml/handlers/attackProtection.ts
@@ -43,7 +43,7 @@ async function dump(context: YAMLContext): Promise<ParsedAttackProtection> {
     attackProtectionConfig.captcha = captcha;
   }
 
-  const maskedAttackProtection = attackProtectionDefaults(attackProtectionConfig);
+  const maskedAttackProtection = attackProtectionDefaults(attackProtectionConfig, context.config);
 
   return {
     attackProtection: maskedAttackProtection,

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -72,7 +72,7 @@ async function dump(context: YAMLContext): Promise<ParsedConnections> {
       };
 
       // Mask secrets
-      dumpedConnection = connectionDefaults(dumpedConnection);
+      dumpedConnection = connectionDefaults(dumpedConnection, context.config);
 
       if (dumpedConnection.strategy === 'email') {
         ensureProp(connection, 'options.email.body');

--- a/src/context/yaml/handlers/emailProvider.ts
+++ b/src/context/yaml/handlers/emailProvider.ts
@@ -23,7 +23,7 @@ async function dump(context: YAMLContext): Promise<ParsedEmailProvider> {
     const excludedDefaults = context.assets.exclude?.defaults || [];
     if (emailProvider && !excludedDefaults.includes('emailProvider')) {
       // Add placeholder for credentials as they cannot be exported
-      return emailProviderDefaults(emailProvider);
+      return emailProviderDefaults(emailProvider, context.config);
     }
     return emailProvider;
   })();

--- a/src/context/yaml/handlers/logStreams.ts
+++ b/src/context/yaml/handlers/logStreams.ts
@@ -21,7 +21,7 @@ async function dump(context: YAMLContext): Promise<ParsedLogStreams> {
   if (!logStreams) return { logStreams: null };
 
   // masked sensitive fields
-  const maskedLogStreams = logStreamDefaults(logStreams);
+  const maskedLogStreams = logStreamDefaults(logStreams, context.config);
 
   return {
     logStreams: maskedLogStreams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export type Config = {
   AUTH0_KEYWORD_REPLACE_MAPPINGS?: KeywordMappings;
   AUTH0_EXPORT_IDENTIFIERS?: boolean;
   AUTH0_EXPORT_ORDERED?: boolean;
+  AUTH0_EXPORT_SECRETS?: boolean;
   AUTH0_CONNECTIONS_DIRECTORY?: string;
   AUTH0_DRY_RUN?: boolean | 'preview';
   AUTH0_DRY_RUN_INTERACTIVE?: boolean;

--- a/test/commands/export.test.ts
+++ b/test/commands/export.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import exportCMD from '../../src/commands/export';
+import * as contextModule from '../../src/context';
+
+describe('#export command', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(contextModule, 'setupContext').resolves({
+      dump: sandbox.stub().resolves(),
+    } as any);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should set AUTH0_EXPORT_SECRETS when export_secrets flag is passed', async () => {
+    await exportCMD({
+      _: ['export'],
+      output_folder: 'local',
+      format: 'directory',
+      export_secrets: true,
+      env: false,
+    } as any);
+
+    const [config] = (contextModule.setupContext as sinon.SinonStub).firstCall.args;
+    expect(config.AUTH0_EXPORT_SECRETS).to.equal(true);
+  });
+
+  it('should not set AUTH0_EXPORT_SECRETS when export_secrets flag is absent', async () => {
+    await exportCMD({
+      _: ['export'],
+      output_folder: 'local',
+      format: 'directory',
+      env: false,
+    } as any);
+
+    const [config] = (contextModule.setupContext as sinon.SinonStub).firstCall.args;
+    expect(config.AUTH0_EXPORT_SECRETS).to.equal(undefined);
+  });
+});

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -162,6 +162,20 @@ describe('#context defaults', () => {
 
       expect(result.options.client_secret).to.equal('##CONNECTIONS_CUSTOM_OAUTH_2_0_SECRET##');
     });
+
+    it('should not mask client_secret when AUTH0_EXPORT_SECRETS is true', () => {
+      const connection = {
+        name: 'Test Connection',
+        strategy: 'oauth2',
+        options: {
+          client_secret: 'real_secret_value',
+        },
+      };
+
+      const result = connectionDefaults(connection, { AUTH0_EXPORT_SECRETS: true });
+
+      expect(result.options.client_secret).to.equal('real_secret_value');
+    });
   });
 
   describe('logStreamDefaults', () => {
@@ -360,6 +374,40 @@ describe('#context defaults', () => {
       const result = logStreamDefaults(logStreams);
 
       expect(result[0].sink.httpAuthorization).to.equal('##LOGSTREAMS_CUSTOM_HTTP_2_0_SECRET##');
+    });
+
+    it('should not mask sensitive fields when AUTH0_EXPORT_SECRETS is true', () => {
+      const logStreams = [
+        {
+          name: 'HTTP Stream',
+          type: 'http',
+          sink: {
+            httpEndpoint: 'https://example.com/logs',
+            httpAuthorization: 'Bearer real_token',
+          },
+        },
+      ];
+
+      const result = logStreamDefaults(logStreams, { AUTH0_EXPORT_SECRETS: true });
+
+      expect(result[0].sink.httpAuthorization).to.equal('Bearer real_token');
+      expect(result[0].sink.httpEndpoint).to.equal('https://example.com/logs');
+    });
+  });
+
+  describe('emailProviderDefaults with AUTH0_EXPORT_SECRETS', () => {
+    it('should not mask credentials when AUTH0_EXPORT_SECRETS is true', () => {
+      const emailProvider = {
+        name: 'smtp',
+        credentials: {
+          smtp_host: 'mail.example.com',
+          smtp_pass: 'real_password',
+        },
+      };
+
+      const result = emailProviderDefaults(emailProvider, { AUTH0_EXPORT_SECRETS: true });
+
+      expect(result).to.deep.equal(emailProvider);
     });
   });
 });

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -4,6 +4,7 @@ import {
   emailProviderDefaults,
   connectionDefaults,
   logStreamDefaults,
+  attackProtectionDefaults,
 } from '../../src/context/defaults';
 
 describe('#context defaults', () => {
@@ -422,6 +423,20 @@ describe('#context defaults', () => {
       const result = emailProviderDefaults(emailProvider, { AUTH0_EXPORT_SECRETS: true });
 
       expect(result).to.deep.equal(emailProvider);
+    });
+  });
+
+  describe('attackProtectionDefaults with AUTH0_EXPORT_SECRETS', () => {
+    it('should not mask captcha secrets when AUTH0_EXPORT_SECRETS is true', () => {
+      const attackProtection = {
+        captcha: {
+          hcaptcha: { secret: 'real-hcaptcha-secret' },
+        },
+      };
+
+      const result = attackProtectionDefaults(attackProtection, { AUTH0_EXPORT_SECRETS: true });
+
+      expect(result.captcha.hcaptcha.secret).to.equal('real-hcaptcha-secret');
     });
   });
 });

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -176,6 +176,20 @@ describe('#context defaults', () => {
 
       expect(result.options.client_secret).to.equal('real_secret_value');
     });
+
+    it('should not mask client_secret when AUTH0_EXPORT_SECRETS is the string "true"', () => {
+      const connection = {
+        name: 'Test Connection',
+        strategy: 'oauth2',
+        options: {
+          client_secret: 'real_secret_value',
+        },
+      };
+
+      const result = connectionDefaults(connection, { AUTH0_EXPORT_SECRETS: 'true' });
+
+      expect(result.options.client_secret).to.equal('real_secret_value');
+    });
   });
 
   describe('logStreamDefaults', () => {

--- a/test/context/directory/logStreams.test.js
+++ b/test/context/directory/logStreams.test.js
@@ -1,0 +1,67 @@
+import path from 'path';
+import { expect } from 'chai';
+import { constants } from '../../../src/tools';
+
+import Context from '../../../src/context/directory';
+import handler from '../../../src/context/directory/handlers/logStreams';
+import { loadJSON } from '../../../src/utils';
+import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
+
+describe('#directory context log streams', () => {
+  it('should dump log streams with secrets masked by default', async () => {
+    const dir = path.join(testDataDir, 'directory', 'logStreamsDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.logStreams = [
+      {
+        name: 'test-stream',
+        type: 'http',
+        status: 'active',
+        sink: {
+          httpEndpoint: 'https://example.com/logs',
+          httpAuthorization: 'real-secret-token',
+          httpContentFormat: 'JSONLINES',
+          httpContentType: 'application/json',
+        },
+      },
+    ];
+
+    await handler.dump(context);
+    const logStreamsDir = path.join(dir, constants.LOG_STREAMS_DIRECTORY);
+    const dumped = loadJSON(path.join(logStreamsDir, 'test-stream.json'));
+
+    expect(dumped.sink.httpAuthorization).to.equal('##LOGSTREAMS_HTTP_SECRET##');
+    expect(dumped.sink.httpEndpoint).to.equal('https://example.com/logs');
+  });
+
+  it('should dump log streams with real secrets when AUTH0_EXPORT_SECRETS is true', async () => {
+    const dir = path.join(testDataDir, 'directory', 'logStreamsDumpSecrets');
+    cleanThenMkdir(dir);
+    const context = new Context(
+      { AUTH0_INPUT_FILE: dir, AUTH0_EXPORT_SECRETS: true },
+      mockMgmtClient()
+    );
+
+    context.assets.logStreams = [
+      {
+        name: 'test-stream',
+        type: 'http',
+        status: 'active',
+        sink: {
+          httpEndpoint: 'https://example.com/logs',
+          httpAuthorization: 'real-secret-token',
+          httpContentFormat: 'JSONLINES',
+          httpContentType: 'application/json',
+        },
+      },
+    ];
+
+    await handler.dump(context);
+    const logStreamsDir = path.join(dir, constants.LOG_STREAMS_DIRECTORY);
+    const dumped = loadJSON(path.join(logStreamsDir, 'test-stream.json'));
+
+    expect(dumped.sink.httpAuthorization).to.equal('real-secret-token');
+    expect(dumped.sink.httpEndpoint).to.equal('https://example.com/logs');
+  });
+});


### PR DESCRIPTION
Adds optional `AUTH0_EXPORT_SECRETS` config flag (and `--export_secrets` CLI option) that skips secret masking during export. When disabled (default), secrets continue to be replaced with placeholder markers like `##CONNECTIONS_OAUTH2_SECRET##`.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

* Added `AUTH0_EXPORT_SECRETS` optional boolean config property to the Config type
* Added `--export_secrets` CLI flag to the `export` command
* Updated `emailProviderDefaults`, `connectionDefaults`, `logStreamDefaults`, and `attackProtectionDefaults` in `src/context/defaults.ts` to accept a config param and skip masking when the flag is enabled
* Updated all affected `directory` and `YAML` dump handlers to pass config through to the masking functions
* Added documentation for `AUTH0_EXPORT_SECRETS` in `docs/configuring-the-deploy-cli.md` and `docs/using-as-cli.md`

When `AUTH0_EXPORT_SECRETS` is `false` (default), behavior is unchanged. In this case, secrets are replaced with placeholder markers. When set to `true`, real secret values are written to exported files where the Management API exposes them.

#### Examples

**Config file**:

```json
{
  "AUTH0_EXPORT_SECRETS": true
}
```

**CLI flag**:

```bash
a0deploy export -c config.json --format=directory --output_folder=./backup --export_secrets
```

#### Shape

Without flag (default - masked):

`YAML` format:

```yaml
connections:
  - name: testConnection
    options:
      client_secret: '##CONNECTIONS_OAUTH2_SECRET##'
```

`JSON` format:

```json
{
  "name": "testConnection",
  "options": {
    "client_secret": "##CONNECTIONS_OAUTH2_SECRET##"
  }
}
```

With `AUTH0_EXPORT_SECRETS: true`, where **API returns** the value:

`YAML` format:

```yaml
connections:
  - name: testConnection
    options:
      client_secret: test-client-secret-value
```

`JSON` format:

```json
{
  "name": "testConnection",
  "options": {
    "client_secret": "test-client-secret-value"
  }
}
```

With `AUTH0_EXPORT_SECRETS: true`, where **API does not return** the value:

`YAML` format:

```yaml
logStreams:
  - sink:
      httpAuthorization: _VALUE_NOT_SHOWN_
```

`JSON` format:

```json
{
  "sink": {
    "httpAuthorization": "_VALUE_NOT_SHOWN_"
  }
}
```


### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Closes #1356

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

* Unit tests added in `test/context/defaults.test.js` covering masking functions with and without the flag
* Manual end-to-end testing performed against a dev tenant; confirmed connections client_secret exports as real value with flag enabled, and as `##CONNECTIONS_OAUTH2_SECRET##` without it

Note: some resources (e.g. log streams) still show `_VALUE_NOT_SHOWN_` as the Management API itself does not return those secrets


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
