### PR TITLE
feat: add third_party_client_access support for organizations

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.14.0
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.x
+          node-version: 22.14.0
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -644,3 +644,12 @@ rateLimitPolicies:
       action: redirect
       limit: 10
       redirect_uri: https://example.com/rate-limited
+
+organizations:
+  - name: my-organization
+    display_name: My Organization
+    # Controls whether third-party clients can perform standard user flows (e.g. Authorization Code,
+    # Refresh Token exchange) within the context of this organization.
+    # Requires the organizations_third_party_client_support feature flag to be enabled on the tenant.
+    # Allowed values: allow, block (defaults to block)
+    third_party_client_access: block

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "~5.9.3"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.19.0"
   },
   "keywords": [
     "auth0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@clack/prompts": "1.4.0",
     "ajv": "^6.12.6",
-    "auth0": "^5.13.0",
+    "auth0": "^6.0.0",
     "chalk": "5.6.2",
     "dot-prop": "^5.3.0",
     "fs-extra": "^10.1.0",
@@ -80,7 +80,7 @@
     "typescript": "~5.9.3"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=24.0.0"
   },
   "keywords": [
     "auth0",

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -89,7 +89,7 @@ export const schema = {
       },
       third_party_client_access: {
         type: 'string',
-        enum: ['allow', 'block'],
+        enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
       },
     },
     required: ['name'],

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -87,6 +87,10 @@ export const schema = {
           required: ['domain', 'status'],
         },
       },
+      third_party_client_access: {
+        type: 'string',
+        enum: ['allow', 'block'],
+      },
     },
     required: ['name'],
   },

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -308,6 +308,53 @@ describe('#organizations handler', () => {
       expect(wasCreateCalled).to.be.true;
     });
 
+    it('should allow valid third_party_client_access property in organization', async () => {
+      for (const value of ['allow', 'block']) {
+        const orgWithTpa = {
+          name: `org-tpa-${value}`,
+          third_party_client_access: value,
+        };
+        let wasCreateCalled = false;
+        const auth0 = {
+          organizations: {
+            create: function (data) {
+              wasCreateCalled = true;
+              expect(data.third_party_client_access).to.equal(value);
+              data.id = 'fake';
+              return Promise.resolve(data);
+            },
+            update: () => Promise.resolve({ data: [] }),
+            delete: () => Promise.resolve({ data: [] }),
+            list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [sampleOrg])),
+            connections: {
+              list: () => mockPagedData({}, 'connections', []),
+            },
+            clientGrants: {
+              list: () => mockPagedData({}, 'client_grants', []),
+            },
+            discoveryDomains: {
+              list: () => mockPagedData({}, 'discovery_domains', []),
+            },
+          },
+          connections: {
+            list: (params) => mockPagedData(params, 'connections', []),
+          },
+          clients: {
+            list: (params) => mockPagedData(params, 'clients', sampleClients),
+          },
+          clientGrants: {
+            list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+          },
+          pool,
+        };
+        const handler = new organizations.default({ client: pageClient(auth0), config });
+        const stageFn = Object.getPrototypeOf(handler).processChanges;
+        await stageFn.apply(handler, [{ organizations: [orgWithTpa] }]);
+        // eslint-disable-next-line no-unused-expressions
+        expect(wasCreateCalled).to.be.true;
+      }
+    });
+
     it('should get organizations', async () => {
       const auth0 = {
         organizations: {


### PR DESCRIPTION
### 🔧 Changes

Adds `third_party_client_access` (enum: `allow` | `block`) to the organizations JSON schema in support of the Third Party Apps GA feature.                                
                                                                                                                                                                            
This is a top-level property on the organization entity that controls whether third-party clients can perform standard user flows (Authorization Code, Refresh Token exchange) within the context of the organization. The property is gated by the `organizations_third_party_client_support` feature flag on the tenant.                     
                                                                                                                                                                            
No handler logic changes were required, the existing create, update, and export flows pass top-level org properties through to the Management API automatically. The schema addition ensures the property is accepted during validation and surfaced correctly in dry-run previews.

### 📚 References



### 🔬 Testing

Tested manually against a tenant with `organizations_third_party_client_support` enabled:

  - **Import (`allow`)**: org created with `third_party_client_access: "allow"` confirmed via Management API
  - **Export**: `third_party_client_access` present on all orgs in exported YAML
  - **Dry-run**: changing `allow` → `block` correctly surfaces as `UPDATE` in the preview table
  - **Import (update)**: PATCH applied, value updated to `block` confirmed via Management API
  - **Schema validation**: invalid value (e.g. `invalid_value`) rejected before any API call with `should be equal to one of the allowed values`

Unit test suite (1304 tests) passes with no failures.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

