### PR TITLE
fix: add use_scope_descriptions_for_consent to allowedTenantFlags

### DIFF
--- a/src/tools/auth0/handlers/tenant.ts
+++ b/src/tools/auth0/handlers/tenant.ts
@@ -119,6 +119,7 @@ export const allowedTenantFlags = [
   'require_pushed_authorization_requests',
   'mfa_show_factor_list_on_enrollment',
   'improved_signup_bot_detection_in_classic',
+  'use_scope_descriptions_for_consent',
 ];
 
 export const removeUnallowedTenantFlags = (

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -122,7 +122,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -175,7 +175,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -184,6 +184,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -227,7 +228,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -236,91 +237,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -363,7 +279,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -376,7 +292,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -398,20 +314,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -431,7 +339,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -440,6 +401,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -489,7 +493,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -514,7 +518,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -528,17 +532,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -548,7 +551,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -558,10 +561,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -574,7 +575,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo/credentials",
+        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -584,7 +585,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/u4hou7fN7KacemoyryHYqngEdJd3jD96/credentials",
+        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -594,7 +595,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC/credentials",
+        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -604,7 +605,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/BSzSWBvdaNE2nlM36e2D58u03cr1PPja/credentials",
+        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -614,7 +615,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/7ySRBgcwnhcDBGxm04WdewfYmztF9up7/credentials",
+        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -624,7 +625,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ/credentials",
+        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -2042,7 +2043,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2095,7 +2096,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2104,6 +2105,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -2147,7 +2149,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2156,91 +2158,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -2283,7 +2200,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -2296,7 +2213,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -2318,20 +2235,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -2351,7 +2260,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2360,6 +2322,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -2409,7 +2414,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2434,7 +2439,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -2448,17 +2453,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -2468,7 +2472,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2478,10 +2482,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2494,18 +2496,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-10T07:02:06.718Z",
-                "updated_at": "2026-07-10T07:02:06.718Z"
+                "created_at": "2026-07-17T06:07:17.374Z",
+                "updated_at": "2026-07-17T06:07:17.374Z"
             }
         ],
         "rawHeaders": [],
@@ -2514,7 +2516,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+        "path": "/api/v2/clients/yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
         "body": "",
         "status": 204,
         "response": "",
@@ -2524,7 +2526,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+        "path": "/api/v2/clients/L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
         "body": "",
         "status": 204,
         "response": "",
@@ -2534,7 +2536,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -2615,7 +2617,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                         }
                     ]
                 }
@@ -2628,7 +2630,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -2652,7 +2654,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
         "body": {
             "name": "API Explorer Application",
             "allowed_clients": [],
@@ -2730,7 +2732,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2752,7 +2754,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/u4hou7fN7KacemoyryHYqngEdJd3jD96",
+        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb",
         "body": {
             "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
@@ -2813,7 +2815,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
+            "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2834,189 +2836,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
-        "body": {
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -3109,7 +2929,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+            "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3136,7 +2956,189 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
         "body": {
             "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
@@ -3214,7 +3216,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+            "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3236,7 +3238,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -3264,7 +3266,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -3306,20 +3308,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
@@ -3335,6 +3323,20 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -3418,34 +3420,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -3495,6 +3469,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/network-acls?page=0&per_page=100&include_totals=true",
         "body": "",
@@ -3520,7 +3522,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-10T07:01:49.216Z",
+                    "updated_at": "2026-07-17T06:06:58.205Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -3565,7 +3567,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-10T07:03:31.872Z",
+            "updated_at": "2026-07-17T06:10:14.781Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -3738,7 +3740,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3746,34 +3748,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3794,7 +3796,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/actions/actions/c344f61a-a341-41d7-a9e1-19555edb3b52",
+        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -3810,7 +3812,7 @@
         },
         "status": 200,
         "response": {
-            "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+            "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -3818,34 +3820,34 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-07-10T07:01:50.770371338Z",
-            "updated_at": "2026-07-10T07:03:33.560980817Z",
+            "created_at": "2026-07-17T06:06:59.806952575Z",
+            "updated_at": "2026-07-17T06:10:16.892278365Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
             "status": "pending",
             "secrets": [],
             "current_version": {
-                "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "runtime": "node18",
                 "status": "BUILT",
                 "number": 1,
-                "build_time": "2026-07-10T07:01:51.460717114Z",
-                "created_at": "2026-07-10T07:01:51.379899215Z",
-                "updated_at": "2026-07-10T07:01:51.461434467Z"
+                "build_time": "2026-07-17T06:07:00.515637114Z",
+                "created_at": "2026-07-17T06:07:00.450141003Z",
+                "updated_at": "2026-07-17T06:07:00.516137765Z"
             },
             "deployed_version": {
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "dependencies": [],
-                "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                 "deployed": true,
                 "number": 1,
-                "built_at": "2026-07-10T07:01:51.460717114Z",
+                "built_at": "2026-07-17T06:07:00.515637114Z",
                 "secrets": [],
                 "status": "built",
-                "created_at": "2026-07-10T07:01:51.379899215Z",
-                "updated_at": "2026-07-10T07:01:51.461434467Z",
+                "created_at": "2026-07-17T06:07:00.450141003Z",
+                "updated_at": "2026-07-17T06:07:00.516137765Z",
                 "runtime": "node18",
                 "supported_triggers": [
                     {
@@ -3868,7 +3870,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3876,34 +3878,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:03:33.560980817Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:10:16.892278365Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3924,19 +3926,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/c344f61a-a341-41d7-a9e1-19555edb3b52/deploy",
+        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
+            "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
             "deployed": false,
             "number": 2,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-07-10T07:03:34.154884654Z",
-            "updated_at": "2026-07-10T07:03:34.154884654Z",
+            "created_at": "2026-07-17T06:10:17.960682631Z",
+            "updated_at": "2026-07-17T06:10:17.960682631Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -3945,7 +3947,7 @@
                 }
             ],
             "action": {
-                "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -3953,10 +3955,72 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-07-10T07:01:50.770371338Z",
-                "updated_at": "2026-07-10T07:03:33.555240977Z",
+                "created_at": "2026-07-17T06:06:59.806952575Z",
+                "updated_at": "2026-07-17T06:10:16.883478043Z",
                 "all_changes_deployed": false
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 2,
+                        "build_time": "2026-07-17T06:10:18.049664680Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "deployed": true,
+                        "number": 2,
+                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3970,7 +4034,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4035,12 +4099,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4083,68 +4147,6 @@
                     ]
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:03:33.560980817Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-07-10T07:03:34.249987170Z",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-07-10T07:03:34.249987170Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4252,7 +4254,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4261,91 +4263,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -4388,7 +4305,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -4401,7 +4318,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -4423,20 +4340,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -4456,7 +4365,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4465,6 +4427,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -4514,7 +4519,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4539,7 +4544,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -4553,17 +4558,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -4573,7 +4577,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4583,10 +4587,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4638,13 +4640,75 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 2,
+                        "build_time": "2026-07-17T06:10:18.049664680Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "deployed": true,
+                        "number": 2,
+                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/connections?take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4709,12 +4773,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4764,88 +4828,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:03:33.560980817Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-07-10T07:03:34.249987170Z",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-07-10T07:03:34.249987170Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1"
-                },
-                {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -4860,12 +4843,31 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "clients": [
+                {
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                },
+                {
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-10T07:03:35.341Z"
+            "deleted_at": "2026-07-17T06:10:19.167Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4873,11 +4875,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_niAIwTTv44pEnqkT",
+            "id": "con_a2fdGQjZWlOIaBqp",
             "options": {
                 "mfa": {
                     "active": true,
@@ -4939,8 +4941,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -4952,7 +4954,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -5012,7 +5014,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_niAIwTTv44pEnqkT",
+            "id": "con_a2fdGQjZWlOIaBqp",
             "options": {
                 "mfa": {
                     "active": true,
@@ -5074,8 +5076,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -5187,7 +5189,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5196,91 +5198,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -5323,7 +5240,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -5336,7 +5253,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -5358,20 +5275,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -5391,7 +5300,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5400,6 +5362,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -5449,7 +5454,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5474,7 +5479,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -5488,17 +5493,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -5508,7 +5512,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5518,10 +5522,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -5579,7 +5581,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5644,12 +5646,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5671,8 +5673,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 }
             ]
@@ -5704,7 +5706,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5769,12 +5771,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5796,8 +5798,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 }
             ]
@@ -5808,16 +5810,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR/clients?take=100",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                 },
                 {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
                 }
             ]
         },
@@ -5827,7 +5829,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8",
         "body": {
             "is_domain_connection": false,
             "options": {
@@ -5841,7 +5843,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_JjHhTcjUkl8GGqXR",
+            "id": "con_u0jv1SLcz6oa6DT8",
             "options": {
                 "email": true,
                 "scope": [
@@ -5860,8 +5862,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
             ],
             "realms": [
                 "google-oauth2"
@@ -6010,7 +6012,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6019,91 +6021,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -6146,7 +6063,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -6159,7 +6076,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -6181,20 +6098,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -6214,7 +6123,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6223,6 +6185,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -6272,7 +6277,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6297,7 +6302,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -6311,17 +6316,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -6331,7 +6335,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6341,10 +6345,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6402,8 +6404,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -6778,144 +6918,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -6925,7 +6927,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_vqavbI9L0lxA6Zi0",
+        "path": "/api/v2/client-grants/cgr_QYueTYBZwIArLvJV",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7062,8 +7064,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_vqavbI9L0lxA6Zi0",
-            "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
+            "id": "cgr_QYueTYBZwIArLvJV",
+            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7205,7 +7207,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_kIMsqPp9nNpS09cZ",
+        "path": "/api/v2/client-grants/cgr_fNVNikQz3aWBSEna",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7342,8 +7344,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_kIMsqPp9nNpS09cZ",
-            "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+            "id": "cgr_fNVNikQz3aWBSEna",
+            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7491,22 +7493,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_RZJPrDR5ZoupOLlC",
+                    "id": "rol_mWNhCNG1yuxyzRW0",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_jiKwPHe3VqS3NOnb",
+                    "id": "rol_KYekWOWLVpJeVWbL",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_8DHaHirGsGLBVlqY",
+                    "id": "rol_TK6bINiThEdD82uJ",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_e77VknJBNucPL4CC",
+                    "id": "rol_9k41FO3KxqnRLjSO",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -7521,7 +7523,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7536,7 +7538,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7551,7 +7553,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7566,7 +7568,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7581,14 +7583,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0",
         "body": {
             "name": "Admin",
             "description": "Can read and write things"
         },
         "status": 200,
         "response": {
-            "id": "rol_RZJPrDR5ZoupOLlC",
+            "id": "rol_mWNhCNG1yuxyzRW0",
             "name": "Admin",
             "description": "Can read and write things"
         },
@@ -7598,14 +7600,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_jiKwPHe3VqS3NOnb",
+            "id": "rol_KYekWOWLVpJeVWbL",
             "name": "Reader",
             "description": "Can only read things"
         },
@@ -7615,14 +7617,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ",
         "body": {
             "name": "read_only",
             "description": "Read Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_8DHaHirGsGLBVlqY",
+            "id": "rol_TK6bINiThEdD82uJ",
             "name": "read_only",
             "description": "Read Only"
         },
@@ -7632,14 +7634,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_e77VknJBNucPL4CC",
+            "id": "rol_9k41FO3KxqnRLjSO",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -7675,7 +7677,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-10T07:02:03.424Z",
+                    "updated_at": "2026-07-17T06:07:13.803Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7751,12 +7753,38 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-10T07:03:42.648Z",
+            "updated_at": "2026-07-17T06:10:27.587Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "enabled": true,
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000
+        },
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7791,32 +7819,6 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "enabled": true,
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000
-        },
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/organizations?take=50",
         "body": "",
@@ -7824,13 +7826,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_C2jPGu4p9C67K6r4",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_DkFl7EwPp9Xa2Qo6",
+                    "id": "org_qdYzZeCFDLEiVOCL",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -7839,6 +7835,12 @@
                             "primary": "#57ddff"
                         }
                     },
+                    "third_party_client_access": "block"
+                },
+                {
+                    "id": "org_o0aVwomUlzXKMyv5",
+                    "name": "org2",
+                    "display_name": "Organization2",
                     "third_party_client_access": "block"
                 }
             ]
@@ -7949,7 +7951,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7958,91 +7960,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8085,7 +8002,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -8098,7 +8015,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -8120,20 +8037,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8153,7 +8062,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8162,6 +8124,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8211,7 +8216,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8236,7 +8241,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -8250,17 +8255,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -8270,7 +8274,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8280,10 +8284,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8335,7 +8337,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8350,7 +8352,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8365,7 +8367,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -8377,7 +8379,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8392,7 +8394,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8407,7 +8409,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -8425,7 +8427,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8490,12 +8492,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8517,8 +8519,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 }
             ]
@@ -8535,8 +8537,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -8911,144 +9051,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -9158,7 +9160,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9167,91 +9169,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -9294,7 +9211,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -9307,7 +9224,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -9329,20 +9246,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -9362,7 +9271,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9371,6 +9333,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -9420,7 +9425,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9445,7 +9450,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -9459,17 +9464,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -9479,7 +9483,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9489,10 +9493,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -9544,24 +9546,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4",
-        "body": {
-            "display_name": "Organization2"
-        },
-        "status": 200,
-        "response": {
-            "id": "org_C2jPGu4p9C67K6r4",
-            "display_name": "Organization2",
-            "name": "org2",
-            "third_party_client_access": "block"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL",
         "body": {
             "branding": {
                 "colors": {
@@ -9579,9 +9564,26 @@
                     "primary": "#57ddff"
                 }
             },
-            "id": "org_DkFl7EwPp9Xa2Qo6",
+            "id": "org_qdYzZeCFDLEiVOCL",
             "display_name": "Organization",
             "name": "org1",
+            "third_party_client_access": "block"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5",
+        "body": {
+            "display_name": "Organization2"
+        },
+        "status": 200,
+        "response": {
+            "id": "org_o0aVwomUlzXKMyv5",
+            "display_name": "Organization2",
+            "name": "org2",
             "third_party_client_access": "block"
         },
         "rawHeaders": [],
@@ -9595,7 +9597,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029630",
+                "id": "lst_0000000000029822",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -9606,14 +9608,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029631",
+                "id": "lst_0000000000029823",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
                 },
                 "filters": [
                     {
@@ -9662,7 +9664,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000029630",
+        "path": "/api/v2/log-streams/lst_0000000000029822",
         "body": {
             "name": "Suspended DD Log Stream",
             "sink": {
@@ -9672,7 +9674,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029630",
+            "id": "lst_0000000000029822",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -9688,7 +9690,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000029631",
+        "path": "/api/v2/log-streams/lst_0000000000029823",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -9733,14 +9735,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029631",
+            "id": "lst_0000000000029823",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
             },
             "filters": [
                 {
@@ -9888,7 +9890,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9897,91 +9899,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -10024,7 +9941,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -10037,7 +9954,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -10059,20 +9976,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -10092,7 +10001,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10101,6 +10063,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -10150,7 +10155,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10175,7 +10180,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -10189,17 +10194,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -10209,7 +10213,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10219,10 +10223,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -10235,18 +10237,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-10T07:02:06.718Z",
-                "updated_at": "2026-07-10T07:02:06.718Z"
+                "created_at": "2026-07-17T06:07:17.374Z",
+                "updated_at": "2026-07-17T06:07:17.374Z"
             }
         ],
         "rawHeaders": [],
@@ -10255,13 +10257,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                         }
                     ]
                 }
@@ -10304,7 +10306,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                         }
                     ]
                 }
@@ -10317,7 +10319,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -10347,7 +10349,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10355,34 +10357,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:03:33.560980817Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:10:16.892278365Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-10T07:03:34.249987170Z",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z"
+                        "build_time": "2026-07-17T06:10:18.049664680Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-10T07:03:34.249987170Z",
+                        "built_at": "2026-07-17T06:10:18.049664680Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -10421,7 +10423,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-10T07:02:08.113Z",
+                    "updated_at": "2026-07-17T06:07:18.621Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -10477,7 +10479,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-10T07:03:48.737Z",
+            "updated_at": "2026-07-17T06:10:33.528Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -10510,21 +10512,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -10538,9 +10525,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-10T07:02:11.682Z"
+                    "updated_at": "2026-07-17T06:07:22.179Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10609,7 +10611,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T07:02:11.682Z"
+            "updated_at": "2026-07-17T06:07:22.179Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10749,7 +10751,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T07:03:52.377Z"
+            "updated_at": "2026-07-17T06:10:37.024Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10771,6 +10773,7 @@
                 "enable_client_connections": false,
                 "enable_dynamic_client_registration": false,
                 "enable_public_signup_user_exists_error": true,
+                "use_scope_descriptions_for_consent": false,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
@@ -10990,7 +10993,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10999,91 +11002,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -11126,7 +11044,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -11139,7 +11057,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11161,20 +11079,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -11194,7 +11104,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11203,6 +11166,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -11252,7 +11258,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11277,7 +11283,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -11291,17 +11297,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -11311,7 +11316,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11321,10 +11326,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -12574,7 +12577,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12583,91 +12586,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -12710,7 +12628,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -12723,7 +12641,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12745,20 +12663,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -12778,7 +12688,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12787,6 +12750,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -12836,7 +12842,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12861,7 +12867,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -12875,17 +12881,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -12895,7 +12900,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12905,10 +12910,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -12921,18 +12924,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-10T07:02:06.718Z",
-                "updated_at": "2026-07-10T07:02:06.718Z"
+                "created_at": "2026-07-17T06:07:17.374Z",
+                "updated_at": "2026-07-17T06:07:17.374Z"
             }
         ],
         "rawHeaders": [],
@@ -12941,7 +12944,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
         "body": "",
         "status": 204,
         "response": "",
@@ -12951,7 +12954,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/u4hou7fN7KacemoyryHYqngEdJd3jD96",
+        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb",
         "body": "",
         "status": 204,
         "response": "",
@@ -12961,7 +12964,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
         "body": "",
         "status": 204,
         "response": "",
@@ -12971,7 +12974,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
         "body": "",
         "status": 204,
         "response": "",
@@ -12981,7 +12984,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
         "body": "",
         "status": 204,
         "response": "",
@@ -12991,7 +12994,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
         "body": "",
         "status": 204,
         "response": "",
@@ -13001,7 +13004,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
         "body": "",
         "status": 204,
         "response": "",
@@ -13072,7 +13075,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -13108,20 +13111,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
@@ -13136,7 +13125,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -13164,7 +13153,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -13192,7 +13181,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -13369,7 +13372,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -13377,34 +13380,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:03:33.560980817Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:10:16.892278365Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-10T07:03:34.249987170Z",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z"
+                        "build_time": "2026-07-17T06:10:18.049664680Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "c194304c-0833-4de7-ba50-d24d1ae9c5b1",
+                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-10T07:03:34.249987170Z",
+                        "built_at": "2026-07-17T06:10:18.049664680Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:03:34.154884654Z",
-                        "updated_at": "2026-07-10T07:03:34.251362965Z",
+                        "created_at": "2026-07-17T06:10:17.960682631Z",
+                        "updated_at": "2026-07-17T06:10:18.050629481Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -13425,103 +13428,10 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/c344f61a-a341-41d7-a9e1-19555edb3b52?force=true",
+        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0?force=true",
         "body": "",
         "status": 204,
         "response": "",
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [],
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_niAIwTTv44pEnqkT",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": []
-                }
-            ]
-        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -13631,7 +13541,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13713,7 +13623,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13787,7 +13697,100 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT/clients?take=100",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [],
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": []
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13799,11 +13802,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-10T07:04:04.196Z"
+            "deleted_at": "2026-07-17T06:10:48.753Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13832,7 +13835,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_sZmrptRT1dRkGEaU",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13884,7 +13887,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13932,14 +13935,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients",
         "body": [
             {
                 "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                 "status": true
             },
             {
-                "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                 "status": true
             }
         ],
@@ -14041,7 +14044,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14110,7 +14113,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14134,7 +14137,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14174,7 +14177,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -14206,7 +14209,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14230,7 +14233,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14270,7 +14273,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -14281,7 +14284,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR/clients?take=100",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -14293,11 +14296,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-10T07:04:09.043Z"
+            "deleted_at": "2026-07-17T06:10:54.004Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -14429,7 +14432,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14751,22 +14754,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_RZJPrDR5ZoupOLlC",
+                    "id": "rol_mWNhCNG1yuxyzRW0",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_jiKwPHe3VqS3NOnb",
+                    "id": "rol_KYekWOWLVpJeVWbL",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_8DHaHirGsGLBVlqY",
+                    "id": "rol_TK6bINiThEdD82uJ",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_e77VknJBNucPL4CC",
+                    "id": "rol_9k41FO3KxqnRLjSO",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -14781,7 +14784,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14796,7 +14799,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14811,7 +14814,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14826,7 +14829,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14841,7 +14844,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0",
         "body": "",
         "status": 200,
         "response": {},
@@ -14851,7 +14854,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL",
         "body": "",
         "status": 200,
         "response": {},
@@ -14861,7 +14864,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ",
         "body": "",
         "status": 200,
         "response": {},
@@ -14871,7 +14874,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO",
         "body": "",
         "status": 200,
         "response": {},
@@ -14887,13 +14890,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_C2jPGu4p9C67K6r4",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_DkFl7EwPp9Xa2Qo6",
+                    "id": "org_qdYzZeCFDLEiVOCL",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -14902,6 +14899,12 @@
                             "primary": "#57ddff"
                         }
                     },
+                    "third_party_client_access": "block"
+                },
+                {
+                    "id": "org_o0aVwomUlzXKMyv5",
+                    "name": "org2",
+                    "display_name": "Organization2",
                     "third_party_client_access": "block"
                 }
             ]
@@ -15002,7 +15005,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15065,7 +15068,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15080,7 +15083,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15095,7 +15098,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15107,7 +15110,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15122,7 +15125,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15137,7 +15140,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15155,7 +15158,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15195,7 +15198,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -15549,7 +15552,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15612,7 +15615,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5",
         "body": "",
         "status": 204,
         "response": "",
@@ -15622,7 +15625,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL",
         "body": "",
         "status": 204,
         "response": "",
@@ -15637,7 +15640,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029630",
+                "id": "lst_0000000000029822",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -15648,14 +15651,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029631",
+                "id": "lst_0000000000029823",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
                 },
                 "filters": [
                     {
@@ -15704,7 +15707,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000029630",
+        "path": "/api/v2/log-streams/lst_0000000000029822",
         "body": "",
         "status": 204,
         "response": "",
@@ -15714,7 +15717,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000029631",
+        "path": "/api/v2/log-streams/lst_0000000000029823",
         "body": "",
         "status": 204,
         "response": "",
@@ -17173,7 +17176,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17203,7 +17206,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17243,7 +17246,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -17267,33 +17270,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections-directory-provisionings?take=50",
-        "body": "",
-        "status": 403,
-        "response": {
-            "statusCode": 403,
-            "error": "Forbidden",
-            "message": "Insufficient scope, expected any of: read:directory_provisionings",
-            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -17307,7 +17295,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17347,10 +17335,25 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections-directory-provisionings?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:directory_provisionings",
+            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -17479,7 +17482,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -17513,37 +17546,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -17573,7 +17576,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
+        "path": "/api/v2/email-templates/reset_email",
         "body": "",
         "status": 404,
         "response": {
@@ -17588,7 +17591,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
+        "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
         "response": {
@@ -17618,7 +17621,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -17633,7 +17636,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/async_approval",
         "body": "",
         "status": 404,
         "response": {
@@ -18254,7 +18257,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18274,17 +18277,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18295,6 +18288,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18334,16 +18337,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
@@ -18354,7 +18347,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18364,7 +18357,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18394,6 +18387,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/customized-consent/custom-text/en",
         "body": "",
         "status": 200,
@@ -18414,7 +18417,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18434,7 +18437,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18454,7 +18457,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18464,7 +18467,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18494,7 +18497,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18504,7 +18507,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18524,7 +18527,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18534,7 +18537,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18554,16 +18557,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/invitation/custom-text/en",
         "body": "",
         "status": 200,
@@ -18574,17 +18567,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/captcha/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
+        "path": "/api/v2/prompts/common/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18604,6 +18587,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
@@ -18614,7 +18617,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/partials",
+        "path": "/api/v2/prompts/login-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -18624,7 +18627,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/partials",
+        "path": "/api/v2/prompts/login-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -18654,16 +18657,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/partials",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
@@ -18675,6 +18668,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/signup-password/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -18734,29 +18737,6 @@
             "triggers": [
                 {
                     "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node18",
-                        "node22"
-                    ],
-                    "default_runtime": "node16",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -18773,14 +18753,25 @@
                     ]
                 },
                 {
-                    "id": "credentials-exchange",
+                    "id": "post-login",
                     "version": "v2",
-                    "status": "CURRENT",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
+                        "node18",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node16",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -18792,6 +18783,18 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "credentials-exchange",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node18-actions",
+                        "node22"
+                    ],
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -18843,17 +18846,6 @@
                 },
                 {
                     "id": "post-change-password",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-change-password",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -18861,6 +18853,17 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-change-password",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19247,7 +19250,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19310,25 +19313,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
@@ -19345,6 +19329,25 @@
                     "shields": []
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19435,11 +19438,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19447,11 +19450,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "remember_for": 30
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19494,21 +19497,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -19522,9 +19510,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-10T07:03:52.377Z"
+                    "updated_at": "2026-07-17T06:10:37.024Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19593,22 +19596,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T07:03:52.377Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-07-17T06:10:37.024Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19624,6 +19612,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19672,7 +19675,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-10T07:03:42.648Z",
+                    "updated_at": "2026-07-17T06:10:27.587Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -19724,7 +19727,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-10T07:03:31.872Z",
+                    "updated_at": "2026-07-17T06:10:14.781Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -19875,7 +19878,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-10T07:03:48.737Z",
+                    "updated_at": "2026-07-17T06:10:33.528Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {

--- a/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
+++ b/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
@@ -1441,7 +1441,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1494,7 +1494,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1503,6 +1503,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -1510,273 +1511,6 @@
                     "custom_login_page_on": true
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Quickstarts API (Test Application)",
-            "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -1872,7 +1606,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1899,7 +1633,7 @@
         "method": "POST",
         "path": "/api/v2/clients",
         "body": {
-            "name": "auth0-deploy-cli-extension",
+            "name": "API Explorer Application",
             "allowed_clients": [],
             "app_type": "non_interactive",
             "callbacks": [],
@@ -1943,7 +1677,7 @@
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
             "is_token_endpoint_ip_header_trusted": false,
-            "name": "auth0-deploy-cli-extension",
+            "name": "API Explorer Application",
             "allowed_clients": [],
             "callbacks": [],
             "client_metadata": {},
@@ -1978,7 +1712,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1987,6 +1721,279 @@
                 "secret_encoded": false
             },
             "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Quickstarts API (Test Application)",
+            "app_type": "non_interactive",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
             "token_endpoint_auth_method": "client_secret_post",
             "app_type": "non_interactive",
             "grant_types": [
@@ -2096,7 +2103,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+            "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2125,17 +2132,15 @@
         "method": "POST",
         "path": "/api/v2/clients",
         "body": {
-            "name": "The Default App",
+            "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
+            "app_type": "non_interactive",
             "callbacks": [],
             "client_aliases": [],
             "client_metadata": {},
             "cross_origin_authentication": false,
             "custom_login_page_on": true,
             "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
                 "client_credentials"
             ],
             "is_first_party": true,
@@ -2153,17 +2158,16 @@
                     "enabled": false
                 }
             },
-            "oidc_conformant": false,
+            "oidc_conformant": true,
             "refresh_token": {
                 "expiration_type": "non-expiring",
                 "leeway": 0,
                 "infinite_token_lifetime": true,
                 "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
                 "rotation_type": "non-rotating"
             },
-            "sso": false,
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
@@ -2172,7 +2176,7 @@
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
             "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
+            "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
             "callbacks": [],
             "client_metadata": {},
@@ -2186,17 +2190,16 @@
                     "enabled": false
                 }
             },
-            "oidc_conformant": false,
+            "oidc_conformant": true,
             "refresh_token": {
                 "expiration_type": "non-expiring",
                 "leeway": 0,
                 "infinite_token_lifetime": true,
                 "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
                 "rotation_type": "non-rotating"
             },
-            "sso": false,
             "sso_disabled": false,
             "cross_origin_auth": false,
             "encrypted": true,
@@ -2208,7 +2211,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+            "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2218,10 +2221,8 @@
             },
             "client_aliases": [],
             "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
             "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
                 "client_credentials"
             ],
             "custom_login_page_on": true
@@ -2274,35 +2275,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-platform",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -2337,6 +2310,34 @@
         "status": 200,
         "response": {
             "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2414,34 +2415,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -2491,6 +2464,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/network-acls?page=0&per_page=100&include_totals=true",
         "body": "",
@@ -2516,7 +2517,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-09T13:25:11.409Z",
+                    "updated_at": "2026-07-10T07:03:31.872Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -2561,7 +2562,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-10T07:01:49.216Z",
+            "updated_at": "2026-07-17T06:06:58.205Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -2625,9 +2626,9 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/user-attribute-profiles/uap_1csDj3sAVu6n5eTzLw6XZg",
+        "path": "/api/v2/user-attribute-profiles/uap_1csDj3szFsgxGS1oTZTdFm",
         "body": {
-            "name": "test-user-attribute-profile",
+            "name": "test-user-attribute-profile-2",
             "user_attributes": {
                 "email": {
                     "description": "Email of the User",
@@ -2643,8 +2644,8 @@
         },
         "status": 200,
         "response": {
-            "id": "uap_1csDj3sAVu6n5eTzLw6XZg",
-            "name": "test-user-attribute-profile",
+            "id": "uap_1csDj3szFsgxGS1oTZTdFm",
+            "name": "test-user-attribute-profile-2",
             "user_id": {
                 "oidc_mapping": "sub",
                 "saml_mapping": [
@@ -2669,9 +2670,9 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/user-attribute-profiles/uap_1csDj3szFsgxGS1oTZTdFm",
+        "path": "/api/v2/user-attribute-profiles/uap_1csDj3sAVu6n5eTzLw6XZg",
         "body": {
-            "name": "test-user-attribute-profile-2",
+            "name": "test-user-attribute-profile",
             "user_attributes": {
                 "email": {
                     "description": "Email of the User",
@@ -2687,8 +2688,8 @@
         },
         "status": 200,
         "response": {
-            "id": "uap_1csDj3szFsgxGS1oTZTdFm",
-            "name": "test-user-attribute-profile-2",
+            "id": "uap_1csDj3sAVu6n5eTzLw6XZg",
+            "name": "test-user-attribute-profile",
             "user_id": {
                 "oidc_mapping": "sub",
                 "saml_mapping": [
@@ -2757,7 +2758,7 @@
         },
         "status": 201,
         "response": {
-            "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+            "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -2765,8 +2766,8 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-07-10T07:01:50.770371338Z",
-            "updated_at": "2026-07-10T07:01:50.788099597Z",
+            "created_at": "2026-07-17T06:06:59.806952575Z",
+            "updated_at": "2026-07-17T06:06:59.821829361Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
@@ -2786,7 +2787,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -2794,8 +2795,8 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
@@ -2813,19 +2814,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/c344f61a-a341-41d7-a9e1-19555edb3b52/deploy",
+        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+            "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
             "deployed": false,
             "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-07-10T07:01:51.379899215Z",
-            "updated_at": "2026-07-10T07:01:51.379899215Z",
+            "created_at": "2026-07-17T06:07:00.450141003Z",
+            "updated_at": "2026-07-17T06:07:00.450141003Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -2834,7 +2835,7 @@
                 }
             ],
             "action": {
-                "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -2842,10 +2843,72 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-07-10T07:01:50.770371338Z",
-                "updated_at": "2026-07-10T07:01:50.770371338Z",
+                "created_at": "2026-07-17T06:06:59.806952575Z",
+                "updated_at": "2026-07-17T06:06:59.806952575Z",
                 "all_changes_deployed": false
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2859,7 +2922,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2899,72 +2962,10 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3062,7 +3063,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3115,7 +3116,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3124,6 +3125,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -3167,7 +3169,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3176,91 +3178,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -3307,7 +3224,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3330,20 +3247,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -3363,7 +3272,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3372,6 +3334,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -3421,7 +3426,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3446,7 +3451,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -3460,17 +3465,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -3480,7 +3484,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3490,10 +3494,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3551,7 +3553,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3559,34 +3561,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3613,7 +3615,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3653,7 +3655,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -3664,16 +3666,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 },
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                 }
             ]
         },
@@ -3730,7 +3732,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_niAIwTTv44pEnqkT",
+            "id": "con_a2fdGQjZWlOIaBqp",
             "options": {
                 "mfa": {
                     "active": true,
@@ -3808,7 +3810,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3882,14 +3884,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT/clients",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients",
         "body": [
             {
-                "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                 "status": true
             },
             {
-                "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                 "status": true
             }
         ],
@@ -3991,7 +3993,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4044,7 +4046,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4053,6 +4055,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -4096,7 +4099,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4105,91 +4108,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -4236,7 +4154,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4259,20 +4177,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -4292,7 +4202,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4301,6 +4264,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -4350,7 +4356,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4375,7 +4381,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -4389,17 +4395,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -4409,7 +4414,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4419,10 +4424,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4480,7 +4483,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4545,12 +4548,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4590,7 +4593,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -4622,7 +4625,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4687,12 +4690,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4732,7 +4735,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -4759,7 +4762,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_JjHhTcjUkl8GGqXR",
+            "id": "con_u0jv1SLcz6oa6DT8",
             "options": {
                 "email": true,
                 "scope": [
@@ -4794,7 +4797,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -4825,14 +4828,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR/clients",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients",
         "body": [
             {
-                "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                 "status": true
             },
             {
-                "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                 "status": true
             }
         ],
@@ -4971,7 +4974,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5024,7 +5027,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5033,6 +5036,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -5076,7 +5080,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5085,91 +5089,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -5216,7 +5135,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5239,20 +5158,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -5272,7 +5183,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5281,6 +5245,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -5330,7 +5337,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5355,7 +5362,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -5369,17 +5376,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -5389,7 +5395,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5399,10 +5405,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -5709,7 +5713,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5846,8 +5850,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_kIMsqPp9nNpS09cZ",
-            "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+            "id": "cgr_QYueTYBZwIArLvJV",
+            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5991,7 +5995,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
+            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6128,8 +6132,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_vqavbI9L0lxA6Zi0",
-            "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
+            "id": "cgr_fNVNikQz3aWBSEna",
+            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6293,7 +6297,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_jiKwPHe3VqS3NOnb",
+            "id": "rol_KYekWOWLVpJeVWbL",
             "name": "Reader",
             "description": "Can only read things"
         },
@@ -6310,7 +6314,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_RZJPrDR5ZoupOLlC",
+            "id": "rol_mWNhCNG1yuxyzRW0",
             "name": "Admin",
             "description": "Can read and write things"
         },
@@ -6327,7 +6331,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_8DHaHirGsGLBVlqY",
+            "id": "rol_TK6bINiThEdD82uJ",
             "name": "read_only",
             "description": "Read Only"
         },
@@ -6344,7 +6348,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_e77VknJBNucPL4CC",
+            "id": "rol_9k41FO3KxqnRLjSO",
             "name": "read_osnly",
             "description": "Readz Only"
         },
@@ -6380,7 +6384,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-09T13:25:19.143Z",
+                    "updated_at": "2026-07-10T07:03:42.648Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -6456,38 +6460,12 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-10T07:02:03.424Z",
+            "updated_at": "2026-07-17T06:07:13.803Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
                 }
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "enabled": true,
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000
-        },
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6516,6 +6494,32 @@
             "syntax": "liquid",
             "urlLifetimeInSeconds": 3600,
             "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "enabled": true,
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000
+        },
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6625,7 +6629,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6678,7 +6682,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6687,6 +6691,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -6730,7 +6735,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6739,91 +6744,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -6870,7 +6790,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6893,20 +6813,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -6926,7 +6838,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6935,6 +6900,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -6984,7 +6992,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7009,7 +7017,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -7023,17 +7031,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -7043,7 +7050,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7053,10 +7060,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -7114,7 +7119,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7179,12 +7184,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7206,12 +7211,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7251,7 +7256,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -7268,8 +7273,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -7644,144 +7787,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -7881,7 +7886,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7934,7 +7939,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7943,6 +7948,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -7986,7 +7992,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7995,91 +8001,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8126,7 +8047,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8149,20 +8070,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8182,7 +8095,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8191,6 +8157,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8240,7 +8249,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8265,7 +8274,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -8279,17 +8288,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -8299,7 +8307,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8309,10 +8317,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8366,24 +8372,6 @@
         "method": "POST",
         "path": "/api/v2/organizations",
         "body": {
-            "name": "org2",
-            "display_name": "Organization2"
-        },
-        "status": 201,
-        "response": {
-            "id": "org_C2jPGu4p9C67K6r4",
-            "display_name": "Organization2",
-            "name": "org2",
-            "third_party_client_access": "block"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
-        "body": {
             "name": "org1",
             "branding": {
                 "colors": {
@@ -8395,7 +8383,7 @@
         },
         "status": 201,
         "response": {
-            "id": "org_DkFl7EwPp9Xa2Qo6",
+            "id": "org_qdYzZeCFDLEiVOCL",
             "display_name": "Organization",
             "name": "org1",
             "branding": {
@@ -8404,6 +8392,24 @@
                     "primary": "#57ddff"
                 }
             },
+            "third_party_client_access": "block"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/organizations",
+        "body": {
+            "name": "org2",
+            "display_name": "Organization2"
+        },
+        "status": 201,
+        "response": {
+            "id": "org_o0aVwomUlzXKMyv5",
+            "display_name": "Organization2",
+            "name": "org2",
             "third_party_client_access": "block"
         },
         "rawHeaders": [],
@@ -8433,7 +8439,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029630",
+            "id": "lst_0000000000029822",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -8498,14 +8504,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029631",
+            "id": "lst_0000000000029823",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
             },
             "filters": [
                 {
@@ -8643,7 +8649,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8696,7 +8702,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8705,6 +8711,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -8748,7 +8755,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8757,91 +8764,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -8888,7 +8810,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8911,20 +8833,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -8944,7 +8858,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8953,6 +8920,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -9002,7 +9012,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9027,7 +9037,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -9041,17 +9051,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -9061,7 +9070,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9071,10 +9080,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -9087,7 +9094,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -9097,7 +9104,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": {
             "name": "e2e-test-key",
             "pem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs8/9RN2qV8HZMunRt8mx\nihqnIX726YqxGwF+7x1A0gpk4TWRpMUWnaaL2D3Nt/Kd5obKM0THZPCuE+Xwncf4\nQloizZEn4jM3PNldweL9qwG160o2wXif2R5zLVQat9/188+Ko/sU/LorHgh23DMp\nznSwIN30AdLG1WRPxqP5s9abVT0WgBt1VuQobw4TS6QltFUnMSEMBsNtMSPK+NPJ\npz9s3ozqkNMLNSLZMTwgODQWchUr2YJeZa5RbM0u5Xt9oF0HtXH8db3L6Rp3TdIA\nuISnZ+mC7zRiCzWljkJZSBrqgtx6Su5wSve9cYGPS23zu3yeSapJWP7pki3G/GBz\nJQIDAQAB\n-----END PUBLIC KEY-----\n",
@@ -9105,13 +9112,13 @@
         },
         "status": 201,
         "response": {
-            "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+            "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
             "credential_type": "public_key",
             "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
             "alg": "RS256",
             "name": "e2e-test-key",
-            "created_at": "2026-07-10T07:02:06.718Z",
-            "updated_at": "2026-07-10T07:02:06.718Z"
+            "created_at": "2026-07-17T06:07:17.374Z",
+            "updated_at": "2026-07-17T06:07:17.374Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9119,13 +9126,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                         }
                     ]
                 }
@@ -9168,7 +9175,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                         }
                     ]
                 }
@@ -9181,7 +9188,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -9211,7 +9218,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -9219,34 +9226,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -9285,7 +9292,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-09T13:25:25.613Z",
+                    "updated_at": "2026-07-10T07:03:48.737Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -9341,7 +9348,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-10T07:02:08.113Z",
+            "updated_at": "2026-07-17T06:07:18.621Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -9374,21 +9381,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -9402,9 +9394,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-10T06:01:05.739Z"
+                    "updated_at": "2026-07-16T08:47:14.857Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9473,7 +9480,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T06:01:05.739Z"
+            "updated_at": "2026-07-16T08:47:14.857Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9613,7 +9620,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T07:02:11.682Z"
+            "updated_at": "2026-07-17T06:07:22.179Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9635,6 +9642,7 @@
                 "enable_client_connections": false,
                 "enable_dynamic_client_registration": false,
                 "enable_public_signup_user_exists_error": true,
+                "use_scope_descriptions_for_consent": false,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
@@ -10971,7 +10979,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11024,7 +11032,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11033,6 +11041,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -11076,7 +11085,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11085,91 +11094,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -11212,7 +11136,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -11225,7 +11149,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11247,20 +11171,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -11280,7 +11196,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11289,6 +11258,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -11338,7 +11350,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11363,7 +11375,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -11377,17 +11389,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -11397,7 +11408,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11407,10 +11418,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11423,18 +11432,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-10T07:02:06.718Z",
-                "updated_at": "2026-07-10T07:02:06.718Z"
+                "created_at": "2026-07-17T06:07:17.374Z",
+                "updated_at": "2026-07-17T06:07:17.374Z"
             }
         ],
         "rawHeaders": [],
@@ -11443,7 +11452,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+        "path": "/api/v2/clients/yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -11501,7 +11510,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+            "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -11537,7 +11546,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -11551,7 +11560,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -11579,7 +11588,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -11607,21 +11630,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -11666,54 +11675,6 @@
         "status": 200,
         "response": {
             "message_types": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "admin_notification",
-                "block"
-            ],
-            "allowlist": [],
-            "stage": {
-                "pre-login": {
-                    "max_attempts": 100,
-                    "rate": 864000
-                },
-                "pre-user-registration": {
-                    "max_attempts": 50,
-                    "rate": 1200
-                }
-            }
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "admin_notification",
-                "block"
-            ],
-            "allowlist": [],
-            "stage": {
-                "pre-login": {
-                    "max_attempts": 100,
-                    "rate": 864000
-                },
-                "pre-user-registration": {
-                    "max_attempts": 50,
-                    "rate": 1200
-                },
-                "pre-custom-token-exchange": {
-                    "max_attempts": 10,
-                    "rate": 600000
-                }
-            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -11776,6 +11737,54 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "admin_notification",
+                "block"
+            ],
+            "allowlist": [],
+            "stage": {
+                "pre-login": {
+                    "max_attempts": 100,
+                    "rate": 864000
+                },
+                "pre-user-registration": {
+                    "max_attempts": 50,
+                    "rate": 1200
+                }
+            }
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "admin_notification",
+                "block"
+            ],
+            "allowlist": [],
+            "stage": {
+                "pre-login": {
+                    "max_attempts": 100,
+                    "rate": 864000
+                },
+                "pre-user-registration": {
+                    "max_attempts": 50,
+                    "rate": 1200
+                },
+                "pre-custom-token-exchange": {
+                    "max_attempts": 10,
+                    "rate": 600000
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/actions/modules?page=0&per_page=100",
         "body": "",
@@ -11798,7 +11807,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11806,34 +11815,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11860,7 +11869,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11868,34 +11877,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11922,7 +11931,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11930,34 +11939,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11984,7 +11993,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12049,12 +12058,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12094,7 +12103,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -12195,7 +12204,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12248,7 +12257,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12257,6 +12266,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -12300,7 +12310,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12309,91 +12319,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -12436,7 +12361,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -12449,7 +12374,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12471,20 +12396,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -12504,7 +12421,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12513,6 +12483,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -12562,7 +12575,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12587,7 +12600,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -12601,17 +12614,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -12621,7 +12633,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12631,10 +12643,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -12692,7 +12702,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -12700,34 +12710,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -12754,7 +12764,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12819,12 +12829,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12864,7 +12874,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -12875,16 +12885,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
-                {
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
-                },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                },
+                {
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                 }
             ]
         },
@@ -12894,16 +12904,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT/clients?take=100",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1"
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                 },
                 {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
                 }
             ]
         },
@@ -12913,11 +12923,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_uhgt3cTfe93QJrXZ",
+            "id": "con_sZmrptRT1dRkGEaU",
             "options": {
                 "mfa": {
                     "active": true,
@@ -12954,7 +12964,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -12966,7 +12976,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -13000,7 +13010,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_uhgt3cTfe93QJrXZ",
+            "id": "con_sZmrptRT1dRkGEaU",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13037,7 +13047,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -13139,7 +13149,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13192,7 +13202,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13201,6 +13211,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -13244,7 +13255,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13253,91 +13264,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -13380,7 +13306,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -13393,7 +13319,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -13415,20 +13341,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -13448,7 +13366,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13457,6 +13428,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -13506,7 +13520,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13531,7 +13545,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -13545,17 +13559,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -13565,7 +13578,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13575,10 +13588,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -13636,7 +13647,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13701,12 +13712,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -13728,12 +13739,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13773,7 +13784,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -13805,7 +13816,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13870,12 +13881,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -13897,12 +13908,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13942,7 +13953,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -13953,16 +13964,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR/clients?take=100",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                 },
                 {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
                 }
             ]
         },
@@ -14077,7 +14088,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14130,7 +14141,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14139,6 +14150,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -14182,7 +14194,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14191,91 +14203,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -14318,7 +14245,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -14331,7 +14258,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -14353,20 +14280,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -14386,7 +14305,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14395,6 +14367,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -14444,7 +14459,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14469,7 +14484,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -14483,17 +14498,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -14503,7 +14517,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14513,10 +14527,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -14574,8 +14586,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -14950,144 +15100,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -15103,22 +15115,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_RZJPrDR5ZoupOLlC",
+                    "id": "rol_mWNhCNG1yuxyzRW0",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_jiKwPHe3VqS3NOnb",
+                    "id": "rol_KYekWOWLVpJeVWbL",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_8DHaHirGsGLBVlqY",
+                    "id": "rol_TK6bINiThEdD82uJ",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_e77VknJBNucPL4CC",
+                    "id": "rol_9k41FO3KxqnRLjSO",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -15133,7 +15145,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15148,7 +15160,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15163,7 +15175,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15178,7 +15190,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15199,13 +15211,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_C2jPGu4p9C67K6r4",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_DkFl7EwPp9Xa2Qo6",
+                    "id": "org_qdYzZeCFDLEiVOCL",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -15214,6 +15220,12 @@
                             "primary": "#57ddff"
                         }
                     },
+                    "third_party_client_access": "block"
+                },
+                {
+                    "id": "org_o0aVwomUlzXKMyv5",
+                    "name": "org2",
+                    "display_name": "Organization2",
                     "third_party_client_access": "block"
                 }
             ]
@@ -15314,7 +15326,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15367,7 +15379,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15376,6 +15388,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -15419,7 +15432,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15428,91 +15441,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -15555,7 +15483,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -15568,7 +15496,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -15590,20 +15518,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -15623,7 +15543,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15632,6 +15605,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -15681,7 +15697,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15706,7 +15722,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -15720,17 +15736,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -15740,7 +15755,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15750,10 +15765,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -15805,7 +15818,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15820,7 +15833,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15835,7 +15848,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15847,7 +15860,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15862,7 +15875,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15877,7 +15890,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15895,7 +15908,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15960,12 +15973,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -15987,12 +16000,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -16032,7 +16045,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -16049,8 +16062,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -16425,144 +16576,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -16662,7 +16675,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16715,7 +16728,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16724,6 +16737,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -16767,7 +16781,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16776,91 +16790,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -16903,7 +16832,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -16916,7 +16845,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -16938,20 +16867,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -16971,7 +16892,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16980,6 +16954,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -17029,7 +17046,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17054,7 +17071,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -17068,17 +17085,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -17088,7 +17104,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17098,10 +17114,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -17158,7 +17172,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029630",
+                "id": "lst_0000000000029822",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -17169,14 +17183,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029631",
+                "id": "lst_0000000000029823",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
                 },
                 "filters": [
                     {
@@ -18674,7 +18688,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18727,7 +18741,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18736,6 +18750,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -18779,7 +18794,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18788,91 +18803,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -18915,7 +18845,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -18928,7 +18858,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -18950,20 +18880,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -18983,7 +18905,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18992,6 +18967,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -19041,7 +19059,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19066,7 +19084,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -19080,17 +19098,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -19100,7 +19117,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19110,10 +19127,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -19126,18 +19141,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1/credentials",
+        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_uBm9gvJ1HYGp15VWntrqTH",
+                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-10T07:02:06.718Z",
-                "updated_at": "2026-07-10T07:02:06.718Z"
+                "created_at": "2026-07-17T06:07:17.374Z",
+                "updated_at": "2026-07-17T06:07:17.374Z"
             }
         ],
         "rawHeaders": [],
@@ -19152,7 +19167,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19217,12 +19232,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19262,7 +19277,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -19279,7 +19294,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -19287,34 +19302,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -19335,16 +19350,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                 },
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
                 }
             ]
         },
@@ -19354,16 +19369,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_niAIwTTv44pEnqkT/clients?take=100",
+        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 },
                 {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                 }
             ]
         },
@@ -19394,7 +19409,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_niAIwTTv44pEnqkT",
+                    "id": "con_a2fdGQjZWlOIaBqp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19459,12 +19474,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_JjHhTcjUkl8GGqXR",
+                    "id": "con_u0jv1SLcz6oa6DT8",
                     "options": {
                         "email": true,
                         "scope": [
@@ -19486,12 +19501,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
-                        "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                     ]
                 },
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_sZmrptRT1dRkGEaU",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19531,7 +19546,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                     ]
                 }
             ]
@@ -19542,16 +19557,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_JjHhTcjUkl8GGqXR/clients?take=100",
+        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja"
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
                 },
                 {
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ"
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
                 }
             ]
         },
@@ -19649,21 +19664,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -19682,7 +19682,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -19697,52 +19697,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/reset_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -19758,21 +19713,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
         "response": {
@@ -19817,7 +19757,52 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
         "response": {
@@ -19851,14 +19836,182 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/client-grants?take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_kIMsqPp9nNpS09cZ",
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "id": "cgr_QYueTYBZwIArLvJV",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_fNVNikQz3aWBSEna",
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -20233,144 +20386,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_vqavbI9L0lxA6Zi0",
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -20504,22 +20519,22 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_RZJPrDR5ZoupOLlC",
+                    "id": "rol_mWNhCNG1yuxyzRW0",
                     "name": "Admin",
                     "description": "Can read and write things"
                 },
                 {
-                    "id": "rol_jiKwPHe3VqS3NOnb",
+                    "id": "rol_KYekWOWLVpJeVWbL",
                     "name": "Reader",
                     "description": "Can only read things"
                 },
                 {
-                    "id": "rol_8DHaHirGsGLBVlqY",
+                    "id": "rol_TK6bINiThEdD82uJ",
                     "name": "read_only",
                     "description": "Read Only"
                 },
                 {
-                    "id": "rol_e77VknJBNucPL4CC",
+                    "id": "rol_9k41FO3KxqnRLjSO",
                     "name": "read_osnly",
                     "description": "Readz Only"
                 }
@@ -20534,7 +20549,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_RZJPrDR5ZoupOLlC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20549,7 +20564,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_jiKwPHe3VqS3NOnb/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20564,7 +20579,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_8DHaHirGsGLBVlqY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20579,7 +20594,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_e77VknJBNucPL4CC/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20814,16 +20829,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
@@ -20835,6 +20840,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20894,16 +20909,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
@@ -20915,6 +20920,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20984,7 +20999,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20994,7 +21009,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21054,6 +21069,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
@@ -21065,16 +21090,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/mfa/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21164,7 +21179,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/partials",
+        "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21174,7 +21189,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/partials",
+        "path": "/api/v2/prompts/login-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21194,7 +21209,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup/partials",
+        "path": "/api/v2/prompts/login-passwordless/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21204,7 +21219,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/partials",
+        "path": "/api/v2/prompts/signup/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21224,7 +21239,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-password/partials",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21234,7 +21249,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/signup-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21265,7 +21280,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -21273,34 +21288,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -21343,6 +21358,18 @@
             "triggers": [
                 {
                     "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node18",
+                        "node22"
+                    ],
+                    "default_runtime": "node16",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -21366,18 +21393,6 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node18",
-                        "node22"
-                    ],
-                    "default_runtime": "node16",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -21760,13 +21775,7 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_C2jPGu4p9C67K6r4",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_DkFl7EwPp9Xa2Qo6",
+                    "id": "org_qdYzZeCFDLEiVOCL",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -21775,6 +21784,12 @@
                             "primary": "#57ddff"
                         }
                     },
+                    "third_party_client_access": "block"
+                },
+                {
+                    "id": "org_o0aVwomUlzXKMyv5",
+                    "name": "org2",
+                    "display_name": "Organization2",
                     "third_party_client_access": "block"
                 }
             ]
@@ -21875,7 +21890,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -21928,7 +21943,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "XZ87AOv2WaXGLMx73HWWceZKOiSKCwfS",
+                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -21937,6 +21952,7 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
                         "client_credentials"
@@ -21980,7 +21996,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "SqYL4IgqYnGZvCWK5QvhZkiPmahgCxHo",
+                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -21989,91 +22005,6 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "u4hou7fN7KacemoyryHYqngEdJd3jD96",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "xTxYAu8lup5tUvIg7I3JiBzT88OGHCdC",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -22116,7 +22047,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_uBm9gvJ1HYGp15VWntrqTH"
+                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
                                 }
                             ]
                         }
@@ -22129,7 +22060,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "m2t6p5kFpsMzccP1HBOqRwvBOZvlCjh1",
+                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -22151,20 +22082,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
                     "cross_origin_authentication": false,
                     "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
@@ -22184,7 +22107,60 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "STYoYWRtAxn6LrPUbVtyx4ghRJf1FghZ",
+                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22193,6 +22169,49 @@
                         "secret_encoded": false
                     },
                     "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
                     "token_endpoint_auth_method": "client_secret_post",
                     "app_type": "non_interactive",
                     "grant_types": [
@@ -22242,7 +22261,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "7ySRBgcwnhcDBGxm04WdewfYmztF9up7",
+                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22267,7 +22286,7 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
+                    "name": "auth0-deploy-cli-extension",
                     "allowed_clients": [],
                     "callbacks": [],
                     "client_metadata": {},
@@ -22281,17 +22300,16 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": false,
+                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
                         "infinite_token_lifetime": true,
                         "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
                         "rotation_type": "non-rotating"
                     },
-                    "sso": false,
                     "sso_disabled": false,
                     "cross_origin_auth": false,
                     "signing_keys": [
@@ -22301,7 +22319,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "BSzSWBvdaNE2nlM36e2D58u03cr1PPja",
+                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22311,10 +22329,8 @@
                     },
                     "client_aliases": [],
                     "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
                     "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -22366,7 +22382,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22381,7 +22397,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22396,7 +22412,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_C2jPGu4p9C67K6r4/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -22408,7 +22424,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22423,7 +22439,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22438,7 +22454,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_DkFl7EwPp9Xa2Qo6/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -22523,6 +22539,23 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/attack-protection/bot-detection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "challenge_password_policy": "never",
+            "challenge_passwordless_policy": "never",
+            "challenge_password_reset_policy": "never",
+            "allowlist": [],
+            "bot_detection_level": "medium",
+            "monitoring_mode_enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/attack-protection/captcha",
         "body": "",
         "status": 200,
@@ -22558,16 +22591,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/bot-detection",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "challenge_password_policy": "never",
-            "challenge_passwordless_policy": "never",
-            "challenge_password_reset_policy": "never",
-            "allowlist": [],
-            "bot_detection_level": "medium",
-            "monitoring_mode_enabled": false
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22587,24 +22615,12 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029630",
+                "id": "lst_0000000000029822",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -22615,14 +22631,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029631",
+                "id": "lst_0000000000029823",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-fa125667-b90d-4108-af24-d61d027fa2bf/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
                 },
                 "filters": [
                     {
@@ -22724,7 +22740,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-10T07:02:11.682Z"
+                    "updated_at": "2026-07-17T06:07:22.179Z"
                 }
             ]
         },
@@ -22795,22 +22811,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-10T07:02:11.682Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-07-17T06:07:22.179Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22826,6 +22827,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22874,7 +22890,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-10T07:02:03.424Z",
+                    "updated_at": "2026-07-17T06:07:13.803Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -22926,7 +22942,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-10T07:01:49.216Z",
+                    "updated_at": "2026-07-17T06:06:58.205Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -23022,7 +23038,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23030,34 +23046,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -23126,7 +23142,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-10T07:02:08.113Z",
+                    "updated_at": "2026-07-17T06:07:18.621Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -23151,7 +23167,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "c344f61a-a341-41d7-a9e1-19555edb3b52",
+                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23159,34 +23175,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-10T07:01:50.770371338Z",
-                    "updated_at": "2026-07-10T07:01:50.788099597Z",
+                    "created_at": "2026-07-17T06:06:59.806952575Z",
+                    "updated_at": "2026-07-17T06:06:59.821829361Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-10T07:01:51.460717114Z",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z"
+                        "build_time": "2026-07-17T06:07:00.515637114Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "12d6d168-8d56-4406-8b02-9ed36ea5b8a4",
+                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-10T07:01:51.460717114Z",
+                        "built_at": "2026-07-17T06:07:00.515637114Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-10T07:01:51.379899215Z",
-                        "updated_at": "2026-07-10T07:01:51.461434467Z",
+                        "created_at": "2026-07-17T06:07:00.450141003Z",
+                        "updated_at": "2026-07-17T06:07:00.516137765Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {

--- a/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
@@ -1357,7 +1357,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1381,13 +1381,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [],
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/connections?take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1427,7 +1440,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -1438,26 +1451,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [],
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -1491,7 +1491,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1531,7 +1531,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -1663,67 +1663,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
         "body": "",
         "status": 404,
         "response": {
@@ -1772,7 +1712,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
+        "path": "/api/v2/email-templates/async_approval",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
         "response": {
@@ -1802,6 +1757,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
@@ -1817,7 +1787,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -2136,7 +2136,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
         "response": {},
@@ -2146,7 +2146,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/sms/providers/twilio",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
         "body": "",
         "status": 200,
         "response": {},
@@ -2264,7 +2264,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T12:36:42.851Z"
+                    "updated_at": "2026-07-09T13:25:18.228Z"
                 }
             ]
         },
@@ -2286,7 +2286,7 @@
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T12:36:44.415Z",
+                    "updated_at": "2026-07-09T13:25:19.811Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2302,7 +2302,7 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T12:36:44.413Z",
+                    "updated_at": "2026-07-09T13:25:19.812Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2318,7 +2318,7 @@
                     "type": "otp_verify",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T12:36:44.498Z",
+                    "updated_at": "2026-07-09T13:25:19.898Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2334,7 +2334,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T12:36:44.719Z",
+                    "updated_at": "2026-07-09T13:25:20.111Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2438,6 +2438,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
@@ -2458,17 +2468,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2488,7 +2488,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2518,16 +2518,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
@@ -2548,7 +2538,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/custom-form/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2578,7 +2568,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/logout/custom-text/en",
+        "path": "/api/v2/prompts/custom-form/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2598,17 +2588,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/logout/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2628,7 +2608,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2658,7 +2648,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2678,17 +2668,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
+        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2708,7 +2688,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/organizations/custom-text/en",
+        "path": "/api/v2/prompts/status/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2738,7 +2728,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
+        "path": "/api/v2/prompts/organizations/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2758,17 +2748,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "path": "/api/v2/prompts/common/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2788,7 +2768,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/partials",
+        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2808,7 +2798,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/partials",
+        "path": "/api/v2/prompts/login-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2818,7 +2808,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup/partials",
+        "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2838,7 +2828,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-password/partials",
+        "path": "/api/v2/prompts/signup/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2858,7 +2858,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/signup-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2929,18 +2929,6 @@
                 },
                 {
                     "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node18",
-                        "node22"
-                    ],
-                    "default_runtime": "node16",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -2957,14 +2945,14 @@
                     ]
                 },
                 {
-                    "id": "credentials-exchange",
+                    "id": "post-login",
                     "version": "v2",
-                    "status": "CURRENT",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
+                        "node18",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node16",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -2976,6 +2964,18 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "credentials-exchange",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node18-actions",
+                        "node22"
+                    ],
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -3004,6 +3004,17 @@
                 },
                 {
                     "id": "post-user-registration",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-user-registration",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -3011,17 +3022,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -3431,7 +3431,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3567,6 +3567,23 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/attack-protection/bot-detection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "challenge_password_policy": "never",
+            "challenge_passwordless_policy": "never",
+            "challenge_password_reset_policy": "never",
+            "allowlist": [],
+            "bot_detection_level": "medium",
+            "monitoring_mode_enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/attack-protection/captcha",
         "body": "",
         "status": 200,
@@ -3602,16 +3619,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/bot-detection",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "challenge_password_policy": "never",
-            "challenge_passwordless_policy": "never",
-            "challenge_password_reset_policy": "never",
-            "allowlist": [],
-            "bot_detection_level": "medium",
-            "monitoring_mode_enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3624,18 +3636,6 @@
         "status": 200,
         "response": {
             "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
-        "body": "",
-        "status": 200,
-        "response": {
-            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3706,7 +3706,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-09T13:23:16.057Z"
+                    "updated_at": "2026-07-17T06:10:37.024Z"
                 }
             ]
         },
@@ -3777,7 +3777,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-09T13:23:16.057Z"
+            "updated_at": "2026-07-17T06:10:37.024Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3856,7 +3856,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-09T13:23:04.966Z",
+                    "updated_at": "2026-07-17T06:10:27.587Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -3908,7 +3908,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-09T13:22:54.852Z",
+                    "updated_at": "2026-07-17T06:10:14.781Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -4059,7 +4059,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-09T13:23:12.427Z",
+                    "updated_at": "2026-07-17T06:10:33.528Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -5529,7 +5529,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5553,7 +5553,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -5611,7 +5611,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -5647,35 +5647,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -5703,7 +5675,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -5731,7 +5717,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -5799,51 +5799,39 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
+        "path": "/api/v2/attack-protection/captcha",
         "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
+            "active_provider_id": "auth_challenge",
+            "auth_challenge": {
+                "fail_open": false
+            }
         },
         "status": 200,
         "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/bot-detection",
-        "body": {
-            "challenge_password_policy": "never",
-            "challenge_passwordless_policy": "never",
-            "challenge_password_reset_policy": "never",
-            "allowlist": [],
-            "bot_detection_level": "medium",
-            "monitoring_mode_enabled": false
-        },
-        "status": 200,
-        "response": {
-            "challenge_password_policy": "never",
-            "challenge_passwordless_policy": "never",
-            "challenge_password_reset_policy": "never",
-            "allowlist": [],
-            "bot_detection_level": "medium",
-            "monitoring_mode_enabled": false
+            "active_provider_id": "auth_challenge",
+            "simple_captcha": {},
+            "auth_challenge": {
+                "fail_open": false
+            },
+            "recaptcha_v2": {
+                "site_key": ""
+            },
+            "recaptcha_enterprise": {
+                "site_key": "",
+                "project_id": ""
+            },
+            "hcaptcha": {
+                "site_key": ""
+            },
+            "friendly_captcha": {
+                "site_key": ""
+            },
+            "arkose": {
+                "site_key": "",
+                "client_subdomain": "client-api",
+                "verify_subdomain": "verify-api",
+                "fail_open": false
+            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5903,39 +5891,23 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/captcha",
+        "path": "/api/v2/attack-protection/bot-detection",
         "body": {
-            "active_provider_id": "auth_challenge",
-            "auth_challenge": {
-                "fail_open": false
-            }
+            "challenge_password_policy": "never",
+            "challenge_passwordless_policy": "never",
+            "challenge_password_reset_policy": "never",
+            "allowlist": [],
+            "bot_detection_level": "medium",
+            "monitoring_mode_enabled": false
         },
         "status": 200,
         "response": {
-            "active_provider_id": "auth_challenge",
-            "simple_captcha": {},
-            "auth_challenge": {
-                "fail_open": false
-            },
-            "recaptcha_v2": {
-                "site_key": ""
-            },
-            "recaptcha_enterprise": {
-                "site_key": "",
-                "project_id": ""
-            },
-            "hcaptcha": {
-                "site_key": ""
-            },
-            "friendly_captcha": {
-                "site_key": ""
-            },
-            "arkose": {
-                "site_key": "",
-                "client_subdomain": "client-api",
-                "verify_subdomain": "verify-api",
-                "fail_open": false
-            }
+            "challenge_password_policy": "never",
+            "challenge_passwordless_policy": "never",
+            "challenge_password_reset_policy": "never",
+            "allowlist": [],
+            "bot_detection_level": "medium",
+            "monitoring_mode_enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5979,13 +5951,27 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/attack-protection/brute-force-protection",
         "body": {
-            "enabled": false
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "status": 200,
         "response": {
-            "enabled": false
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6000,6 +5986,20 @@
         "status": 200,
         "response": {
             "remember_for": 30
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/risk-assessments/settings",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6041,7 +6041,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-09T13:22:54.852Z",
+                    "updated_at": "2026-07-17T06:10:14.781Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -6086,7 +6086,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-09T13:25:11.409Z",
+            "updated_at": "2026-07-17T06:13:14.009Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -6314,6 +6314,63 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    ]
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -6404,7 +6461,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6467,63 +6524,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_uhgt3cTfe93QJrXZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/actions/actions?page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -6543,7 +6543,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6583,7 +6583,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -6594,13 +6594,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -6613,11 +6613,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_uhgt3cTfe93QJrXZ",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -6654,7 +6654,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -6666,7 +6666,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_uhgt3cTfe93QJrXZ",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": {
             "authentication": {
                 "active": true
@@ -6706,7 +6706,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_uhgt3cTfe93QJrXZ",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -6743,7 +6743,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -6845,7 +6845,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6914,7 +6914,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -6954,7 +6954,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -6986,7 +6986,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7026,7 +7026,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -7164,7 +7164,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7515,7 +7515,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T12:36:42.851Z"
+                    "updated_at": "2026-07-09T13:25:18.228Z"
                 }
             ]
         },
@@ -7555,7 +7555,7 @@
                 ]
             },
             "created_at": "2025-12-09T12:24:00.604Z",
-            "updated_at": "2026-07-09T13:25:18.228Z"
+            "updated_at": "2026-07-17T06:13:20.998Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7589,7 +7589,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-09T13:23:04.966Z",
+                    "updated_at": "2026-07-17T06:10:27.587Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7665,7 +7665,7 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-09T13:25:19.143Z",
+            "updated_at": "2026-07-17T06:13:21.914Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
@@ -7690,7 +7690,7 @@
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T12:36:44.415Z",
+                    "updated_at": "2026-07-09T13:25:19.811Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7706,7 +7706,7 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T12:36:44.413Z",
+                    "updated_at": "2026-07-09T13:25:19.812Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7722,7 +7722,7 @@
                     "type": "otp_verify",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T12:36:44.498Z",
+                    "updated_at": "2026-07-09T13:25:19.898Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7738,7 +7738,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T12:36:44.719Z",
+                    "updated_at": "2026-07-09T13:25:20.111Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7749,39 +7749,6 @@
                     }
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/branding/phone/templates/tem_qarYST5TTE5pbMNB5NHZAj",
-        "body": {
-            "content": {
-                "body": {
-                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
-                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
-                }
-            },
-            "disabled": false
-        },
-        "status": 200,
-        "response": {
-            "id": "tem_qarYST5TTE5pbMNB5NHZAj",
-            "tenant": "auth0-deploy-cli-e2e",
-            "channel": "phone",
-            "type": "otp_enroll",
-            "disabled": false,
-            "created_at": "2025-12-09T12:26:25.327Z",
-            "updated_at": "2026-07-09T13:25:19.811Z",
-            "content": {
-                "syntax": "liquid",
-                "body": {
-                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
-                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
-                }
-            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7807,12 +7774,45 @@
             "type": "change_password",
             "disabled": false,
             "created_at": "2025-12-09T12:26:20.243Z",
-            "updated_at": "2026-07-09T13:25:19.812Z",
+            "updated_at": "2026-07-17T06:13:22.506Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
                     "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                     "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/branding/phone/templates/tem_qarYST5TTE5pbMNB5NHZAj",
+        "body": {
+            "content": {
+                "body": {
+                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
+                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                }
+            },
+            "disabled": false
+        },
+        "status": 200,
+        "response": {
+            "id": "tem_qarYST5TTE5pbMNB5NHZAj",
+            "tenant": "auth0-deploy-cli-e2e",
+            "channel": "phone",
+            "type": "otp_enroll",
+            "disabled": false,
+            "created_at": "2025-12-09T12:26:25.327Z",
+            "updated_at": "2026-07-17T06:13:22.508Z",
+            "content": {
+                "syntax": "liquid",
+                "body": {
+                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
+                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                 }
             }
         },
@@ -7840,7 +7840,7 @@
             "type": "otp_verify",
             "disabled": false,
             "created_at": "2025-12-09T12:26:30.547Z",
-            "updated_at": "2026-07-09T13:25:19.898Z",
+            "updated_at": "2026-07-17T06:13:22.584Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
@@ -7874,7 +7874,7 @@
             "type": "blocked_account",
             "disabled": false,
             "created_at": "2025-12-09T12:22:47.683Z",
-            "updated_at": "2026-07-09T13:25:20.111Z",
+            "updated_at": "2026-07-17T06:13:22.815Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
@@ -8122,7 +8122,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8191,7 +8191,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_uhgt3cTfe93QJrXZ",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8231,7 +8231,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -8585,7 +8585,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8673,140 +8673,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true&is_global=false",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 2,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/LBC6ctkweOO8CIiFRSDg8Mp3lusKgpFc/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/actions/actions?page=0&per_page=100",
         "body": "",
         "status": 200,
@@ -8838,7 +8704,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-09T13:23:12.427Z",
+                    "updated_at": "2026-07-17T06:10:33.528Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -8894,7 +8760,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-09T13:25:25.613Z",
+            "updated_at": "2026-07-17T06:13:27.176Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -9000,7 +8866,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-09T13:23:16.057Z"
+                    "updated_at": "2026-07-17T06:10:37.024Z"
                 }
             ]
         },
@@ -9071,7 +8937,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-09T13:23:16.057Z"
+            "updated_at": "2026-07-17T06:10:37.024Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9211,7 +9077,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-09T13:25:29.770Z"
+            "updated_at": "2026-07-17T06:13:31.396Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9236,6 +9102,7 @@
                 "enable_client_connections": false,
                 "enable_dynamic_client_registration": false,
                 "enable_public_signup_user_exists_error": true,
+                "use_scope_descriptions_for_consent": false,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false

--- a/test/e2e/recordings/should-preserve-keywords-for-directory-format.json
+++ b/test/e2e/recordings/should-preserve-keywords-for-directory-format.json
@@ -92,7 +92,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -145,7 +145,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -169,7 +169,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+        "path": "/api/v2/clients/luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
         "body": {
             "name": "Auth0 CLI - dev",
             "allowed_clients": [],
@@ -246,7 +246,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+            "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -285,6 +285,7 @@
                 "enable_client_connections": false,
                 "enable_dynamic_client_registration": false,
                 "enable_public_signup_user_exists_error": true,
+                "use_scope_descriptions_for_consent": false,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
@@ -466,7 +467,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -519,7 +520,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -635,74 +636,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
+        "path": "/api/v2/email-templates/welcome_email",
         "body": "",
-        "status": 404,
+        "status": 200,
         "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome to This tenant name should be preserved!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://travel0.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -725,7 +670,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -755,6 +700,66 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
@@ -770,18 +775,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
+        "path": "/api/v2/email-templates/async_approval",
         "body": "",
-        "status": 200,
+        "status": 404,
         "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome to This tenant name should be preserved!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://travel0.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -804,7 +805,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
+        "path": "/api/v2/email-templates/reset_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -909,7 +910,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -962,7 +963,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1060,82 +1061,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -1183,7 +1109,67 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -1213,7 +1199,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/async_approval",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -1240,21 +1256,6 @@
             "syntax": "liquid",
             "urlLifetimeInSeconds": 3600,
             "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
         },
         "rawHeaders": [],
         "responseIsBinary": false

--- a/test/e2e/recordings/should-preserve-keywords-for-yaml-format.json
+++ b/test/e2e/recordings/should-preserve-keywords-for-yaml-format.json
@@ -92,7 +92,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -196,7 +196,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+            "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -263,6 +263,7 @@
                 "enable_client_connections": false,
                 "enable_dynamic_client_registration": false,
                 "enable_public_signup_user_exists_error": true,
+                "use_scope_descriptions_for_consent": false,
                 "revoke_refresh_token_grant": false,
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
@@ -444,7 +445,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -497,7 +498,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -613,59 +614,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/welcome_email",
         "body": "",
-        "status": 404,
+        "status": 200,
         "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome to This tenant name should be preserved!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://travel0.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -703,7 +663,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
         "body": "",
         "status": 404,
         "response": {
@@ -733,7 +723,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -741,25 +731,6 @@
             "error": "Not Found",
             "message": "The template does not exist.",
             "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome to This tenant name should be preserved!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://travel0.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -782,7 +753,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
+        "path": "/api/v2/email-templates/reset_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -887,7 +888,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -940,7 +941,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1038,7 +1039,100 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
         "response": {
@@ -1083,7 +1177,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -1113,100 +1207,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
         "response": {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `use_scope_descriptions_for_consent` to `allowedTenantFlags` in the tenant handler. This flag was being silently stripped from the import payload despite being publicly documented in the Auth0 API and returned by `GET /api/v2/tenants/settings` on export — causing a broken export→import roundtrip.

### 📚 References

* Fixes #1426

### 🔬 Testing

**Unit tests**

Existing unit tests cover this. `mockAllowedFlags` is built dynamically from `allowedTenantFlags`, so the new flag is automatically exercised by the `#removeUnallowedTenantFlags` test suite.

**Manual testing**

Tested against a real tenant:
1. Added `use_scope_descriptions_for_consent: true` to `tenant.yaml`
2. Ran `a0deploy import` - flag is now included in the `PATCH /api/v2/tenants/settings` payload with no "deemed incompatible" warning
3. Ran `a0deploy export` - exported `tenant.yaml` confirms `use_scope_descriptions_for_consent: true` is set on the tenant

**E2E Tests**

E2E tests rerun and recordings updated.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
