### PR TITLE
fix: warn and skip deprecated guardian phone provider on 403 during import

### DIFF
--- a/src/tools/auth0/handlers/guardianFactorTemplates.ts
+++ b/src/tools/auth0/handlers/guardianFactorTemplates.ts
@@ -67,14 +67,22 @@ export default class GuardianFactorTemplatesHandler extends DefaultHandler {
       guardianFactorTemplates.map(async (fatorTemplates) => {
         const { name, ...data } = fatorTemplates;
         const params = { name: fatorTemplates.name };
-        if (name === 'sms') {
-          await this.client.guardian.factors.sms.setTemplates(
-            data as Management.SetGuardianFactorSmsTemplatesRequestContent
-          );
-        } else if (name === 'phone') {
-          await this.client.guardian.factors.phone.setTemplates(
-            data as Management.SetGuardianFactorPhoneTemplatesRequestContent
-          );
+        try {
+          if (name === 'sms') {
+            await this.client.guardian.factors.sms.setTemplates(
+              data as Management.SetGuardianFactorSmsTemplatesRequestContent
+            );
+          } else if (name === 'phone') {
+            await this.client.guardian.factors.phone.setTemplates(
+              data as Management.SetGuardianFactorPhoneTemplatesRequestContent
+            );
+          }
+        } catch (err) {
+          if (isForbiddenFeatureError(err, this.type)) {
+            // Feature is deprecated/disabled on this tenant; warn and skip instead of failing the import.
+            return;
+          }
+          throw err;
         }
         this.didUpdate(params);
         this.updated += 1;

--- a/src/tools/auth0/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/tools/auth0/handlers/guardianPhoneFactorMessageTypes.ts
@@ -23,16 +23,7 @@ const isFeatureUnavailableError = (err): boolean => {
     // Older Management API version where the endpoint is not available.
     return true;
   }
-  if (
-    err.statusCode === 403 &&
-    err.originalError &&
-    err.originalError.response &&
-    err.originalError.response.body &&
-    err.originalError.response.body.errorCode === 'voice_mfa_not_allowed'
-  ) {
-    // Recent Management API version, but with feature explicitly disabled.
-    return true;
-  }
+  // 403s (feature explicitly disabled) are handled by isForbiddenFeatureError.
   return false;
 };
 

--- a/src/tools/auth0/handlers/guardianPhoneFactorMessageTypes.ts
+++ b/src/tools/auth0/handlers/guardianPhoneFactorMessageTypes.ts
@@ -84,9 +84,17 @@ export default class GuardianPhoneMessageTypesHandler extends DefaultHandler {
     }
 
     const data = guardianPhoneFactorMessageTypes;
-    await this.client.guardian.factors.phone.setMessageTypes(
-      data as unknown as Management.SetGuardianFactorPhoneMessageTypesRequestContent
-    );
+    try {
+      await this.client.guardian.factors.phone.setMessageTypes(
+        data as unknown as Management.SetGuardianFactorPhoneMessageTypesRequestContent
+      );
+    } catch (err) {
+      if (isFeatureUnavailableError(err) || isForbiddenFeatureError(err, this.type)) {
+        // Feature is deprecated/disabled on this tenant; warn and skip instead of failing the import.
+        return;
+      }
+      throw err;
+    }
     this.updated += 1;
     this.didUpdate(guardianPhoneFactorMessageTypes);
   }

--- a/src/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -20,16 +20,7 @@ const isFeatureUnavailableError = (err) => {
     // Older Management API version where the endpoint is not available.
     return true;
   }
-  if (
-    err.statusCode === 403 &&
-    err.originalError &&
-    err.originalError.response &&
-    err.originalError.response.body &&
-    err.originalError.response.body.errorCode === 'hooks_not_allowed'
-  ) {
-    // Recent Management API version, but with feature explicitly disabled.
-    return true;
-  }
+  // 403s (feature explicitly disabled) are handled by isForbiddenFeatureError.
   return false;
 };
 

--- a/src/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.ts
+++ b/src/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.ts
@@ -81,9 +81,17 @@ export default class GuardianPhoneSelectedProviderHandler extends DefaultHandler
     }
 
     const data = guardianPhoneFactorSelectedProvider;
-    await this.client.guardian.factors.phone.setProvider(
-      data as Management.SetGuardianFactorsProviderPhoneRequestContent
-    );
+    try {
+      await this.client.guardian.factors.phone.setProvider(
+        data as Management.SetGuardianFactorsProviderPhoneRequestContent
+      );
+    } catch (err) {
+      if (isFeatureUnavailableError(err) || isForbiddenFeatureError(err, this.type)) {
+        // Feature is deprecated/disabled on this tenant; warn and skip instead of failing the import.
+        return;
+      }
+      throw err;
+    }
     this.updated += 1;
     this.didUpdate(guardianPhoneFactorSelectedProvider);
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -357,7 +357,12 @@ export const isDeprecatedError = (err: { message: string; statusCode: number }):
 
 export const isForbiddenFeatureError = (err, type): boolean => {
   if (err.statusCode === 403) {
-    log.warn(`${err.message};${err.errorCode ?? ''} - Skipping ${type}`);
+    // The SDK error's top-level `message` is the full serialized response body; the clean,
+    // human-readable message and errorCode live on the response body itself.
+    const body = err.originalError?.response?.body ?? {};
+    const message = body.message ?? err.message;
+    const errorCode = body.errorCode ?? err.errorCode ?? '';
+    log.warn(`${message}${errorCode ? ` (${errorCode})` : ''} - Skipping ${type}`);
     return true;
   }
   return false;

--- a/test/tools/auth0/handlers/guardianFactorTemplates.tests.js
+++ b/test/tools/auth0/handlers/guardianFactorTemplates.tests.js
@@ -122,5 +122,38 @@ describe('#guardianFactorTemplates handler', () => {
 
       await stageFn.apply(handler, [{ guardianFactorTemplates: data }]);
     });
+
+    it('should warn and skip when the legacy feature is not allowed on the tenant', async () => {
+      const auth0 = {
+        guardian: {
+          factors: {
+            sms: {
+              setTemplates: () => {
+                const err = new Error(
+                  'Insufficient privileges to use this deprecated feature. To handle Phone Provider/Templates refer to Tenant Phone Settings'
+                );
+                err.statusCode = 403;
+                err.errorCode = 'legacy_mfa_phone_provider_not_allowed';
+                return Promise.reject(err);
+              },
+            },
+          },
+        },
+        pool,
+      };
+
+      const handler = new guardianFactorTemplatesTests.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'sms',
+          enrollment_message: 'test',
+        },
+      ];
+
+      // Should resolve (not throw) even though the API rejects with a 403.
+      await stageFn.apply(handler, [{ guardianFactorTemplates: data }]);
+      expect(handler.updated).to.equal(0);
+    });
   });
 });

--- a/test/tools/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
+++ b/test/tools/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
@@ -174,5 +174,31 @@ describe('#guardianPhoneFactorMessageTypes handler', () => {
 
       await stageFn.apply(handler, [{ guardianPhoneFactorMessageTypes: null }]);
     });
+
+    it('should warn and skip when the legacy feature is not allowed on the tenant', async () => {
+      const auth0 = {
+        guardian: {
+          factors: {
+            phone: {
+              setMessageTypes: () => {
+                const err = new Error('This endpoint is disabled for your tenant.');
+                err.statusCode = 403;
+                err.errorCode = 'voice_mfa_not_allowed';
+                return Promise.reject(err);
+              },
+            },
+          },
+        },
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      // Should resolve (not throw) even though the API rejects with a 403.
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorMessageTypes: { message_types: ['sms', 'voice'] } },
+      ]);
+      expect(handler.updated).to.equal(0);
+    });
   });
 });

--- a/test/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
+++ b/test/tools/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
@@ -174,5 +174,31 @@ describe('#guardianPhoneFactorSelectedProvider handler', () => {
 
       await stageFn.apply(handler, [{ guardianPhoneFactorSelectedProvider: null }]);
     });
+
+    it('should warn and skip when the legacy feature is not allowed on the tenant', async () => {
+      const auth0 = {
+        guardian: {
+          factors: {
+            phone: {
+              setProvider: () => {
+                const err = new Error('This endpoint is disabled for your tenant.');
+                err.statusCode = 403;
+                err.errorCode = 'legacy_mfa_phone_provider_not_allowed';
+                return Promise.reject(err);
+              },
+            },
+          },
+        },
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      // Should resolve (not throw) even though the API rejects with a 403.
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorSelectedProvider: { provider: 'twilio' } },
+      ]);
+      expect(handler.updated).to.equal(0);
+    });
   });
 });

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -805,7 +805,7 @@ describe('#isForbiddenFeatureError', () => {
 
     // eslint-disable-next-line no-unused-expressions
     expect(utils.isForbiddenFeatureError(error, resourceType)).to.be.true;
-    expect(warnMessage).to.equal('Forbidden resource access; - Skipping connections');
+    expect(warnMessage).to.equal('Forbidden resource access - Skipping connections');
 
     // Restore original warn function
     log.warn = originalWarn;
@@ -829,7 +829,44 @@ describe('#isForbiddenFeatureError', () => {
     // eslint-disable-next-line no-unused-expressions
     expect(utils.isForbiddenFeatureError(error, resourceType)).to.be.true;
     expect(warnMessage).to.equal(
-      'Forbidden resource access;forbidden_resource_error - Skipping actions'
+      'Forbidden resource access (forbidden_resource_error) - Skipping actions'
+    );
+
+    // Restore original warn function
+    log.warn = originalWarn;
+  });
+
+  it('should use the clean message and errorCode from the response body when available', () => {
+    let warnMessage;
+    const originalWarn = log.warn;
+    // Mock the log.warn function
+    log.warn = (msg) => {
+      warnMessage = msg;
+    };
+
+    // Mirrors the real SDK ForbiddenError: top-level `message` is the full serialized body,
+    // while the human-readable message and errorCode live on originalError.response.body.
+    const error = {
+      message:
+        'ForbiddenError\nStatus code: 403\nBody: {\n  "statusCode": 403,\n  "errorCode": "legacy_mfa_phone_provider_not_allowed"\n}',
+      statusCode: 403,
+      originalError: {
+        response: {
+          body: {
+            statusCode: 403,
+            error: 'Forbidden',
+            message: 'Insufficient privileges to use this deprecated feature.',
+            errorCode: 'legacy_mfa_phone_provider_not_allowed',
+          },
+        },
+      },
+    };
+    const resourceType = 'guardianPhoneFactorSelectedProvider';
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(utils.isForbiddenFeatureError(error, resourceType)).to.be.true;
+    expect(warnMessage).to.equal(
+      'Insufficient privileges to use this deprecated feature. (legacy_mfa_phone_provider_not_allowed) - Skipping guardianPhoneFactorSelectedProvider'
     );
 
     // Restore original warn function


### PR DESCRIPTION
### 🔧 Changes

Importing a YAML configuration exported from an older tenant into a newer tenant could abort the entire import when the legacy per-factor phone provider API is disabled on the target tenant. The Management API returns `403 legacy_mfa_phone_provider_not_allowed` ("Insufficient privileges to use this deprecated feature"), and the import failed hard during the `processChanges` stage.

The export/`getType` path already handled such 403s gracefully via `isForbiddenFeatureError` (warn + skip). This change wires the same behavior into the import/`processChanges` path for the guardian phone resources, so a deprecated/forbidden feature now logs a warning and is skipped instead of failing the deployment.

- `guardianFactorTemplates`, `guardianPhoneFactorSelectedProvider`, `guardianPhoneFactorMessageTypes`: wrapped the write API calls in `processChanges` to catch a deprecated/forbidden 403 and skip instead of throwing.
- `isForbiddenFeatureError` (utils): cleaned up the warning to read the human-readable `message` and `errorCode` from the response body (`originalError.response.body`) instead of logging the full serialized error blob. This improves logging for every 403-skippable resource that uses the helper.
- `guardianPhoneFactorSelectedProvider`, `guardianPhoneFactorMessageTypes`: simplified `isFeatureUnavailableError` to only handle the 404 (endpoint-not-available) case. The `hooks_not_allowed` / `voice_mfa_not_allowed` 403 branches were redundant since `isForbiddenFeatureError` already catches any 403 - these 403s now emit a warn log instead of being skipped silently, consistent with other forbidden-feature handling.

### 📚 References

- Error `legacy_mfa_phone_provider_not_allowed` is returned at runtime by the Management API but is **not documented** in the OpenAPI spec or typed in auth0-node (v6.x) - verified against `management-api-oas.json`. The fix therefore treats any 403 on these guardian phone endpoints as a skippable deprecated/forbidden feature rather than matching a specific errorCode string.
- `GET` / `PUT` [`/guardian/factors/sms/templates`](https://auth0.com/docs/api/management/v2/guardian/put-factor-sms-templates) are documented as deprecated in favor of the phone-templates endpoints: https://auth0.com/docs/api/management/v2/guardian/put-factor-phone-templates

### 🔬 Testing

Verified end-to-end against a live tenant with **"Use Tenant-Level Messaging Provider"** enabled (which disables the legacy per-factor phone API):

- **Before the fix:** `a0deploy import` with `guardianPhoneFactorSelectedProvider` in the YAML failed with `Problem running command import during stage processChanges when processing type guardianPhoneFactorSelectedProvider` and exited with code `1`.
- **After the fix:** the same import logged `warn: Insufficient privileges to use this deprecated feature. (legacy_mfa_phone_provider_not_allowed) - Skipping guardianPhoneFactorSelectedProvider`, reported `Import Successful`, and exited with code `0`.

Unit tests added/updated:
- `guardianFactorTemplates`: verifies `processChanges` warns and skips on a legacy-feature 403 instead of throwing.
- `isForbiddenFeatureError`: verifies the cleaned-up warning message and errorCode are extracted from the response body.
- `guardianPhoneFactorSelectedProvider` / `guardianPhoneFactorMessageTypes`: existing "endpoint is disabled for tenant" tests still pass, now routing the 403 through `isForbiddenFeatureError` (returns null/skips, with a warn log).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
