### PR TITLE
feat: add client credential lifecycle management for Private Key JWT and mTLS

### DIFF
--- a/src/context/directory/handlers/clientAuthCredentials.ts
+++ b/src/context/directory/handlers/clientAuthCredentials.ts
@@ -1,0 +1,20 @@
+import { DirectoryHandler } from '.';
+import DirectoryContext from '..';
+import { ParsedAsset } from '../../../types';
+
+type ParsedClientAuthCredentials = ParsedAsset<'clientAuthCredentials', null>;
+
+function parse(_context: DirectoryContext): ParsedClientAuthCredentials {
+  return { clientAuthCredentials: null };
+}
+
+async function dump(_context: DirectoryContext): Promise<void> {
+  // Credentials are embedded inside each client's JSON file — nothing to dump separately.
+}
+
+const clientAuthCredentialsHandler: DirectoryHandler<ParsedClientAuthCredentials> = {
+  parse,
+  dump,
+};
+
+export default clientAuthCredentialsHandler;

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -140,6 +140,16 @@ async function dump(context: DirectoryContext): Promise<void> {
         client_authentication_methods: client.client_authentication_methods,
         organization_require_behavior: client.organization_require_behavior,
       } as Client;
+    } else {
+      // strip id-only credentials — they carry no useful info and would
+      // confuse the clientAuthCredentials handler on deploy
+      if (client.client_authentication_methods) {
+        Object.values(client.client_authentication_methods).forEach((method: any) => {
+          if (method?.credentials) {
+            method.credentials = method.credentials.filter((c: any) => c.name);
+          }
+        });
+      }
     }
 
     dumpJSON(clientFile, clearClientArrays(client));

--- a/src/context/directory/handlers/index.ts
+++ b/src/context/directory/handlers/index.ts
@@ -39,6 +39,7 @@ import connectionProfiles from './connectionProfiles';
 import tokenExchangeProfiles from './tokenExchangeProfiles';
 import supplementalSignals from './supplementalSignals';
 import eventStreams from './eventStreams';
+import clientAuthCredentials from './clientAuthCredentials';
 
 import DirectoryContext from '..';
 import { AssetTypes, Asset } from '../../../types';
@@ -94,6 +95,7 @@ const directoryHandlers: {
   tokenExchangeProfiles,
   supplementalSignals,
   eventStreams,
+  clientAuthCredentials,
 };
 
 export default directoryHandlers;

--- a/src/context/yaml/handlers/clientAuthCredentials.ts
+++ b/src/context/yaml/handlers/clientAuthCredentials.ts
@@ -1,0 +1,20 @@
+import { YAMLHandler } from '.';
+import YAMLContext from '..';
+import { ParsedAsset } from '../../../types';
+
+type ParsedClientAuthCredentials = ParsedAsset<'clientAuthCredentials', null>;
+
+async function parse(_context: YAMLContext): Promise<ParsedClientAuthCredentials> {
+  return { clientAuthCredentials: null };
+}
+
+async function dump(_context: YAMLContext): Promise<ParsedClientAuthCredentials> {
+  return { clientAuthCredentials: null };
+}
+
+const clientAuthCredentialsHandler: YAMLHandler<ParsedClientAuthCredentials> = {
+  parse,
+  dump,
+};
+
+export default clientAuthCredentialsHandler;

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -124,6 +124,16 @@ async function dump(context: YAMLContext): Promise<ParsedClients> {
             client_authentication_methods: client.client_authentication_methods,
             organization_require_behavior: client.organization_require_behavior,
           } as Client;
+        } else {
+          // strip id-only credentials — they carry no useful info and would
+          // confuse the clientAuthCredentials handler on deploy
+          if (client.client_authentication_methods) {
+            Object.values(client.client_authentication_methods).forEach((method: any) => {
+              if (method?.credentials) {
+                method.credentials = method.credentials.filter((c: any) => c.name);
+              }
+            });
+          }
         }
 
         return clearClientArrays(client) as Client;

--- a/src/context/yaml/handlers/index.ts
+++ b/src/context/yaml/handlers/index.ts
@@ -39,6 +39,7 @@ import connectionProfiles from './connectionProfiles';
 import tokenExchangeProfiles from './tokenExchangeProfiles';
 import supplementalSignals from './supplementalSignals';
 import eventStreams from './eventStreams';
+import clientAuthCredentials from './clientAuthCredentials';
 
 import YAMLContext from '..';
 import { AssetTypes } from '../../../types';
@@ -92,6 +93,7 @@ const yamlHandlers: { [key in AssetTypes]: YAMLHandler<{ [key: string]: unknown 
   tokenExchangeProfiles,
   supplementalSignals,
   eventStreams,
+  clientAuthCredentials,
 };
 
 export default yamlHandlers;

--- a/src/tools/auth0/handlers/clientAuthCredentials.ts
+++ b/src/tools/auth0/handlers/clientAuthCredentials.ts
@@ -98,8 +98,10 @@ export default class ClientAuthCredentialsHandler {
         continue;
       }
 
-      // If no pem-based credentials in config and nothing in Auth0, nothing to do
-      if (desired.length === 0 && existing.length === 0) continue;
+      // Skip reconciliation entirely when no pem is present — pem is the opt-in signal.
+      // Without this guard, a plain export→deploy would delete all existing credentials
+      // because desired would be empty (exported credentials never have pem).
+      if (desired.length === 0) continue;
 
       // Warn if duplicate names exist in Auth0 — we can't match safely
       const existingNames = existing.map((c) => c.name);

--- a/src/tools/auth0/handlers/clientAuthCredentials.ts
+++ b/src/tools/auth0/handlers/clientAuthCredentials.ts
@@ -47,17 +47,24 @@ export default class ClientAuthCredentialsHandler {
     const allowDelete =
       this.config('AUTH0_ALLOW_DELETE') === true || this.config('AUTH0_ALLOW_DELETE') === 'true';
 
-    // Fetch existing clients from Auth0 so we can resolve names to IDs
-    // when client_id is null (directory mode strips it from exported JSON)
-    const existingClients = await paginate(this.client.clients.list, {
-      paginate: true,
-      is_global: false,
-    });
-    const clientIdByName = new Map(existingClients.map((c: any) => [c.name, c.client_id]));
+    const needsNameResolution = clients.some(
+      (c) => !c.client_id && c.client_authentication_methods
+    );
+
+    // Only fetch all clients when directory mode has stripped client_id (null) from any entry
+    // that also has client_authentication_methods — avoids an extra API call in the common case.
+    let clientIdByName = new Map<string, string>();
+    if (needsNameResolution) {
+      const existingClients = await paginate(this.client.clients.list, {
+        paginate: true,
+        is_global: false,
+      });
+      clientIdByName = new Map(existingClients.map((c: any) => [c.name, c.client_id]));
+    }
 
     for (const client of clients) {
       if (!client.client_authentication_methods) continue;
-      const clientId = (client.client_id || clientIdByName.get(client.name)) as string | undefined;
+      const clientId = client.client_id || (client.name && clientIdByName.get(client.name));
       if (!clientId) continue;
       client.client_id = clientId;
 
@@ -140,6 +147,7 @@ export default class ClientAuthCredentialsHandler {
       const createdIds = [...createdIdByName.values()];
       const finalIds = [...keptIds, ...createdIds];
 
+      let updatedAuthMethods: Record<string, any> = {};
       if (finalIds.length > 0) {
         // Build method→ids map. For kept credentials use Auth0's stored type to infer method;
         // for created credentials use the method from the user's config entry (by name).
@@ -155,12 +163,15 @@ export default class ClientAuthCredentialsHandler {
           if (!methodToIds[methodKey]) methodToIds[methodKey] = [];
           methodToIds[methodKey].push(id);
         }
-
-        const updatedAuthMethods: Record<string, any> = {};
         for (const [methodKey, ids] of Object.entries(methodToIds)) {
           updatedAuthMethods[methodKey] = { credentials: ids.map((id) => ({ id })) };
         }
+      }
 
+      // Always update client_authentication_methods before deletes:
+      // - When finalIds > 0: re-wire to the remaining credentials
+      // - When finalIds === 0 but toDelete > 0: clear references so Auth0 allows the deletes
+      if (finalIds.length > 0 || toDelete.length > 0) {
         try {
           await (this.client.clients.update as Function)(clientId, {
             client_authentication_methods: updatedAuthMethods,

--- a/src/tools/auth0/handlers/clientAuthCredentials.ts
+++ b/src/tools/auth0/handlers/clientAuthCredentials.ts
@@ -62,8 +62,7 @@ export default class ClientAuthCredentialsHandler {
       client.client_id = clientId;
 
       // Collect all desired credentials across all auth methods
-      const desired: { name: string; pem?: string; credential_type: string; method: string }[] =
-        [];
+      const desired: { name: string; pem?: string; credential_type: string; method: string }[] = [];
 
       for (const [methodKey, methodVal] of Object.entries(
         client.client_authentication_methods as Record<string, any>
@@ -86,7 +85,9 @@ export default class ClientAuthCredentialsHandler {
       try {
         existing = (await this.client.clients.credentials.list(clientId)) as any[];
       } catch (err) {
-        log.warn(`clientAuthCredentials: failed to list credentials for client "${clientName}": ${err}`);
+        log.warn(
+          `clientAuthCredentials: failed to list credentials for client "${clientName}": ${err}`
+        );
         continue;
       }
 
@@ -98,7 +99,9 @@ export default class ClientAuthCredentialsHandler {
       const duplicateNames = existingNames.filter((n, i) => existingNames.indexOf(n) !== i);
       if (duplicateNames.length > 0) {
         log.warn(
-          `clientAuthCredentials: client "${clientName}" has duplicate credential names in Auth0 [${duplicateNames.join(', ')}] — skipping credential reconciliation for this client`
+          `clientAuthCredentials: client "${clientName}" has duplicate credential names in Auth0 [${duplicateNames.join(
+            ', '
+          )}] — skipping credential reconciliation for this client`
         );
         continue;
       }
@@ -119,19 +122,21 @@ export default class ClientAuthCredentialsHandler {
             pem: cred.pem,
             credential_type: cred.credential_type,
           });
-          log.info(`clientAuthCredentials: created credential "${cred.name}" on client "${clientName}"`);
+          log.info(
+            `clientAuthCredentials: created credential "${cred.name}" on client "${clientName}"`
+          );
           createdIdByName.set(cred.name, created.id);
         } catch (err) {
-          log.warn(`clientAuthCredentials: failed to create credential "${cred.name}" on client "${clientName}": ${err}`);
+          log.warn(
+            `clientAuthCredentials: failed to create credential "${cred.name}" on client "${clientName}": ${err}`
+          );
         }
       }
 
       // Re-wire client_authentication_methods with final IDs (kept + newly created).
       // This must happen BEFORE deletes — Auth0 rejects deleting a credential that
       // is still referenced in client_authentication_methods.
-      const keptIds = existing
-        .filter((e) => desiredNames.has(e.name))
-        .map((e) => e.id);
+      const keptIds = existing.filter((e) => desiredNames.has(e.name)).map((e) => e.id);
       const createdIds = [...createdIdByName.values()];
       const finalIds = [...keptIds, ...createdIds];
 
@@ -160,9 +165,13 @@ export default class ClientAuthCredentialsHandler {
           await (this.client.clients.update as Function)(clientId, {
             client_authentication_methods: updatedAuthMethods,
           });
-          log.info(`clientAuthCredentials: updated client_authentication_methods on client "${clientName}"`);
+          log.info(
+            `clientAuthCredentials: updated client_authentication_methods on client "${clientName}"`
+          );
         } catch (err) {
-          log.warn(`clientAuthCredentials: failed to update client_authentication_methods on client "${clientName}": ${err}`);
+          log.warn(
+            `clientAuthCredentials: failed to update client_authentication_methods on client "${clientName}": ${err}`
+          );
         }
       }
 
@@ -170,15 +179,21 @@ export default class ClientAuthCredentialsHandler {
       if (toDelete.length > 0) {
         if (!allowDelete) {
           log.warn(
-            `clientAuthCredentials: the following credentials on client "${clientName}" would be deleted but AUTH0_ALLOW_DELETE is not set:\n${toDelete.map((c) => `  ${c.name} (${c.id})`).join('\n')}`
+            `clientAuthCredentials: the following credentials on client "${clientName}" would be deleted but AUTH0_ALLOW_DELETE is not set:\n${toDelete
+              .map((c) => `  ${c.name} (${c.id})`)
+              .join('\n')}`
           );
         } else {
           for (const cred of toDelete) {
             try {
               await (this.client.clients.credentials.delete as Function)(clientId, cred.id);
-              log.info(`clientAuthCredentials: deleted credential "${cred.name}" on client "${clientName}"`);
+              log.info(
+                `clientAuthCredentials: deleted credential "${cred.name}" on client "${clientName}"`
+              );
             } catch (err) {
-              log.warn(`clientAuthCredentials: failed to delete credential "${cred.name}" on client "${clientName}": ${err}`);
+              log.warn(
+                `clientAuthCredentials: failed to delete credential "${cred.name}" on client "${clientName}": ${err}`
+              );
             }
           }
         }

--- a/src/tools/auth0/handlers/clientAuthCredentials.ts
+++ b/src/tools/auth0/handlers/clientAuthCredentials.ts
@@ -1,0 +1,175 @@
+import { order } from './default';
+import { Assets, Auth0APIClient } from '../../../types';
+import { ConfigFunction } from '../../../configFactory';
+import log from '../../../logger';
+
+export const schema = {
+  type: 'array',
+  items: { type: 'object' },
+};
+
+const CREDENTIAL_TYPE_TO_METHOD: Record<string, string> = {
+  public_key: 'private_key_jwt',
+  x509_cert: 'self_signed_tls_client_auth',
+  cert_subject_dn: 'tls_client_auth',
+};
+
+export default class ClientAuthCredentialsHandler {
+  client: Auth0APIClient;
+  config: ConfigFunction;
+  type = 'clientAuthCredentials';
+  existing = null;
+
+  constructor({ client, config }: { client: Auth0APIClient; config: ConfigFunction }) {
+    this.client = client;
+    this.config = config;
+  }
+
+  async getType() {
+    return null;
+  }
+
+  @order('70')
+  async processChanges(assets: Assets): Promise<void> {
+    const { clients } = assets;
+    if (!clients) return;
+
+    const allowDelete =
+      this.config('AUTH0_ALLOW_DELETE') === true || this.config('AUTH0_ALLOW_DELETE') === 'true';
+
+    for (const client of clients) {
+      if (!client.client_id || !client.client_authentication_methods) continue;
+
+      // Collect all desired credentials across all auth methods
+      const desired: { name: string; pem?: string; credential_type: string; method: string }[] =
+        [];
+
+      for (const [methodKey, methodVal] of Object.entries(
+        client.client_authentication_methods as Record<string, any>
+      )) {
+        const credentials: any[] = methodVal?.credentials || [];
+        for (const cred of credentials) {
+          if (!cred.pem) continue; // only manage credentials the user has explicitly provided a pem for
+          desired.push({
+            name: cred.name,
+            pem: cred.pem,
+            credential_type: cred.credential_type || this.inferCredentialType(methodKey),
+            method: methodKey,
+          });
+        }
+      }
+
+      if (desired.length === 0) continue;
+
+      const clientId = client.client_id as string;
+      const clientName = client.name || clientId;
+
+      let existing: any[] = [];
+      try {
+        existing = (await this.client.clients.credentials.list(clientId)) as any[];
+      } catch (err) {
+        log.warn(`clientAuthCredentials: failed to list credentials for client "${clientName}": ${err}`);
+        continue;
+      }
+
+      // Warn if duplicate names exist in Auth0 — we can't match safely
+      const existingNames = existing.map((c) => c.name);
+      const duplicateNames = existingNames.filter((n, i) => existingNames.indexOf(n) !== i);
+      if (duplicateNames.length > 0) {
+        log.warn(
+          `clientAuthCredentials: client "${clientName}" has duplicate credential names in Auth0 [${duplicateNames.join(', ')}] — skipping credential reconciliation for this client`
+        );
+        continue;
+      }
+
+      const existingByName = new Map(existing.map((c) => [c.name, c]));
+      const desiredNames = new Set(desired.map((d) => d.name));
+
+      const toCreate = desired.filter((d) => !existingByName.has(d.name));
+      const toDelete = existing.filter((e) => !desiredNames.has(e.name));
+
+      // Creates first — Auth0 allows max 2 credentials; both must exist simultaneously during rotation
+      const createdIds: string[] = [];
+      for (const cred of toCreate) {
+        try {
+          const created = await (this.client.clients.credentials.create as Function)(clientId, {
+            name: cred.name,
+            pem: cred.pem,
+            credential_type: cred.credential_type,
+          });
+          log.info(`clientAuthCredentials: created credential "${cred.name}" on client "${clientName}"`);
+          createdIds.push(created.id);
+        } catch (err) {
+          log.warn(`clientAuthCredentials: failed to create credential "${cred.name}" on client "${clientName}": ${err}`);
+        }
+      }
+
+      // Deletes after — gated by AUTH0_ALLOW_DELETE
+      if (toDelete.length > 0) {
+        if (!allowDelete) {
+          log.warn(
+            `clientAuthCredentials: the following credentials on client "${clientName}" would be deleted but AUTH0_ALLOW_DELETE is not set:\n${toDelete.map((c) => `  ${c.name} (${c.id})`).join('\n')}`
+          );
+        } else {
+          for (const cred of toDelete) {
+            try {
+              await (this.client.clients.credentials.delete as Function)(clientId, cred.id);
+              log.info(`clientAuthCredentials: deleted credential "${cred.name}" on client "${clientName}"`);
+            } catch (err) {
+              log.warn(`clientAuthCredentials: failed to delete credential "${cred.name}" on client "${clientName}": ${err}`);
+            }
+          }
+        }
+      }
+
+      // Re-wire client_authentication_methods with the final resolved credential IDs
+      const keptIds = existing
+        .filter((e) => desiredNames.has(e.name))
+        .map((e) => e.id);
+      const finalIds = [...keptIds, ...createdIds];
+
+      if (finalIds.length === 0) continue;
+
+      // Group final IDs by method key
+      const methodToIds: Record<string, string[]> = {};
+      for (const id of finalIds) {
+        // find which method this credential belongs to
+        const fromExisting = existing.find((e) => e.id === id);
+        const fromDesired = desired.find((d) => createdIds.includes(id) && d.name);
+        const methodKey =
+          (fromExisting && this.inferMethodFromType(fromExisting.credential_type)) ||
+          (fromDesired && fromDesired.method) ||
+          Object.keys(client.client_authentication_methods as object)[0];
+        if (!methodToIds[methodKey]) methodToIds[methodKey] = [];
+        methodToIds[methodKey].push(id);
+      }
+
+      const updatedAuthMethods: Record<string, any> = {};
+      for (const [methodKey, ids] of Object.entries(methodToIds)) {
+        updatedAuthMethods[methodKey] = { credentials: ids.map((id) => ({ id })) };
+      }
+
+      try {
+        await (this.client.clients.update as Function)(clientId, {
+          client_authentication_methods: updatedAuthMethods,
+        });
+        log.info(`clientAuthCredentials: updated client_authentication_methods on client "${clientName}"`);
+      } catch (err) {
+        log.warn(`clientAuthCredentials: failed to update client_authentication_methods on client "${clientName}": ${err}`);
+      }
+    }
+  }
+
+  private inferCredentialType(methodKey: string): string {
+    const map: Record<string, string> = {
+      private_key_jwt: 'public_key',
+      self_signed_tls_client_auth: 'x509_cert',
+      tls_client_auth: 'cert_subject_dn',
+    };
+    return map[methodKey] || 'public_key';
+  }
+
+  private inferMethodFromType(credentialType: string): string {
+    return CREDENTIAL_TYPE_TO_METHOD[credentialType] || 'private_key_jwt';
+  }
+}

--- a/src/tools/auth0/handlers/clientAuthCredentials.ts
+++ b/src/tools/auth0/handlers/clientAuthCredentials.ts
@@ -1,6 +1,7 @@
 import { order } from './default';
 import { Assets, Auth0APIClient } from '../../../types';
 import { ConfigFunction } from '../../../configFactory';
+import { paginate } from '../client';
 import log from '../../../logger';
 
 export const schema = {
@@ -29,6 +30,15 @@ export default class ClientAuthCredentialsHandler {
     return null;
   }
 
+  async load() {
+    log.info(`Retrieving ${this.type} data from Auth0`);
+    return { [this.type]: null };
+  }
+
+  async validate() {
+    return null;
+  }
+
   @order('70')
   async processChanges(assets: Assets): Promise<void> {
     const { clients } = assets;
@@ -37,8 +47,19 @@ export default class ClientAuthCredentialsHandler {
     const allowDelete =
       this.config('AUTH0_ALLOW_DELETE') === true || this.config('AUTH0_ALLOW_DELETE') === 'true';
 
+    // Fetch existing clients from Auth0 so we can resolve names to IDs
+    // when client_id is null (directory mode strips it from exported JSON)
+    const existingClients = await paginate(this.client.clients.list, {
+      paginate: true,
+      is_global: false,
+    });
+    const clientIdByName = new Map(existingClients.map((c: any) => [c.name, c.client_id]));
+
     for (const client of clients) {
-      if (!client.client_id || !client.client_authentication_methods) continue;
+      if (!client.client_authentication_methods) continue;
+      const clientId = (client.client_id || clientIdByName.get(client.name)) as string | undefined;
+      if (!clientId) continue;
+      client.client_id = clientId;
 
       // Collect all desired credentials across all auth methods
       const desired: { name: string; pem?: string; credential_type: string; method: string }[] =
@@ -59,9 +80,6 @@ export default class ClientAuthCredentialsHandler {
         }
       }
 
-      if (desired.length === 0) continue;
-
-      const clientId = client.client_id as string;
       const clientName = client.name || clientId;
 
       let existing: any[] = [];
@@ -71,6 +89,9 @@ export default class ClientAuthCredentialsHandler {
         log.warn(`clientAuthCredentials: failed to list credentials for client "${clientName}": ${err}`);
         continue;
       }
+
+      // If no pem-based credentials in config and nothing in Auth0, nothing to do
+      if (desired.length === 0 && existing.length === 0) continue;
 
       // Warn if duplicate names exist in Auth0 — we can't match safely
       const existingNames = existing.map((c) => c.name);
@@ -89,7 +110,8 @@ export default class ClientAuthCredentialsHandler {
       const toDelete = existing.filter((e) => !desiredNames.has(e.name));
 
       // Creates first — Auth0 allows max 2 credentials; both must exist simultaneously during rotation
-      const createdIds: string[] = [];
+      // Track name→id so we can correctly attribute each created credential to its method later.
+      const createdIdByName = new Map<string, string>();
       for (const cred of toCreate) {
         try {
           const created = await (this.client.clients.credentials.create as Function)(clientId, {
@@ -98,13 +120,53 @@ export default class ClientAuthCredentialsHandler {
             credential_type: cred.credential_type,
           });
           log.info(`clientAuthCredentials: created credential "${cred.name}" on client "${clientName}"`);
-          createdIds.push(created.id);
+          createdIdByName.set(cred.name, created.id);
         } catch (err) {
           log.warn(`clientAuthCredentials: failed to create credential "${cred.name}" on client "${clientName}": ${err}`);
         }
       }
 
-      // Deletes after — gated by AUTH0_ALLOW_DELETE
+      // Re-wire client_authentication_methods with final IDs (kept + newly created).
+      // This must happen BEFORE deletes — Auth0 rejects deleting a credential that
+      // is still referenced in client_authentication_methods.
+      const keptIds = existing
+        .filter((e) => desiredNames.has(e.name))
+        .map((e) => e.id);
+      const createdIds = [...createdIdByName.values()];
+      const finalIds = [...keptIds, ...createdIds];
+
+      if (finalIds.length > 0) {
+        // Build method→ids map. For kept credentials use Auth0's stored type to infer method;
+        // for created credentials use the method from the user's config entry (by name).
+        const methodToIds: Record<string, string[]> = {};
+        for (const id of finalIds) {
+          const fromExisting = existing.find((e) => e.id === id);
+          const createdName = [...createdIdByName.entries()].find(([, cid]) => cid === id)?.[0];
+          const fromDesired = createdName ? desired.find((d) => d.name === createdName) : undefined;
+          const methodKey =
+            (fromExisting && this.inferMethodFromType(fromExisting.credential_type)) ||
+            (fromDesired && fromDesired.method) ||
+            Object.keys(client.client_authentication_methods as object)[0];
+          if (!methodToIds[methodKey]) methodToIds[methodKey] = [];
+          methodToIds[methodKey].push(id);
+        }
+
+        const updatedAuthMethods: Record<string, any> = {};
+        for (const [methodKey, ids] of Object.entries(methodToIds)) {
+          updatedAuthMethods[methodKey] = { credentials: ids.map((id) => ({ id })) };
+        }
+
+        try {
+          await (this.client.clients.update as Function)(clientId, {
+            client_authentication_methods: updatedAuthMethods,
+          });
+          log.info(`clientAuthCredentials: updated client_authentication_methods on client "${clientName}"`);
+        } catch (err) {
+          log.warn(`clientAuthCredentials: failed to update client_authentication_methods on client "${clientName}": ${err}`);
+        }
+      }
+
+      // Deletes last — after client_authentication_methods no longer references them
       if (toDelete.length > 0) {
         if (!allowDelete) {
           log.warn(
@@ -120,42 +182,6 @@ export default class ClientAuthCredentialsHandler {
             }
           }
         }
-      }
-
-      // Re-wire client_authentication_methods with the final resolved credential IDs
-      const keptIds = existing
-        .filter((e) => desiredNames.has(e.name))
-        .map((e) => e.id);
-      const finalIds = [...keptIds, ...createdIds];
-
-      if (finalIds.length === 0) continue;
-
-      // Group final IDs by method key
-      const methodToIds: Record<string, string[]> = {};
-      for (const id of finalIds) {
-        // find which method this credential belongs to
-        const fromExisting = existing.find((e) => e.id === id);
-        const fromDesired = desired.find((d) => createdIds.includes(id) && d.name);
-        const methodKey =
-          (fromExisting && this.inferMethodFromType(fromExisting.credential_type)) ||
-          (fromDesired && fromDesired.method) ||
-          Object.keys(client.client_authentication_methods as object)[0];
-        if (!methodToIds[methodKey]) methodToIds[methodKey] = [];
-        methodToIds[methodKey].push(id);
-      }
-
-      const updatedAuthMethods: Record<string, any> = {};
-      for (const [methodKey, ids] of Object.entries(methodToIds)) {
-        updatedAuthMethods[methodKey] = { credentials: ids.map((id) => ({ id })) };
-      }
-
-      try {
-        await (this.client.clients.update as Function)(clientId, {
-          client_authentication_methods: updatedAuthMethods,
-        });
-        log.info(`clientAuthCredentials: updated client_authentication_methods on client "${clientName}"`);
-      } catch (err) {
-        log.warn(`clientAuthCredentials: failed to update client_authentication_methods on client "${clientName}": ${err}`);
       }
     }
   }

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -649,6 +649,19 @@ export default class ClientHandler extends DefaultAPIHandler {
             delete item.refresh_token;
           }
         }
+
+        // If any credential has a pem field, strip client_authentication_methods
+        // from the PATCH payload — the clientAuthCredentials handler (order 70)
+        // will create the credentials and re-wire it with the resulting IDs.
+        if (item.client_authentication_methods) {
+          const hasPem = Object.values(item.client_authentication_methods).some(
+            (method: any) => method?.credentials?.some((c: any) => c.pem)
+          );
+          if (hasPem) {
+            delete item.client_authentication_methods;
+          }
+        }
+
         return item;
       });
     };
@@ -674,7 +687,30 @@ export default class ClientHandler extends DefaultAPIHandler {
       ...(shouldExcludeThirdPartyClients(this.config) && { is_first_party: true }),
     });
 
-    this.existing = createClientSanitizer(clients).sanitizeCrossOriginAuth(false).get();
+    const sanitized = createClientSanitizer(clients).sanitizeCrossOriginAuth(false).get();
+
+    // Enrich credential stubs with full metadata (name, credential_type, kid, alg).
+    // Auth0 does not return pem on read — enrichment is metadata only.
+    await Promise.all(
+      sanitized.map(async (client) => {
+        if (!client.client_authentication_methods) return;
+        try {
+          const creds = await this.client.clients.credentials.list(client.client_id as string);
+          const credMap = new Map((creds as any[]).map((c) => [c.id, c]));
+          Object.values(client.client_authentication_methods).forEach((method: any) => {
+            if (method?.credentials) {
+              method.credentials = method.credentials.map((stub: any) =>
+                credMap.has(stub.id) ? { ...credMap.get(stub.id) } : stub
+              );
+            }
+          });
+        } catch (_) {
+          // leave stubs as-is if the credentials API call fails
+        }
+      })
+    );
+
+    this.existing = sanitized;
     return this.existing;
   }
 

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -654,8 +654,8 @@ export default class ClientHandler extends DefaultAPIHandler {
         // from the PATCH payload — the clientAuthCredentials handler (order 70)
         // will create the credentials and re-wire it with the resulting IDs.
         if (item.client_authentication_methods) {
-          const hasPem = Object.values(item.client_authentication_methods).some(
-            (method: any) => method?.credentials?.some((c: any) => c.pem)
+          const hasPem = Object.values(item.client_authentication_methods).some((method: any) =>
+            method?.credentials?.some((c: any) => c.pem)
           );
           if (hasPem) {
             delete item.client_authentication_methods;

--- a/src/tools/auth0/handlers/index.ts
+++ b/src/tools/auth0/handlers/index.ts
@@ -40,6 +40,7 @@ import * as connectionProfiles from './connectionProfiles';
 import * as tokenExchangeProfiles from './tokenExchangeProfiles';
 import * as supplementalSignals from './supplementalSignals';
 import * as eventStreams from './eventStreams';
+import * as clientAuthCredentials from './clientAuthCredentials';
 
 import { AssetTypes } from '../../../types';
 import APIHandler from './default';
@@ -88,6 +89,7 @@ const auth0ApiHandlers: { [key in AssetTypes]: any } = {
   tokenExchangeProfiles,
   supplementalSignals,
   eventStreams,
+  clientAuthCredentials,
 };
 
 export default auth0ApiHandlers as {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,8 @@ export type AssetTypes =
   | 'connectionProfiles'
   | 'tokenExchangeProfiles'
   | 'supplementalSignals'
-  | 'eventStreams';
+  | 'eventStreams'
+  | 'clientAuthCredentials';
 
 export type KeywordMappings = { [key: string]: (string | number)[] | string | number };
 

--- a/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
+++ b/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
@@ -1,0 +1,470 @@
+import pageClient from '../../../../src/tools/auth0/client';
+import { expect } from 'chai';
+import clientAuthCredentials from '../../../../src/tools/auth0/handlers/clientAuthCredentials';
+import { mockPagedData } from '../../../utils';
+
+const pool = {
+  addEachTask: (data) => {
+    if (data.data && data.data.length) {
+      data.generator(data.data[0]);
+    }
+    return { promise: () => null };
+  },
+};
+
+const makeConfig = (overrides = {}) => {
+  const data = { AUTH0_CLIENT_ID: 'mgmt_client', AUTH0_ALLOW_DELETE: true, ...overrides };
+  const fn = (key) => data[key];
+  return fn;
+};
+
+const makeClient = (overrides: any = {}) => {
+  const base = {
+    clients: {
+      list: (params) =>
+        mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+      update: () => Promise.resolve({ data: {} }),
+      credentials: {
+        list: () => Promise.resolve([]),
+        create: () => Promise.resolve({ id: 'cred_new', name: 'new-key' }),
+        delete: () => Promise.resolve({}),
+      },
+    },
+    pool,
+  };
+
+  return pageClient({
+    ...base,
+    ...overrides,
+    clients: { ...base.clients, ...(overrides.clients || {}) },
+  });
+};
+
+describe('#clientAuthCredentials handler', () => {
+  describe('#processChanges', () => {
+    it('should skip clients with no client_authentication_methods', async () => {
+      let credListCalled = false;
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: () => Promise.resolve({ data: {} }),
+          credentials: {
+            list: () => {
+              credListCalled = true;
+              return Promise.resolve([]);
+            },
+            create: () => Promise.resolve({ id: 'cred_new' }),
+            delete: () => Promise.resolve({}),
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [{ clients: [{ client_id: 'client1', name: 'My App' }] }]);
+
+      expect(credListCalled).to.equal(false);
+    });
+
+    it('should not create or delete when no credential has a pem field and Auth0 has no credentials', async () => {
+      const createCalls: any[] = [];
+      const deleteCalls: any[] = [];
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: () => Promise.resolve({ data: {} }),
+          credentials: {
+            list: () => Promise.resolve([]),
+            create: (clientId, data) => {
+              createCalls.push(data);
+              return Promise.resolve({ id: 'cred_new' });
+            },
+            delete: (clientId, credId) => {
+              deleteCalls.push(credId);
+              return Promise.resolve({});
+            },
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: { credentials: [{ id: 'cred_abc', name: 'old-key' }] },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(createCalls).to.have.lengthOf(0);
+      expect(deleteCalls).to.have.lengthOf(0);
+    });
+
+    it('should create credential when pem is present and name is new', async () => {
+      const createCalls: any[] = [];
+      const updateCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: (id, data) => {
+            updateCalls.push({ id, data });
+            return Promise.resolve({ data });
+          },
+          credentials: {
+            list: () => Promise.resolve([]),
+            create: (clientId, data) => {
+              createCalls.push({ clientId, data });
+              return Promise.resolve({ id: 'cred_new123', name: data.name });
+            },
+            delete: () => Promise.resolve({}),
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'new-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(createCalls).to.have.lengthOf(1);
+      expect(createCalls[0].clientId).to.equal('client1');
+      expect(createCalls[0].data.name).to.equal('new-key');
+      expect(createCalls[0].data.pem).to.include('BEGIN PUBLIC KEY');
+      expect(updateCalls).to.have.lengthOf(1);
+      expect(
+        updateCalls[0].data.client_authentication_methods.private_key_jwt.credentials
+      ).to.deep.equal([{ id: 'cred_new123' }]);
+    });
+
+    it('should resolve client_id by name when client_id is null (directory mode)', async () => {
+      const createCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: () => Promise.resolve({ data: {} }),
+          credentials: {
+            list: () => Promise.resolve([]),
+            create: (clientId, data) => {
+              createCalls.push({ clientId, data });
+              return Promise.resolve({ id: 'cred_new123', name: data.name });
+            },
+            delete: () => Promise.resolve({}),
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: null,
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'new-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(createCalls).to.have.lengthOf(1);
+      expect(createCalls[0].clientId).to.equal('client1');
+    });
+
+    it('should not delete credentials when AUTH0_ALLOW_DELETE is false', async () => {
+      const deleteCalls: any[] = [];
+      const updateCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: (id, data) => {
+            updateCalls.push({ id, data });
+            return Promise.resolve({ data });
+          },
+          credentials: {
+            list: () =>
+              Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
+            create: (clientId, data) => Promise.resolve({ id: 'cred_new', name: data.name }),
+            delete: (clientId, credId) => {
+              deleteCalls.push(credId);
+              return Promise.resolve({});
+            },
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({
+        client,
+        config: makeConfig({ AUTH0_ALLOW_DELETE: false }),
+      });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'new-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(deleteCalls).to.have.lengthOf(0);
+    });
+
+    it('should delete stale credentials when AUTH0_ALLOW_DELETE is true, after updating client_authentication_methods', async () => {
+      const callOrder: string[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: (id, data) => {
+            callOrder.push('update');
+            return Promise.resolve({ data });
+          },
+          credentials: {
+            list: () =>
+              Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
+            create: (clientId, data) => {
+              callOrder.push('create');
+              return Promise.resolve({ id: 'cred_new', name: data.name });
+            },
+            delete: () => {
+              callOrder.push('delete');
+              return Promise.resolve({});
+            },
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'new-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      // create → update → delete order is critical
+      expect(callOrder).to.deep.equal(['create', 'update', 'delete']);
+    });
+
+    it('should delete all stale credentials when config has empty credentials array', async () => {
+      const deleteCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: () => Promise.resolve({ data: {} }),
+          credentials: {
+            list: () =>
+              Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
+            create: () => Promise.resolve({ id: 'cred_new' }),
+            delete: (clientId, credId) => {
+              deleteCalls.push(credId);
+              return Promise.resolve({});
+            },
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: { credentials: [] },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(deleteCalls).to.deep.equal(['cred_old']);
+    });
+
+    it('should skip client with duplicate credential names in Auth0', async () => {
+      const createCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: () => Promise.resolve({ data: {} }),
+          credentials: {
+            list: () =>
+              Promise.resolve([
+                { id: 'cred_1', name: 'dup-key', credential_type: 'public_key' },
+                { id: 'cred_2', name: 'dup-key', credential_type: 'public_key' },
+              ]),
+            create: (clientId, data) => {
+              createCalls.push(data);
+              return Promise.resolve({ id: 'cred_new' });
+            },
+            delete: () => Promise.resolve({}),
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'new-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(createCalls).to.have.lengthOf(0);
+    });
+
+    it('should correctly attribute multiple created credentials to their methods', async () => {
+      const updateCalls: any[] = [];
+
+      const client = makeClient({
+        clients: {
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
+          update: (id, data) => {
+            updateCalls.push(data);
+            return Promise.resolve({ data });
+          },
+          credentials: {
+            list: () => Promise.resolve([]),
+            create: (clientId, data) =>
+              Promise.resolve({ id: `cred_${data.name}`, name: data.name }),
+            delete: () => Promise.resolve({}),
+          },
+        },
+      });
+
+      const handler = new clientAuthCredentials({ client, config: makeConfig() });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'My App',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'key-a',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                    {
+                      name: 'key-b',
+                      pem: '-----BEGIN PUBLIC KEY-----\ndef\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(updateCalls).to.have.lengthOf(1);
+      const creds = updateCalls[0].client_authentication_methods.private_key_jwt.credentials;
+      expect(creds).to.have.lengthOf(2);
+      const ids = creds.map((c) => c.id);
+      expect(ids).to.include('cred_key-a');
+      expect(ids).to.include('cred_key-b');
+    });
+  });
+});

--- a/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
+++ b/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
@@ -321,20 +321,25 @@ describe('#clientAuthCredentials handler', () => {
       expect(callOrder).to.deep.equal(['create', 'update', 'delete']);
     });
 
-    it('should delete all stale credentials when config has empty credentials array', async () => {
-      const deleteCalls: any[] = [];
+    it('should clear client_authentication_methods then delete when config has empty credentials array', async () => {
+      const callOrder: string[] = [];
+      const updatePayloads: any[] = [];
 
       const client = makeClient({
         clients: {
           list: (params) =>
             mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
-          update: () => Promise.resolve({ data: {} }),
+          update: (id, data) => {
+            callOrder.push('update');
+            updatePayloads.push(data);
+            return Promise.resolve({ data });
+          },
           credentials: {
             list: () =>
               Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
             create: () => Promise.resolve({ id: 'cred_new' }),
             delete: (clientId, credId) => {
-              deleteCalls.push(credId);
+              callOrder.push('delete');
               return Promise.resolve({});
             },
           },
@@ -357,7 +362,9 @@ describe('#clientAuthCredentials handler', () => {
         },
       ]);
 
-      expect(deleteCalls).to.deep.equal(['cred_old']);
+      // update must clear references before delete, otherwise Auth0 rejects the delete
+      expect(callOrder).to.deep.equal(['update', 'delete']);
+      expect(updatePayloads[0].client_authentication_methods).to.deep.equal({});
     });
 
     it('should skip client with duplicate credential names in Auth0', async () => {

--- a/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
+++ b/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
@@ -67,7 +67,7 @@ describe('#clientAuthCredentials handler', () => {
       expect(credListCalled).to.equal(false);
     });
 
-    it('should not create or delete when no credential has a pem field and Auth0 has no credentials', async () => {
+    it('should skip all reconciliation when no credential has a pem field, even if Auth0 has existing credentials', async () => {
       const createCalls: any[] = [];
       const deleteCalls: any[] = [];
       const client = makeClient({
@@ -321,25 +321,24 @@ describe('#clientAuthCredentials handler', () => {
       expect(callOrder).to.deep.equal(['create', 'update', 'delete']);
     });
 
-    it('should clear client_authentication_methods then delete when config has empty credentials array', async () => {
-      const callOrder: string[] = [];
-      const updatePayloads: any[] = [];
+    it('should skip reconciliation when credentials array is empty (no pem present)', async () => {
+      const deleteCalls: any[] = [];
+      const updateCalls: any[] = [];
 
       const client = makeClient({
         clients: {
           list: (params) =>
             mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'My App' }]),
           update: (id, data) => {
-            callOrder.push('update');
-            updatePayloads.push(data);
+            updateCalls.push(data);
             return Promise.resolve({ data });
           },
           credentials: {
             list: () =>
               Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
             create: () => Promise.resolve({ id: 'cred_new' }),
-            delete: (_clientId, _credId) => {
-              callOrder.push('delete');
+            delete: (_clientId, credId) => {
+              deleteCalls.push(credId);
               return Promise.resolve({});
             },
           },
@@ -362,9 +361,9 @@ describe('#clientAuthCredentials handler', () => {
         },
       ]);
 
-      // update must clear references before delete, otherwise Auth0 rejects the delete
-      expect(callOrder).to.deep.equal(['update', 'delete']);
-      expect(updatePayloads[0].client_authentication_methods).to.deep.equal({});
+      // empty credentials = no pem = skip reconciliation; existing Auth0 credentials untouched
+      expect(deleteCalls).to.have.lengthOf(0);
+      expect(updateCalls).to.have.lengthOf(0);
     });
 
     it('should skip client with duplicate credential names in Auth0', async () => {

--- a/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
+++ b/test/tools/auth0/handlers/clientAuthCredentials.tests.ts
@@ -338,7 +338,7 @@ describe('#clientAuthCredentials handler', () => {
             list: () =>
               Promise.resolve([{ id: 'cred_old', name: 'old-key', credential_type: 'public_key' }]),
             create: () => Promise.resolve({ id: 'cred_new' }),
-            delete: (clientId, credId) => {
+            delete: (_clientId, _credId) => {
               callOrder.push('delete');
               return Promise.resolve({});
             },

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -1791,6 +1791,132 @@ describe('#clients handler', () => {
     });
   });
 
+  describe('#clients getType credential enrichment', () => {
+    it('should enrich credential stubs with full metadata for clients with client_authentication_methods', async () => {
+      const auth0 = {
+        clients: {
+          create: () => Promise.resolve({ data: {} }),
+          update: () => Promise.resolve({ data: {} }),
+          delete: () => Promise.resolve({ data: {} }),
+          list: (params) =>
+            mockPagedData(params, 'clients', [
+              {
+                client_id: 'client1',
+                name: 'My App',
+                client_authentication_methods: {
+                  private_key_jwt: { credentials: [{ id: 'cred_abc' }] },
+                },
+              },
+            ]),
+          credentials: {
+            list: () =>
+              Promise.resolve([
+                {
+                  id: 'cred_abc',
+                  name: 'my-key',
+                  credential_type: 'public_key',
+                  kid: 'kid123',
+                  alg: 'RS256',
+                },
+              ]),
+          },
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const result = await handler.getType();
+
+      const cred = result[0].client_authentication_methods.private_key_jwt.credentials[0];
+      expect(cred.id).to.equal('cred_abc');
+      expect(cred.name).to.equal('my-key');
+      expect(cred.credential_type).to.equal('public_key');
+      expect(cred.kid).to.equal('kid123');
+      expect(cred.alg).to.equal('RS256');
+    });
+  });
+
+  describe('#clients pem stripping in processChanges', () => {
+    it('should strip client_authentication_methods from PATCH only when credential has pem', async () => {
+      const updatePayloads = {};
+      const auth0 = {
+        clients: {
+          create: () => Promise.resolve({ data: {} }),
+          update: (clientId, data) => {
+            updatePayloads[clientId] = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: {} }),
+          list: (params) =>
+            mockPagedData(params, 'clients', [
+              {
+                client_id: 'client1',
+                name: 'App With PEM',
+                client_authentication_methods: {
+                  private_key_jwt: { credentials: [{ id: 'cred_abc', name: 'my-key' }] },
+                },
+              },
+              {
+                client_id: 'client2',
+                name: 'App Without PEM',
+                client_authentication_methods: {
+                  private_key_jwt: { credentials: [{ id: 'cred_xyz' }] },
+                },
+              },
+            ]),
+          credentials: {
+            list: () =>
+              Promise.resolve([{ id: 'cred_abc', name: 'my-key', credential_type: 'public_key' }]),
+          },
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'App With PEM',
+              client_authentication_methods: {
+                private_key_jwt: {
+                  credentials: [
+                    {
+                      name: 'my-key',
+                      pem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----\n',
+                      credential_type: 'public_key',
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              client_id: 'client2',
+              name: 'App Without PEM',
+              client_authentication_methods: {
+                private_key_jwt: { credentials: [{ id: 'cred_xyz' }] },
+              },
+            },
+          ],
+        },
+      ]);
+
+      expect(updatePayloads['client1']).to.not.have.property('client_authentication_methods');
+      expect(updatePayloads['client2']).to.have.property('client_authentication_methods');
+    });
+  });
+
   describe('#clients validate', () => {
     it('should allow validation when external_metadata_type is set without external_client_id', async () => {
       const handler = new clients.default({ client: {}, config });


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The CLI previously had no support for the `/clients/{id}/credentials` API. This adds full create/delete reconciliation for client credentials across all three credential types (`public_key`, `x509_cert`, `cert_subject_dn`).

**Export changes**

- `client_authentication_methods` is now exported for **all** client types (previously only `express_configuration` clients). This fixes incomplete export behavior for M2M and other app types.
- Credential stubs are enriched with full metadata (`name`, `credential_type`, `kid`, `alg`) instead of just `{ "id": "cred_xxx" }`.
- `pem` is never exported; Auth0 does not return it after creation.

Before:
```json
"client_authentication_methods": {
  "private_key_jwt": {
    "credentials": [{ "id": "cred_abc123" }]
  }
}
```

After:

```json
"client_authentication_methods": {
  "private_key_jwt": {
    "credentials": [{
      "id": "cred_abc123",
      "name": "my-rotation-key",
      "credential_type": "public_key",
      "kid": "9P8IC1...",
      "alg": "RS256"
    }]
  }
}
```

**Deploy changes**

A new clientAuthCredentials handler (runs at order 70, after clients at 50) reconciles credential state when the config contains credentials with a pem field:

User-managed config shape (pem must be supplied manually from key generation; Auth0 never returns it):

```json
"client_authentication_methods": {
  "private_key_jwt": {
    "credentials": [{
      "name": "my-rotation-key",
      "pem": "-----BEGIN PUBLIC KEY-----\n...",
      "credential_type": "public_key"
    }]
  }
}
```

* Creates credentials present in config but missing in Auth0
* Deletes credentials removed from config (requires `AUTH0_ALLOW_DELETE=true`)
* Creates run before deletes; Auth0 allows max 2 credentials per client; this preserves the rotation overlap window and avoids an auth gap
* Re-wires `client_authentication_methods` on the client with the resolved credential IDs after reconciliation

**Safety / backward compatibility**

* Credentials are only managed when the config contains a pem field. Configs with no credentials, id-only credentials `{ "id": "cred_xxx" }`, or no `client_authentication_methods` at all are untouched, ensuring there is no breaking change for existing users.
* Deletions are gated behind `AUTH0_ALLOW_DELETE`, consistent with other resource types.
* Creates always run before deletes, so both credentials exist simultaneously during the rotation window - no auth gap.
* A plain `export`->`deploy` never deletes credentials; reconciliation only activates when at least one credential in the config has a `pem` field

### 📚 References

Closes #1167

### 🔬 Testing

Manual end-to-end testing against a dev tenant:

1. **Export enrichment**: registered a credential via the API directly, ran `auth0 export`, verified exported JSON includes full metadata (`name`, `kid`, `alg`, `credential_type`) for all client types, not just `express_configuration`
2. **Create**: added a new credential with `pem` to the config, ran `auth0 deploy`, verified it was created in Auth0
3. **Rotation overlap**: added a second credential alongside an existing one, verified both existed simultaneously in Auth0 before the old one was removed
4. **`AUTH0_ALLOW_DELETE=false` guard**: removed a credential from config with `AUTH0_ALLOW_DELETE=false`, verified a warning was logged and Auth0 state was untouched
5. **Delete**: with `AUTH0_ALLOW_DELETE=true`, removed a credential from config, verified it was deleted from Auth0 after `client_authentication_methods` was updated
6. **Full cleanup**: removed a pem-based credential from config entirely, verified it was deleted from Auth0 after `client_authentication_methods` was updated
7. **Idempotency**: deployed with no config changes, verified no create/delete operations ran
8. **Safety gate**: deployed config with no `pem` fields, verified credentials in Auth0 were untouched


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
