### PR TITLE
feat: add cross_app_access_requesting_app support for connections (EA)

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -321,6 +321,49 @@ connections:
 }
 ```
 
+## Connections (Cross App Access — Requesting Application)
+
+> **Early Access:** Requires the `token_vault_xaa` feature flag to be enabled on the tenant.
+
+For enterprise connections with strategy `oidc` or `okta`, the Deploy CLI supports configuring the connection as a Requesting Application for Cross App Access via the top-level `cross_app_access_requesting_app` field:
+
+- `cross_app_access_requesting_app.active` (boolean): Set to `true` to enable the connection as a Requesting Application for Cross App Access. Defaults to `true`.
+
+**YAML Example**
+
+```yaml
+connections:
+  - name: enterprise-oidc
+    strategy: oidc
+    cross_app_access_requesting_app:
+      active: true
+    options:
+      type: back_channel
+      issuer: https://example-idp.com
+      jwks_uri: https://example-idp.com/.well-known/jwks.json
+```
+
+**Directory Example**
+
+```
+./connections/enterprise-oidc.json
+```
+
+```json
+{
+  "name": "enterprise-oidc",
+  "strategy": "oidc",
+  "cross_app_access_requesting_app": {
+    "active": true
+  },
+  "options": {
+    "type": "back_channel",
+    "issuer": "https://example-idp.com",
+    "jwks_uri": "https://example-idp.com/.well-known/jwks.json"
+  }
+}
+```
+
 ## Databases
 
 When managing database connections, the values of `options.customScripts` point to specific javascript files relative to

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -101,6 +101,7 @@ export const schema = {
         properties: {
           active: { type: 'boolean' },
         },
+        required: ['active'],
         additionalProperties: false,
       },
       directory_provisioning_configuration: {

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -96,6 +96,13 @@ export const schema = {
         required: ['active'],
         additionalProperties: false,
       },
+      cross_app_access_requesting_app: {
+        type: 'object',
+        properties: {
+          active: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
       directory_provisioning_configuration: {
         type: 'object',
         properties: {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -99,6 +99,22 @@ describe('#connections handler', () => {
       expect(ajv.errors).to.be.null;
     });
 
+    it('should reject cross_app_access_requesting_app without active field', () => {
+      const ajv = new Ajv({ useDefaults: true, nullable: true });
+      const assets = [
+        {
+          name: 'oidc-connection',
+          strategy: 'oidc',
+          cross_app_access_requesting_app: {},
+        },
+      ];
+
+      const valid = ajv.validate(connections.schema, assets);
+
+      expect(valid).to.equal(false);
+      expect(ajv.errors).to.not.be.null;
+    });
+
     it('should reject cross_app_access_requesting_app with unknown properties', () => {
       const ajv = new Ajv({ useDefaults: true, nullable: true });
       const assets = [

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -77,6 +77,43 @@ describe('#connections handler', () => {
       expect(valid).to.equal(true);
       expect(ajv.errors).to.be.null;
     });
+
+    it('should allow cross_app_access_requesting_app with active boolean', () => {
+      const ajv = new Ajv({ useDefaults: true, nullable: true });
+      const assets = [
+        {
+          name: 'oidc-connection',
+          strategy: 'oidc',
+          cross_app_access_requesting_app: { active: true },
+        },
+        {
+          name: 'okta-connection',
+          strategy: 'okta',
+          cross_app_access_requesting_app: { active: false },
+        },
+      ];
+
+      const valid = ajv.validate(connections.schema, assets);
+
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should reject cross_app_access_requesting_app with unknown properties', () => {
+      const ajv = new Ajv({ useDefaults: true, nullable: true });
+      const assets = [
+        {
+          name: 'oidc-connection',
+          strategy: 'oidc',
+          cross_app_access_requesting_app: { active: true, unknown_field: 'value' },
+        },
+      ];
+
+      const valid = ajv.validate(connections.schema, assets);
+
+      expect(valid).to.equal(false);
+      expect(ajv.errors).to.not.be.null;
+    });
   });
 
   describe('#connections validate', () => {
@@ -499,6 +536,44 @@ describe('#connections handler', () => {
           connected_accounts: {
             active: false,
           },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ connections: data }]);
+    });
+
+    it('should pass cross_app_access_requesting_app through in the update payload', async () => {
+      const auth0 = {
+        connections: {
+          create: () => Promise.resolve({ data: {} }),
+          update: function (id, data) {
+            expect(id).to.equal('con1');
+            expect(data).to.have.deep.property('cross_app_access_requesting_app', { active: true });
+            return Promise.resolve({ ...data, id });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) =>
+            mockPagedData(params, 'connections', [
+              { name: 'someConnection', id: 'con1', strategy: 'custom' },
+            ]),
+          _getRestClient: () => ({}),
+          clients: {
+            update: () => Promise.resolve({}),
+          },
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'someConnection',
+          strategy: 'custom',
+          cross_app_access_requesting_app: { active: true },
         },
       ];
 


### PR DESCRIPTION
### 🔧 Changes

Adds schema support for the `cross_app_access_requesting_app` connection property introduced by the Cross App Access (CAA) feature.                                       
                                                                                                                                                                            
  **What changed:**                      
  - Added `cross_app_access_requesting_app` to the connections JSON schema `src/tools/auth0/handlers/connections.ts`. The field accepts `{ active: boolean }` and follows the same pattern as the existing `authentication` and `connected_accounts` fields.                                                                                       
                                                                                                                                                                            
No additional handler logic was required, the property flows through the existing export and deploy paths automatically, as the auth0 Node SDK (`^5.13.0`) already includes the `CrossAppAccessRequestingApp` type on `ConnectionForList`.

  **Usage:**
  ```yaml
  connections:
    - name: enterprise-oidc
      strategy: oidc
      cross_app_access_requesting_app:
        active: true
```

### 📚 References



### 🔬 Testing

Requires the token_vault_xaa feature flag enabled on the tenant.

  Unit tests - added to `test/tools/auth0/handlers/connections.tests.js`:
  - Schema accepts `cross_app_access_requesting_app` with active: true/false
  - Schema rejects unknown properties (additionalProperties: false)
  - Property passes through unchanged in the connections.update payload

  Manual end-to-end test (verified on dev-ankita-t.us.auth0.com with flag enabled):
  1. Exported tenant - `cross_app_access_requesting_app` absent from OIDC connection
  2. Added `cross_app_access_requesting_app`: active: true to the connection in tenant.yaml
  3. Deployed - API accepted the property, connection updated successfully
  4. Re-exported - `cross_app_access_requesting_app`: active: true present in exported YAML

Round-trip confirmed. Attempted deploy without the feature flag returns operation_not_supported (400) from the API - expected behavior, no special handling needed in the CLI.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)


