### PR TITLE
fix: preserve false value for default_head_tags_disabled in screen renderer update

### DIFF
--- a/src/tools/auth0/handlers/prompts.ts
+++ b/src/tools/auth0/handlers/prompts.ts
@@ -610,7 +610,7 @@ export default class PromptsHandler extends DefaultHandler {
       updatePayload = {
         ...updatePrams,
         rendering_mode: Management.AculRenderingModeEnum.Advanced,
-        default_head_tags_disabled: screenRenderer.default_head_tags_disabled || undefined,
+        default_head_tags_disabled: screenRenderer.default_head_tags_disabled ?? undefined,
         head_tags: screenRenderer.head_tags as Management.AculHeadTag[],
       };
     }

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -440,8 +440,9 @@ describe('#prompts handler', () => {
             return Promise.resolve({ data });
           },
           rendering: {
-            update: () => {
+            update: (_prompt: string, _screen: string, payload: { default_head_tags_disabled?: boolean | null }) => {
               didCallUpdateScreenRenderer = true;
+              expect(payload).to.have.property('default_head_tags_disabled', false);
               return Promise.resolve({ data: {} });
             },
           },
@@ -649,6 +650,39 @@ describe('#prompts handler', () => {
         screenRenderers: [],
       });
       sinon.restore();
+    });
+
+    it('should send default_head_tags_disabled: false to the API (not drop it as undefined)', async () => {
+      let capturedPayload: any = null;
+
+      const auth0 = {
+        prompts: {
+          rendering: {
+            update: (_prompt: string, _screen: string, payload: any) => {
+              capturedPayload = payload;
+              return Promise.resolve({ data: {} });
+            },
+          },
+        },
+        pool: new PromisePoolExecutor({
+          concurrencyLimit: 3,
+          frequencyLimit: 1000,
+          frequencyWindow: 1000,
+        }),
+      };
+
+      const handler = new promptsHandler({ client: auth0, config: config });
+
+      await handler.updateScreenRenderer({
+        prompt: 'login',
+        screen: 'login',
+        rendering_mode: 'advanced',
+        default_head_tags_disabled: false,
+        head_tags: [],
+      });
+
+      expect(capturedPayload).to.not.equal(null);
+      expect(capturedPayload).to.have.property('default_head_tags_disabled', false);
     });
   });
   describe('withErrorHandling', () => {

--- a/test/tools/auth0/handlers/prompts.tests.ts
+++ b/test/tools/auth0/handlers/prompts.tests.ts
@@ -440,7 +440,11 @@ describe('#prompts handler', () => {
             return Promise.resolve({ data });
           },
           rendering: {
-            update: (_prompt: string, _screen: string, payload: { default_head_tags_disabled?: boolean | null }) => {
+            update: (
+              _prompt: string,
+              _screen: string,
+              payload: { default_head_tags_disabled?: boolean | null }
+            ) => {
               didCallUpdateScreenRenderer = true;
               expect(payload).to.have.property('default_head_tags_disabled', false);
               return Promise.resolve({ data: {} });


### PR DESCRIPTION
### 🔧 Changes

Fix `default_head_tags_disabled` being silently ignored when set to false in screen renderer settings. The field uses the `||` operator which coerces `false` to `undefined`, causing it to be omitted from the Management API request body. Changed to `??` (nullish coalescing) so that only `null`/`undefined` fall back, preserving explicit `false` values.

This means once `default_head_tags_disabled: true` was deployed, it could never be reverted to false via the CLI.

### 📚 References

fixes #1413 

### 🔬 Testing

* Added a unit test in `test/tools/auth0/handlers/prompts.tests.ts` that calls `updateScreenRenderer` with `default_head_tags_disabled: false` and asserts the captured API payload contains false (not undefined). This test fails on the original code and passes after the fix.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
