### PR TITLE
fix: allow Auth0 lowercase template variables to pass keyword placeholder validation

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -251,7 +251,7 @@ export const obfuscateSensitiveValues = (
   return newAsset;
 };
 
-const UNRESOLVED_PLACEHOLDER_REGEX = /^(##.+##|@@.+@@)$/;
+const UNRESOLVED_PLACEHOLDER_REGEX = /^(##[A-Z0-9_]+##|@@[A-Z0-9_]+@@)$/;
 
 // Recursively collects all fields in an asset that still contain an unresolved
 // ##...## (string) or @@...@@ (array) keyword placeholder.

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -251,6 +251,7 @@ export const obfuscateSensitiveValues = (
   return newAsset;
 };
 
+// Uppercase-only to avoid false positives on lowercase Auth0 template variables like @@password@@
 const UNRESOLVED_PLACEHOLDER_REGEX = /^(##[A-Z0-9_]+##|@@[A-Z0-9_]+@@)$/;
 
 // Recursively collects all fields in an asset that still contain an unresolved

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -631,7 +631,7 @@ describe('#filterExcluded', () => {
         id: 'asset-id-4',
         name: 'resolved-resource',
         secret: 'a-real-secret-value',
-        options: { domain: 'example.auth0.com' },
+        options: { domain: 'example.auth0.com', template: '@@password@@' },
       };
 
       const result = utils.validateNoUnresolvedPlaceholders(asset, 'clients', 'resolved-resource');


### PR DESCRIPTION
Auth0 SMS connections support native template variables like `@@password@@` that were being incorrectly flagged as unresolved keyword placeholders, causing imports to fail.

### 🔧 Changes

* Tightened the unresolved placeholder regex to only match uppercase patterns (`[A-Z0-9_]`), aligning with the established deploy-cli keyword convention (`@@MY_KEY@@`, `##MY_SECRET##`). Lowercase Auth0-native template variables are no longer flagged as unresolved.

### 📚 References

[Auth0 SMS template variables documentation](https://auth0.com/docs/authenticate/passwordless/authentication-methods/email-otp/customize-otp-notifications-for-email-passwordless-connections)

### 🔬 Testing

#### Unit tests: 

* Updated an existing test in `test/tools/utils.test.js` to include a lowercase `@@...@@` value, confirming it no longer throws

#### Manual end-to-end:

* Created an SMS passwordless connection in a test tenant with template: `@@password@@`
* Exported the tenant with a0deploy export --format yaml
* Before applying  fix: `import` failed with `Unresolved placeholder(s) found in connections: "options.template": @@password@@`
* After applying fix: `import` completed successfully - SMS connection updated without error
* Confirmed uppercase unresolved placeholders (e.g. `##CONNECTIONS_OAUTH2_SECRET##`) still correctly throw an error

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
