### PR TITLE
fix: remove incorrect maximum priority constraint from Network ACL schema 

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -792,7 +792,7 @@ NetworkACLs have the following key properties:
 
 - `description`: A descriptive name for the rule
 - `active`: Boolean indicating if the rule is active
-- `priority`: Number between 1-10 determining the order of rule evaluation (lower numbers have higher priority)
+- `priority`: Number (minimum 1) determining the order of rule evaluation (lower numbers have higher priority)
 - `rule`: The rule configuration containing:
   - `action`: The action to take (block, allow, log, or redirect)
   - `scope`: The scope of the rule ('management', 'authentication', or 'tenant')

--- a/src/tools/auth0/handlers/networkACLs.ts
+++ b/src/tools/auth0/handlers/networkACLs.ts
@@ -72,7 +72,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     geo_country_codes: {
       type: 'array',
@@ -81,7 +80,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     geo_subdivision_codes: {
       type: 'array',
@@ -90,7 +88,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     ipv4_cidrs: {
       type: 'array',
@@ -99,7 +96,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     ipv6_cidrs: {
       type: 'array',
@@ -108,7 +104,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     ja3_fingerprints: {
       type: 'array',
@@ -117,7 +112,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     ja4_fingerprints: {
       type: 'array',
@@ -126,7 +120,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     user_agents: {
       type: 'array',
@@ -135,7 +128,6 @@ const MatchSchema = {
       },
       uniqueItems: true,
       minItems: 1,
-      maxItems: 10,
     },
     hostnames: {
       type: 'array',

--- a/src/tools/auth0/handlers/networkACLs.ts
+++ b/src/tools/auth0/handlers/networkACLs.ts
@@ -179,7 +179,6 @@ export const schema = {
       priority: {
         type: 'number',
         minimum: 1,
-        maximum: 10,
       },
       rule: {
         anyOf: [

--- a/test/tools/auth0/handlers/networkACLs.test.ts
+++ b/test/tools/auth0/handlers/networkACLs.test.ts
@@ -65,6 +65,29 @@ describe('#networkACLs handler', () => {
 
       await stageFn.apply(handler, [{ networkACLs: data }]);
     });
+
+    it('should pass validation for priority greater than 10', async () => {
+      const handler = new NetworkACLsHandler({ client: {}, config } as any);
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          description: 'High Priority Rule',
+          active: true,
+          priority: 15,
+          rule: {
+            action: {
+              block: true,
+            },
+            scope: 'tenant',
+            match: {
+              asns: [12345],
+            },
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ networkACLs: data }]);
+    });
   });
 
   describe('#networkACLs process', () => {


### PR DESCRIPTION
### 🔧 Changes

Removes the incorrect `maximum: 10` client-side constraint on the Network ACL `priority` field in the JSON schema validation. The Management API has no such restriction and accepts priority values greater than 10, so the Deploy CLI was incorrectly blocking valid configurations during import.                                                                                                         
                                         
Also updates the documentation to remove the "1-10" range description for priority. 

### 📚 References

### 🔬 Testing

Unit tests updated to include a validation test case with `priority: 15` confirming values above 10 now pass schema validation. No end-to-end testing required as the fix is purely a removal of a client-side schema constraint, the Management API already accepts these values.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)


