### PR TITLE
feat: add invitation_landing_client_id support to my_organization_configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@clack/prompts": "1.3.0",
     "ajv": "^6.12.6",
+    "auth0": "^5.12.0",
     "chalk": "5.6.2",
-    "auth0": "^5.9.0",
     "dot-prop": "^5.3.0",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.1",

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -122,6 +122,14 @@ async function dump(context: DirectoryContext): Promise<void> {
         client.my_organization_configuration.connection_profile_id =
           c?.name || myOrganizationConnectionProfileId;
       }
+
+      const invitationLandingClientId =
+        client.my_organization_configuration.invitation_landing_client_id;
+      if (invitationLandingClientId) {
+        const c = clients?.find((cl) => cl.client_id === invitationLandingClientId);
+        client.my_organization_configuration.invitation_landing_client_id =
+          c?.name || invitationLandingClientId;
+      }
     }
 
     if (client.app_type === 'express_configuration') {

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -90,6 +90,14 @@ async function dump(context: YAMLContext): Promise<ParsedClients> {
         c?.name || myOrganizationConnectionProfileId;
     }
 
+    const invitationLandingClientId =
+      client?.my_organization_configuration?.invitation_landing_client_id;
+    if (client.my_organization_configuration && invitationLandingClientId) {
+      const c = clients?.find((cl) => cl.client_id === invitationLandingClientId);
+      client.my_organization_configuration.invitation_landing_client_id =
+        c?.name || invitationLandingClientId;
+    }
+
     return client;
   });
 

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -408,13 +408,7 @@ export const schema = {
   },
 };
 
-export type Client = Omit<Management.Client, 'my_organization_configuration'> & {
-  my_organization_configuration?:
-    | (Management.ClientMyOrganizationResponseConfiguration & {
-        invitation_landing_client_id?: string;
-      })
-    | null;
-};
+export type Client = Management.Client;
 
 type ClientSanitizerChain = {
   sanitizeOidcLogout(): ClientSanitizerChain;

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -57,6 +57,11 @@ const myOrganizationConfigurationSchema = {
       enum: Object.values(Management.ClientMyOrganizationDeletionBehaviorEnum),
       description: 'The deletion behavior for My Organization connections created by this client',
     },
+    invitation_landing_client_id: {
+      type: 'string',
+      description:
+        'The client ID of the invitation landing client for the My Organization configuration',
+    },
   },
   required: ['allowed_strategies', 'connection_deletion_behavior'],
 };
@@ -403,7 +408,13 @@ export const schema = {
   },
 };
 
-export type Client = Management.Client;
+export type Client = Omit<Management.Client, 'my_organization_configuration'> & {
+  my_organization_configuration?:
+    | (Management.ClientMyOrganizationResponseConfiguration & {
+        invitation_landing_client_id?: string;
+      })
+    | null;
+};
 
 type ClientSanitizerChain = {
   sanitizeOidcLogout(): ClientSanitizerChain;
@@ -768,6 +779,18 @@ export default class ClientHandler extends DefaultAPIHandler {
         );
         if (connectionProfile?.id) {
           client.my_organization_configuration.connection_profile_id = connectionProfile.id;
+        }
+      }
+
+      const invitationLandingClientName =
+        client.my_organization_configuration.invitation_landing_client_id;
+      if (invitationLandingClientName) {
+        const invitationLandingClient = clientData?.find(
+          (c) => c.name === invitationLandingClientName
+        );
+        if (invitationLandingClient?.client_id) {
+          client.my_organization_configuration.invitation_landing_client_id =
+            invitationLandingClient.client_id;
         }
       }
 

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -311,6 +311,15 @@ describe('#directory context clients', () => {
         },
       },
       {
+        name: 'someClientUnknownInvitation',
+        app_type: 'regular_web',
+        my_organization_configuration: {
+          invitation_landing_client_id: 'cli_unknown',
+          allowed_strategies: ['okta'],
+          connection_deletion_behavior: 'allow_if_empty',
+        },
+      },
+      {
         client_id: 'cli_abc',
         name: 'My Invitation Landing Client',
       },
@@ -333,6 +342,13 @@ describe('#directory context clients', () => {
         connection_deletion_behavior: 'allow_if_empty',
       },
     });
+
+    const dumpedClientUnknown = loadJSON(
+      path.join(dir, 'clients', 'someClientUnknownInvitation.json')
+    );
+    expect(dumpedClientUnknown.my_organization_configuration.invitation_landing_client_id).to.equal(
+      'cli_unknown'
+    );
   });
 
   it('should dump clients with app_type express_configuration and filter fields', async () => {

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -305,9 +305,14 @@ describe('#directory context clients', () => {
         my_organization_configuration: {
           user_attribute_profile_id: 'uap_123',
           connection_profile_id: 'cp_123',
+          invitation_landing_client_id: 'cli_abc',
           allowed_strategies: ['okta', 'samlp'],
           connection_deletion_behavior: 'allow_if_empty',
         },
+      },
+      {
+        client_id: 'cli_abc',
+        name: 'My Invitation Landing Client',
       },
     ];
 
@@ -323,6 +328,7 @@ describe('#directory context clients', () => {
       my_organization_configuration: {
         user_attribute_profile_id: 'My User Attribute Profile',
         connection_profile_id: 'My Connection Profile',
+        invitation_landing_client_id: 'My Invitation Landing Client',
         allowed_strategies: ['okta', 'samlp'],
         connection_deletion_behavior: 'allow_if_empty',
       },

--- a/test/context/yaml/clients.test.js
+++ b/test/context/yaml/clients.test.js
@@ -270,9 +270,14 @@ describe('#YAML context clients', () => {
         my_organization_configuration: {
           user_attribute_profile_id: 'uap_123',
           connection_profile_id: 'cp_123',
+          invitation_landing_client_id: 'cli_abc',
           allowed_strategies: ['okta', 'samlp'],
           connection_deletion_behavior: 'allow_if_empty',
         },
+      },
+      {
+        client_id: 'cli_abc',
+        name: 'My Invitation Landing Client',
       },
     ];
 
@@ -287,6 +292,7 @@ describe('#YAML context clients', () => {
       my_organization_configuration: {
         user_attribute_profile_id: 'My User Attribute Profile',
         connection_profile_id: 'My Connection Profile',
+        invitation_landing_client_id: 'My Invitation Landing Client',
         allowed_strategies: ['okta', 'samlp'],
         connection_deletion_behavior: 'allow_if_empty',
       },

--- a/test/context/yaml/clients.test.js
+++ b/test/context/yaml/clients.test.js
@@ -276,6 +276,15 @@ describe('#YAML context clients', () => {
         },
       },
       {
+        name: 'someClientUnknownInvitation',
+        app_type: 'regular_web',
+        my_organization_configuration: {
+          invitation_landing_client_id: 'cli_unknown',
+          allowed_strategies: ['okta'],
+          connection_deletion_behavior: 'allow_if_empty',
+        },
+      },
+      {
         client_id: 'cli_abc',
         name: 'My Invitation Landing Client',
       },
@@ -297,6 +306,10 @@ describe('#YAML context clients', () => {
         connection_deletion_behavior: 'allow_if_empty',
       },
     });
+
+    expect(
+      dumped.clients[1].my_organization_configuration.invitation_landing_client_id
+    ).to.equal('cli_unknown');
   });
 
   it('should dump clients with app_type express_configuration and filter fields', async () => {

--- a/test/context/yaml/clients.test.js
+++ b/test/context/yaml/clients.test.js
@@ -307,9 +307,9 @@ describe('#YAML context clients', () => {
       },
     });
 
-    expect(
-      dumped.clients[1].my_organization_configuration.invitation_landing_client_id
-    ).to.equal('cli_unknown');
+    expect(dumped.clients[1].my_organization_configuration.invitation_landing_client_id).to.equal(
+      'cli_unknown'
+    );
   });
 
   it('should dump clients with app_type express_configuration and filter fields', async () => {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -505,19 +505,34 @@ describe('#clients handler', () => {
         },
       };
 
+      const clientWithUnknownInvitation = {
+        name: 'Client With Unknown Invitation',
+        app_type: 'regular_web',
+        my_organization_configuration: {
+          invitation_landing_client_id: 'Unknown Client',
+          allowed_strategies: ['okta'],
+          connection_deletion_behavior: 'allow_if_empty',
+        },
+      };
+
       const auth0 = {
         clients: {
           create: function (data) {
             wasCreateCalled = true;
             expect(data).to.be.an('object');
-            expect(data.name).to.equal('Client With My Org Config');
-            expect(data.my_organization_configuration).to.deep.equal({
-              user_attribute_profile_id: 'uap_123',
-              connection_profile_id: 'cp_123',
-              invitation_landing_client_id: 'cli_abc',
-              allowed_strategies: ['okta', 'samlp'],
-              connection_deletion_behavior: 'allow_if_empty',
-            });
+            if (data.name === 'Client With My Org Config') {
+              expect(data.my_organization_configuration).to.deep.equal({
+                user_attribute_profile_id: 'uap_123',
+                connection_profile_id: 'cp_123',
+                invitation_landing_client_id: 'cli_abc',
+                allowed_strategies: ['okta', 'samlp'],
+                connection_deletion_behavior: 'allow_if_empty',
+              });
+            } else if (data.name === 'Client With Unknown Invitation') {
+              expect(
+                data.my_organization_configuration.invitation_landing_client_id
+              ).to.equal('Unknown Client');
+            }
             return Promise.resolve({ data });
           },
           update: () => Promise.resolve({ data: [] }),
@@ -544,7 +559,9 @@ describe('#clients handler', () => {
 
       const handler = new clients.default({ client: pageClient(auth0), config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
-      await stageFn.apply(handler, [{ clients: [clientWithMyOrganizationConfig] }]);
+      await stageFn.apply(handler, [
+        { clients: [clientWithMyOrganizationConfig, clientWithUnknownInvitation] },
+      ]);
       expect(wasCreateCalled).to.be.equal(true);
     });
 

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -499,6 +499,7 @@ describe('#clients handler', () => {
         my_organization_configuration: {
           user_attribute_profile_id: 'My User Attribute Profile',
           connection_profile_id: 'My Connection Profile',
+          invitation_landing_client_id: 'My Invitation Landing Client',
           allowed_strategies: ['okta', 'samlp'],
           connection_deletion_behavior: 'allow_if_empty',
         },
@@ -513,6 +514,7 @@ describe('#clients handler', () => {
             expect(data.my_organization_configuration).to.deep.equal({
               user_attribute_profile_id: 'uap_123',
               connection_profile_id: 'cp_123',
+              invitation_landing_client_id: 'cli_abc',
               allowed_strategies: ['okta', 'samlp'],
               connection_deletion_behavior: 'allow_if_empty',
             });
@@ -520,7 +522,10 @@ describe('#clients handler', () => {
           },
           update: () => Promise.resolve({ data: [] }),
           delete: () => Promise.resolve({ data: [] }),
-          list: (params) => mockPagedData(params, 'clients', []),
+          list: (params) =>
+            mockPagedData(params, 'clients', [
+              { client_id: 'cli_abc', name: 'My Invitation Landing Client' },
+            ]),
         },
         connectionProfiles: {
           list: (params) =>

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -529,9 +529,9 @@ describe('#clients handler', () => {
                 connection_deletion_behavior: 'allow_if_empty',
               });
             } else if (data.name === 'Client With Unknown Invitation') {
-              expect(
-                data.my_organization_configuration.invitation_landing_client_id
-              ).to.equal('Unknown Client');
+              expect(data.my_organization_configuration.invitation_landing_client_id).to.equal(
+                'Unknown Client'
+              );
             }
             return Promise.resolve({ data });
           },


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Added support for `invitation_landing_client_id` within the `my_organization_configuration` object on the Client entity. This field references the client used as the invitation landing page for the My Organization API.

On `export`, the client ID is resolved to the client's name for environment portability. On `import`/`deploy`, the name is resolved back to a client ID before calling the Management API.

#### Shape

JSON (directory format):
```json
{
  "name": "My App",
  "app_type": "regular_web",
  "my_organization_configuration": {
    "connection_profile_id": "My Connection Profile",
    "user_attribute_profile_id": "My User Attribute Profile",
    "invitation_landing_client_id": "My Invitation Landing Client",
    "allowed_strategies": ["okta", "samlp"],
    "connection_deletion_behavior": "allow_if_empty"
  }
}
```

YAML format:
```yaml
clients:
  - name: My App
    app_type: regular_web
    my_organization_configuration:
      connection_profile_id: My Connection Profile
      user_attribute_profile_id: My User Attribute Profile
      invitation_landing_client_id: My Invitation Landing Client
      allowed_strategies:
        - okta
        - samlp
      connection_deletion_behavior: allow_if_empty
```

### 🔬 Testing

Unit tests updated in:

* `test/tools/auth0/handlers/clients.tests.js` - verifies name -> ID mapping on deploy
* `test/context/directory/clients.test.js` - verifies ID -> name mapping on directory export
* `test/context/yaml/clients.test.js` - verifies ID -> name mapping on YAML export

For end-to-end testing, a tenant with enabled and a client with `invitation_landing_client_id` set is required. Export should produce the client name in the config; re-importing should resolve it back to the correct client ID.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
