### PR TITLE
feat: add fedcm_login support for Google One Tap / FedCM in Universal Login

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@clack/prompts": "1.3.0",
     "ajv": "^6.12.6",
-    "auth0": "^5.12.0",
+    "auth0": "^5.13.0",
     "chalk": "5.6.2",
     "dot-prop": "^5.3.0",
     "fs-extra": "^10.1.0",

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -403,6 +403,18 @@ export const schema = {
           },
         },
       },
+      fedcm_login: {
+        type: ['object', 'null'],
+        description: 'Configuration for FedCM (Federated Credential Management) login',
+        properties: {
+          google: {
+            type: 'object',
+            properties: {
+              is_enabled: { type: 'boolean' },
+            },
+          },
+        },
+      },
     },
     required: ['name'],
   },

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -412,8 +412,10 @@ export const schema = {
             properties: {
               is_enabled: { type: 'boolean' },
             },
+            required: ['is_enabled'],
           },
         },
+        required: ['google'],
       },
     },
     required: ['name'],

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import pageClient from '../../../../src/tools/auth0/client';
 
+const Ajv = require('ajv');
 const { expect } = require('chai');
 const clients = require('../../../../src/tools/auth0/handlers/clients');
 const { mockPagedData } = require('../../../utils');
@@ -47,6 +48,52 @@ describe('#clients handler', () => {
     AUTH0_CLIENT_ID: 'client_id',
     AUTH0_ALLOW_DELETE: true,
   };
+
+  describe('#clients schema', () => {
+    const ajv = new Ajv({ useDefaults: true, nullable: true });
+
+    it('should pass validation with fedcm_login', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: { google: { is_enabled: true } },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should pass validation with fedcm_login set to null', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: null,
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should fail validation with fedcm_login missing google', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: {},
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
+
+    it('should fail validation with fedcm_login.google missing is_enabled', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: { google: {} },
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
+  });
 
   describe('#clients validate', () => {
     it('should not allow same names', async () => {
@@ -95,35 +142,6 @@ describe('#clients handler', () => {
       await stageFn.apply(handler, [{ clients: data }]);
     });
 
-    it('should pass validation with fedcm_login', async () => {
-      const handler = new clients.default({ client: {}, config });
-      const stageFn = Object.getPrototypeOf(handler).validate;
-      const data = [
-        {
-          name: 'someFedCMClient',
-          fedcm_login: {
-            google: {
-              is_enabled: true,
-            },
-          },
-        },
-      ];
-
-      await stageFn.apply(handler, [{ clients: data }]);
-    });
-
-    it('should pass validation with fedcm_login set to null', async () => {
-      const handler = new clients.default({ client: {}, config });
-      const stageFn = Object.getPrototypeOf(handler).validate;
-      const data = [
-        {
-          name: 'someFedCMClient',
-          fedcm_login: null,
-        },
-      ];
-
-      await stageFn.apply(handler, [{ clients: data }]);
-    });
   });
 
   describe('#clients process', () => {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -94,6 +94,36 @@ describe('#clients handler', () => {
 
       await stageFn.apply(handler, [{ clients: data }]);
     });
+
+    it('should pass validation with fedcm_login', async () => {
+      const handler = new clients.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: {
+            google: {
+              is_enabled: true,
+            },
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ clients: data }]);
+    });
+
+    it('should pass validation with fedcm_login set to null', async () => {
+      const handler = new clients.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          name: 'someFedCMClient',
+          fedcm_login: null,
+        },
+      ];
+
+      await stageFn.apply(handler, [{ clients: data }]);
+    });
   });
 
   describe('#clients process', () => {
@@ -305,6 +335,45 @@ describe('#clients handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [{ clients: [someNativeClient] }]);
+    });
+
+    it('should create client with fedcm_login', async () => {
+      const fedcmClient = {
+        name: 'someFedCMClient',
+        fedcm_login: {
+          google: {
+            is_enabled: true,
+          },
+        },
+      };
+
+      const auth0 = {
+        clients: {
+          create: function (data) {
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('someFedCMClient');
+            expect(data.fedcm_login).to.deep.equal({
+              google: {
+                is_enabled: true,
+              },
+            });
+            return Promise.resolve({ data });
+          },
+          update: () => Promise.resolve({ data: [] }),
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [{ clients: [fedcmClient] }]);
     });
 
     it('should create client with refresh token policies', async () => {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -141,7 +141,6 @@ describe('#clients handler', () => {
 
       await stageFn.apply(handler, [{ clients: data }]);
     });
-
   });
 
   describe('#clients process', () => {


### PR DESCRIPTION
### 🔧 Changes

Adds fedcm_login to the client JSON schema to support the Google One Tap / FedCM (Federated Credential Management) feature in New Universal Login.                           
                                                                                                                                                                               
  Schema addition (`src/tools/auth0/handlers/clients.ts`):
  - fedcm_login - optional object (null supported for deletion via PATCH)                                                                                                      
    - fedcm_login.google - required if fedcm_login is defined                                                                                                                  
        - fedcm_login.google.is_enabled - boolean, controls whether the Google One Tap prompt is shown on New Universal Login for this client                                  

  No additional handler changes were required - fedcm_login is a plain nested object with no ID-to-name mapping, no special serialization, and is valid on both create and
  update operations.

### 📚 References



### 🔬 Testing

 Unit tests (`test/tools/auth0/handlers/clients.tests.js`):
  - should pass validation with fedcm_login - { google: { is_enabled: true } } accepted by schema
  - should pass validation with fedcm_login set to null - null accepted by schema (deletion case)
  - should create client with fedcm_login - fedcm_login passed through unchanged to the API create call

Manual end-to-end against dev-ankita-t.us.auth0.com (feature flag enable_google_one_tap_ul enabled):

| Scenario | Operation | Result |
|--------|--------|--------|
| is_enabled: true on existing client | PATCH | Written and returned in export |
| is_enabled: false on existing client | PATCH | Written and returned in export |
| fedcm_login: null   | PATCH | Field absent from export |
| New client with fedcm_login  | POST (create) | Written and returned in export | 


 
### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

