### PR TITLE
feat: add id_token_session_expiry_supported validation for enterprise connnections(IPSIE)

### DIFF
--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -51,6 +51,7 @@ const oidcOktaOnlyConnectionOptionFields = [
   'token_endpoint_auth_signing_alg',
   'id_token_signed_response_algs',
   'token_endpoint_jwtca_aud_format',
+  'id_token_session_expiry_supported',
 ];
 
 export const schema = {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -123,6 +123,7 @@ describe('#connections handler', () => {
             token_endpoint_auth_signing_alg: 'RS256',
             id_token_signed_response_algs: ['RS256', 'RS512'],
             token_endpoint_jwtca_aud_format: 'issuer',
+            id_token_session_expiry_supported: true,
           },
         },
         {
@@ -132,6 +133,7 @@ describe('#connections handler', () => {
             token_endpoint_auth_signing_alg: 'RS384',
             id_token_signed_response_algs: ['RS384'],
             token_endpoint_jwtca_aud_format: 'token_endpoint',
+            id_token_session_expiry_supported: false,
           },
         },
       ];
@@ -150,6 +152,7 @@ describe('#connections handler', () => {
             token_endpoint_auth_signing_alg: 'RS256',
             id_token_signed_response_algs: ['RS256'],
             token_endpoint_jwtca_aud_format: 'issuer',
+            id_token_session_expiry_supported: true,
           },
         },
       ];


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Added `id_token_session_expiry_supported` to the list of OIDC/Okta-only connection option fields. This boolean field is part of the IPSIE session expiry claims feature and is only valid for `oidc` and `okta` connection strategies. Deploy-cli will now throw a `ValidationError` if the field is used on any other strategy.

No schema changes are required as connection options already accept additional properties and the field passes through to the Management API as-is.

#### Shape:

`YAML`:

```yaml
connections:
  - name: my-oidc-connection
    strategy: oidc
    options:
      client_id: YOUR_CLIENT_ID
      client_secret: YOUR_CLIENT_SECRET
      discovery_url: https://YOUR_IDP/.well-known/openid-configuration
      id_token_session_expiry_supported: true
```
Note: Requires the `id_token_session_expiry_federated` feature flag to be enabled on the tenant.

### 🔬 Testing

* Unit tests updated to cover:
    * id_token_session_expiry_supported is accepted on oidc and okta strategies
    * id_token_session_expiry_supported is rejected (ValidationError) on non-oidc/okta strategies (e.g. samlp)
* Manually verified end-to-end on a tenant with the feature flag enabled: imported an OIDC connection with `id_token_session_expiry_supported: true`, then exported and confirmed the field round-trips correctly.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
