### PR TITLE
feat: add session_transfer delegation config support for CTE impersonation

### DIFF
--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -210,6 +210,25 @@ export const schema = {
               "Indicates whether Refresh Tokens created during a native-to-web session are tied to that session's lifetime. This determines if such refresh tokens should be automatically revoked when their corresponding sessions are. Usually configured in the web application.",
             default: true,
           },
+          delegation: {
+            type: 'object',
+            description:
+              'Settings for impersonation via session transfer. Required to accept Session Transfer Tokens that contain an Actor.',
+            properties: {
+              allow_delegated_access: {
+                type: 'boolean',
+                description:
+                  'Allows clients to access an impersonated session via SSO by accepting STTs that contain an Actor.',
+              },
+              enforce_device_binding: {
+                type: 'string',
+                description:
+                  "Enforces device binding for impersonation sessions. Defaults to 'ip' when omitted.",
+                enum: ['ip', 'asn'],
+              },
+            },
+            additionalProperties: false,
+          },
         },
         additionalProperties: true,
       },

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -405,6 +405,46 @@ describe('#clients handler', () => {
       expect(wasCreateCalled).to.be.true;
     });
 
+    it('should allow valid session_transfer delegation property in client', async () => {
+      const clientWithDelegation = {
+        name: 'clientWithDelegation',
+        session_transfer: {
+          delegation: {
+            allow_delegated_access: true,
+            enforce_device_binding: 'ip',
+          },
+        },
+      };
+      let wasCreateCalled = false;
+      const auth0 = {
+        clients: {
+          create: function (data) {
+            wasCreateCalled = true;
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('clientWithDelegation');
+            expect(data.session_transfer.delegation).to.deep.equal({
+              allow_delegated_access: true,
+              enforce_device_binding: 'ip',
+            });
+            return Promise.resolve({ data });
+          },
+          update: () => Promise.resolve({ data: [] }),
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [{ clients: [clientWithDelegation] }]);
+      // eslint-disable-next-line no-unused-expressions
+      expect(wasCreateCalled).to.be.true;
+    });
+
     it('should create resource server client', async () => {
       let wasCreateCalled = false;
       const resourceServerClient = {


### PR DESCRIPTION
### 🔧 Changes

Added support for `session_transfer.delegation` configuration on clients, enabling the Custom Token Exchange Impersonation via Session Transfer feature (Phase 2).

  New optional properties under `session_transfer.delegation`:
  - `allow_delegated_access` (boolean) — allows clients to accept Session Transfer Tokens that contain an Actor, enabling impersonated SSO sessions
  - `enforce_device_binding` (string: `"ip"` | `"asn"`) — enforces device binding for impersonation sessions; defaults to `"ip"` when omitted

### 📚 References



### 🔬 Testing

 **Unit test** added in `test/tools/auth0/handlers/clients.tests.js`: `should allow valid session_transfer delegation property in client` — verifies the delegation config is
  correctly passed through to the Management API on client create.

  **Manual end-to-end test** against a tenant with the Custom Token Exchange Delegation feature flag enabled:
  1. Added `session_transfer.delegation.allow_delegated_access: true` and `enforce_device_binding: ip` to a `regular_web` client config
  2. Ran `a0deploy import` - Management API accepted the properties and returned 200
  3. Verified the properties were persisted on the client via the Management API

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)


