### PR TITLE
feat: add Cross App Access (XAA) resource app support for connections and clients

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -364,6 +364,67 @@ connections:
 }
 ```
 
+## Connections (Cross App Access — Resource Application)
+
+> **Early Access:** Part of the XAA (Cross App Access) — Auth0 as Resource Application Authorization Server feature.
+
+The Deploy CLI supports configuring a connection as a Resource Application for Cross App Access via the top-level `cross_app_access_resource_app` field. This is supported for enterprise connections including SAML (`strategy: samlp`) and OIDC (`strategy: oidc`).
+
+- `cross_app_access_resource_app.status` (`"enabled"` | `"disabled"`): Enables or disables the connection as a Resource Application for Cross App Access.
+
+For SAML connections, the `discovery_url` and `oidc_metadata` connection options — previously only supported for OIDC connections — are now also accepted under `options`.
+
+**YAML Example**
+
+```yaml
+connections:
+  - name: enterprise-saml
+    strategy: samlp
+    cross_app_access_resource_app:
+      status: enabled
+    options:
+      discovery_url: https://example-idp.com/.well-known/openid-configuration
+      oidc_metadata:
+        issuer: https://example-idp.com
+```
+
+**Directory Example**
+
+```
+./connections/enterprise-saml.json
+```
+
+```json
+{
+  "name": "enterprise-saml",
+  "strategy": "samlp",
+  "cross_app_access_resource_app": {
+    "status": "enabled"
+  },
+  "options": {
+    "discovery_url": "https://example-idp.com/.well-known/openid-configuration",
+    "oidc_metadata": {
+      "issuer": "https://example-idp.com"
+    }
+  }
+}
+```
+
+## Clients (Cross App Access — Identity Assertion Authorization Grant)
+
+> **Early Access:** Part of the XAA (Cross App Access) — Auth0 as Resource Application Authorization Server feature.
+
+The Deploy CLI supports the `identity_assertion_authorization_grant` property on clients, which enables the client to participate in Cross App Access (ID-JAG) token exchange.
+
+- `identity_assertion_authorization_grant.active` (boolean): Set to `true` to enable ID-JAG exchange for the client.
+
+```yaml
+clients:
+  - name: My XAA Client
+    identity_assertion_authorization_grant:
+      active: true
+```
+
 ## Databases
 
 When managing database connections, the values of `options.customScripts` point to specific javascript files relative to

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -232,6 +232,20 @@ export const schema = {
         },
         additionalProperties: true,
       },
+      identity_assertion_authorization_grant: {
+        type: 'object',
+        description:
+          'Settings for Cross App Access (ID-JAG) token exchange. Early Access. Enables the client to request identity assertion authorization grants.',
+        properties: {
+          active: {
+            type: 'boolean',
+            description:
+              'Indicates whether the client can request an identity assertion authorization grant (ID-JAG) via token exchange.',
+          },
+        },
+        required: ['active'],
+        additionalProperties: false,
+      },
       app_type: {
         type: 'string',
         description: 'The type of application this client represents',

--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -104,6 +104,14 @@ export const schema = {
         required: ['active'],
         additionalProperties: false,
       },
+      cross_app_access_resource_app: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['enabled', 'disabled'] },
+        },
+        required: ['status'],
+        additionalProperties: false,
+      },
       directory_provisioning_configuration: {
         type: 'object',
         properties: {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -531,6 +531,42 @@ describe('#clients handler', () => {
       expect(wasCreateCalled).to.be.true;
     });
 
+    it('should allow valid identity_assertion_authorization_grant property in client', async () => {
+      const clientWithIdJag = {
+        name: 'clientWithIdJag',
+        identity_assertion_authorization_grant: {
+          active: true,
+        },
+      };
+      let wasCreateCalled = false;
+      const auth0 = {
+        clients: {
+          create: function (data) {
+            wasCreateCalled = true;
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('clientWithIdJag');
+            expect(data.identity_assertion_authorization_grant).to.deep.equal({
+              active: true,
+            });
+            return Promise.resolve({ data });
+          },
+          update: () => Promise.resolve({ data: [] }),
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [{ clients: [clientWithIdJag] }]);
+      // eslint-disable-next-line no-unused-expressions
+      expect(wasCreateCalled).to.be.true;
+    });
+
     it('should create resource server client', async () => {
       let wasCreateCalled = false;
       const resourceServerClient = {

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -70,6 +70,14 @@ describe('#connections handler', () => {
             dpop_signing_alg: 'Ed25519',
           },
         },
+        {
+          name: 'samlp-connection',
+          strategy: 'samlp',
+          options: {
+            discovery_url: 'https://example-idp.com/.well-known/openid-configuration',
+            oidc_metadata: { issuer: 'https://example-idp.com' },
+          },
+        },
       ];
 
       const valid = ajv.validate(connections.schema, assets);
@@ -122,6 +130,43 @@ describe('#connections handler', () => {
           name: 'oidc-connection',
           strategy: 'oidc',
           cross_app_access_requesting_app: { active: true, unknown_field: 'value' },
+        },
+      ];
+
+      const valid = ajv.validate(connections.schema, assets);
+
+      expect(valid).to.equal(false);
+      expect(ajv.errors).to.not.be.null;
+    });
+
+    it('should allow cross_app_access_resource_app with status enum', () => {
+      const ajv = new Ajv({ useDefaults: true, nullable: true });
+      const assets = [
+        {
+          name: 'samlp-connection',
+          strategy: 'samlp',
+          cross_app_access_resource_app: { status: 'enabled' },
+        },
+        {
+          name: 'oidc-connection',
+          strategy: 'oidc',
+          cross_app_access_resource_app: { status: 'disabled' },
+        },
+      ];
+
+      const valid = ajv.validate(connections.schema, assets);
+
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should reject cross_app_access_resource_app with invalid status', () => {
+      const ajv = new Ajv({ useDefaults: true, nullable: true });
+      const assets = [
+        {
+          name: 'samlp-connection',
+          strategy: 'samlp',
+          cross_app_access_resource_app: { status: 'on' },
         },
       ];
 
@@ -590,6 +635,46 @@ describe('#connections handler', () => {
           name: 'someConnection',
           strategy: 'custom',
           cross_app_access_requesting_app: { active: true },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ connections: data }]);
+    });
+
+    it('should pass cross_app_access_resource_app through in the update payload', async () => {
+      const auth0 = {
+        connections: {
+          create: () => Promise.resolve({ data: {} }),
+          update: function (id, data) {
+            expect(id).to.equal('con1');
+            expect(data).to.have.deep.property('cross_app_access_resource_app', {
+              status: 'enabled',
+            });
+            return Promise.resolve({ ...data, id });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) =>
+            mockPagedData(params, 'connections', [
+              { name: 'someConnection', id: 'con1', strategy: 'custom' },
+            ]),
+          _getRestClient: () => ({}),
+          clients: {
+            update: () => Promise.resolve({}),
+          },
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', []),
+        },
+        pool,
+      };
+
+      const handler = new connections.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'someConnection',
+          strategy: 'custom',
+          cross_app_access_resource_app: { status: 'enabled' },
         },
       ];
 


### PR DESCRIPTION
### 🔧 Changes

Adds Deploy CLI support for the XAA (Cross App Access) - "Auth0 as Resource Application Authorization Server" EA feature, covering the new Management API properties on connections and clients:

- **Connections** - new top-level `cross_app_access_resource_app` object (`src/tools/auth0/handlers/connections.ts`):
  - `cross_app_access_resource_app.status`: `"enabled"` | `"disabled"` - enables the connection as a Cross App Access Resource Application.
- **Clients** - new top-level `identity_assertion_authorization_grant` object (`src/tools/auth0/handlers/clients.ts`):
  - `identity_assertion_authorization_grant.active`: `boolean` - enables ID-JAG token exchange for the client.
- **SAML connections** - `options.discovery_url` (string) and `options.oidc_metadata` (object), previously only meaningful for OIDC, are now accepted for `strategy: samlp` connections. No schema change was required: `connectionOptionsSchema` already allows additional properties and these fields are not strategy-restricted; a test was added to lock in the behavior.

Both new properties are additive and pass through to the Management API on create/update and round-trip back on export.

#### Shape

New optional fields; both YAML and directory (JSON) formats supported.

Connection: cross_app_access_resource_app (optional)

YAML (`connections` in `tenant.yaml`):
```yaml
connections:
  - name: enterprise-saml
    strategy: samlp
    cross_app_access_resource_app:
      status: enabled   # "enabled" | "disabled"
```

JSON (`connections/enterprise-saml.json`):
```json
{
  "name": "enterprise-saml",
  "strategy": "samlp",
  "cross_app_access_resource_app": {
    "status": "enabled"
  }
}
```

Client: `identity_assertion_authorization_grant` (optional)

YAML (clients in tenant.yaml):
```yaml
clients:
  - name: My XAA Client
    identity_assertion_authorization_grant:
      active: true
```
JSON (`clients/My XAA Client.json`):
```json
{
  "name": "My XAA Client",
  "identity_assertion_authorization_grant": {
    "active": true
  }
}
```
SAML connection options: `strategy: samlp` now also accepts (previously OIDC-only)

YAML:
```yaml
options:
  discovery_url: https://idp.example.com/.well-known/openid-configuration
  oidc_metadata:
    issuer: https://idp.example.com
```
JSON:
```json
"options": {
  "discovery_url": "https://idp.example.com/.well-known/openid-configuration",
  "oidc_metadata": {
    "issuer": "https://idp.example.com"
  }
}
```

### 🔬 Testing

**Unit tests** 
* `test/tools/auth0/handlers/connections.tests.js`: added tests for `cross_app_access_resource_app` (accept valid status, reject invalid status, pass-through on update); updated existing options test to cover SAML discovery_url/oidc_metadata.
* `test/tools/auth0/handlers/clients.tests.js`: added test for `identity_assertion_authorization_grant` (accepted + passed through on create).

**Manual end-to-end** (verified against a real EA tenant):
1. `export` a tenant, add `identity_assertion_authorization_grant: { active: true }` to a client, `import`, then re-`export` → field persisted.
2. `import` a `samlp` connection with `cross_app_access_resource_app: { status: enabled }` (plus a valid issuer/cert, required by the API), then re-`export` → `cross_app_access_resource_app`, `discovery_url`, and `oidc_metadata` all round-tripped from the tenant.

> Note: the EA feature flags must be enabled on the tenant for the API to store these fields.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
