### PR TITLE
fix: skip destination update for action event streams

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -1451,6 +1451,8 @@ Note: EventBridge streams cannot have their `destination` updated after creation
 }
 ```
 
+Note: like EventBridge, Action streams cannot have their `destination` updated after creation. Only `name`, `subscriptions`, and `status` can be patched — the `destination` is stripped from update payloads (an info message is logged when this happens).
+
 ### YAML Example
 
 ```yaml

--- a/src/tools/auth0/handlers/eventStreams.ts
+++ b/src/tools/auth0/handlers/eventStreams.ts
@@ -3,6 +3,7 @@ import DefaultAPIHandler, { order } from './default';
 import { Asset, Assets } from '../../../types';
 import { paginate } from '../client';
 import { Action } from './actions';
+import log from '../../../logger';
 
 export const schema = {
   type: 'array',
@@ -141,8 +142,16 @@ export default class EventStreamsHandler extends DefaultAPIHandler {
       create: changesResponse.create.map((stream: any) => this.resolveActionId(stream)),
       update: changesResponse.update.map((stream: EventStream) => {
         const resolved = this.resolveActionId(stream);
-        // EventBridge destinations cannot be patched — the API rejects destination on PATCH
-        if (resolved.destination?.type === 'eventbridge') {
+        // A destination's type cannot be changed once an event stream is created. The API
+        // rejects the destination on PATCH for eventbridge and action streams, so strip it
+        // from the update payload and only apply the other mutable fields.
+        if (
+          resolved.destination?.type === 'eventbridge' ||
+          resolved.destination?.type === 'action'
+        ) {
+          log.info(
+            `Skipping destination update for event stream "${resolved.name}": ${resolved.destination.type} destinations cannot be changed after creation.`
+          );
           const { destination: _dest, ...rest } = resolved as any;
           return rest;
         }

--- a/test/tools/auth0/handlers/eventStreams.tests.ts
+++ b/test/tools/auth0/handlers/eventStreams.tests.ts
@@ -327,7 +327,7 @@ describe('#eventStreams handler', () => {
       expect(created.destination.configuration.action_id).to.equal('act_abc123');
     });
 
-    it('should resolve action name to ID when updating action-destination stream', async () => {
+    it('should strip destination from update payload for action streams', async () => {
       let updatedData: any = null;
       const existing = { ...sampleActionStreamConfig, status: 'disabled' };
 
@@ -347,7 +347,10 @@ describe('#eventStreams handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [{ eventStreams: [sampleActionStreamConfig] }]);
-      expect(updatedData.destination.configuration.action_id).to.equal('act_abc123');
+      // action destinations cannot be changed after creation, so destination is stripped
+      expect(updatedData).to.not.have.property('destination');
+      // other mutable fields still applied
+      expect(updatedData.status).to.equal('enabled');
     });
 
     it('should throw when action-destination references unknown action name', async () => {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

A destination's type cannot be changed once an event stream is created. The API already rejected `destination` on PATCH for `action` streams.

### 📚 References
- https://github.com/auth0/auth0-deploy-cli/pull/1412


### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
- Unit test updated

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
