### PR TITLE
feat: add login-post-identifier and signup-post-identifier action triggers

### DIFF
--- a/examples/directory/triggers/triggers.json
+++ b/examples/directory/triggers/triggers.json
@@ -14,5 +14,7 @@
       "action_name": "ldoorz",
       "display_name": "ldoorz"
     }
-  ]
+  ],
+  "login-post-identifier": [],
+  "signup-post-identifier": []
 }

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -384,6 +384,8 @@ triggers:
   post-user-registration: []
   pre-user-registration: []
   send-phone-message: []
+  login-post-identifier: []
+  signup-post-identifier: []
 
 prompts:
   customText:

--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -70,6 +70,8 @@ const constants = {
     'send-phone-message',
     'password-reset-post-challenge',
     'custom-token-exchange',
+    'login-post-identifier',
+    'signup-post-identifier',
   ],
   EMAIL_TEMPLATES_DIRECTORY: 'emails',
   EMAIL_VERIFY,


### PR DESCRIPTION
### 🔧 Changes

Add `login-post-identifier` and `signup-post-identifier` to the list of supported action triggers.
                                                                                                                                                                               
  - Added both triggers to `ACTIONS_TRIGGERS` in `src/tools/constants.ts`
  - Updated example configs (`examples/directory/triggers/triggers.json`, `examples/yaml/tenant.yaml`)

### 📚 References

- Auth0 Terraform Provider: [auth0/terraform-provider-auth0#1605](https://github.com/auth0/terraform-provider-auth0/pull/1605)

### 🔬 Testing

- Existing trigger tests cover the new entries via the `ACTIONS_TRIGGERS` constant
- Manual: deploy a tenant config containing `login-post-identifier` or `signup-post-identifier` trigger bindings

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)


