### PR TITLE
fix: handle 403 entitlement errors for bot detection and captcha on export                                                                                                

### DIFF
--- a/src/tools/auth0/handlers/attackProtection.ts
+++ b/src/tools/auth0/handlers/attackProtection.ts
@@ -258,15 +258,26 @@ export default class AttackProtectionHandler extends DefaultAPIHandler {
     let captcha: Asset | null = null;
 
     try {
-      [botDetection, captcha] = await Promise.all([
-        this.client.attackProtection.botDetection.get(),
-        this.client.attackProtection.captcha.get(),
-      ]);
+      botDetection = await this.client.attackProtection.botDetection.get();
     } catch (err) {
       if (err.statusCode === 403) {
         log.warn(
-          'Bot Detection API are not enabled for this tenant. Please verify `scope` or contact Auth0 support to enable this feature.'
+          'Bot detection is not available on this tenant\'s current plan. Skipping bot detection settings.'
         );
+      } else {
+        throw err;
+      }
+    }
+
+    try {
+      captcha = await this.client.attackProtection.captcha.get();
+    } catch (err) {
+      if (err.statusCode === 403) {
+        log.warn(
+          'Captcha is not available on this tenant\'s current plan. Skipping captcha settings.'
+        );
+      } else {
+        throw err;
       }
     }
 

--- a/src/tools/auth0/handlers/attackProtection.ts
+++ b/src/tools/auth0/handlers/attackProtection.ts
@@ -262,7 +262,7 @@ export default class AttackProtectionHandler extends DefaultAPIHandler {
     } catch (err) {
       if (err.statusCode === 403) {
         log.warn(
-          'Bot detection is not available on this tenant\'s current plan. Skipping bot detection settings.'
+          "Bot detection is not available on this tenant's current plan. Skipping bot detection settings."
         );
       } else {
         throw err;
@@ -274,7 +274,7 @@ export default class AttackProtectionHandler extends DefaultAPIHandler {
     } catch (err) {
       if (err.statusCode === 403) {
         log.warn(
-          'Captcha is not available on this tenant\'s current plan. Skipping captcha settings.'
+          "Captcha is not available on this tenant's current plan. Skipping captcha settings."
         );
       } else {
         throw err;

--- a/test/context/yaml/context.test.js
+++ b/test/context/yaml/context.test.js
@@ -321,8 +321,10 @@ describe('#YAML context validation', () => {
         enabled_locales: ['en'],
       },
       attackProtection: {
+        botDetection: {},
         breachedPasswordDetection: {},
         bruteForceProtection: {},
+        captcha: {},
         suspiciousIpThrottling: {},
       },
       logStreams: [],
@@ -466,8 +468,10 @@ describe('#YAML context validation', () => {
         enabled_locales: ['en'],
       },
       attackProtection: {
+        botDetection: {},
         breachedPasswordDetection: {},
         bruteForceProtection: {},
+        captcha: {},
         suspiciousIpThrottling: {},
       },
       logStreams: [],
@@ -612,8 +616,10 @@ describe('#YAML context validation', () => {
         enabled_locales: ['en'],
       },
       attackProtection: {
+        botDetection: {},
         breachedPasswordDetection: {},
         bruteForceProtection: {},
+        captcha: {},
         suspiciousIpThrottling: {},
       },
       prompts: {

--- a/test/tools/auth0/handlers/attackProtection.tests.js
+++ b/test/tools/auth0/handlers/attackProtection.tests.js
@@ -220,7 +220,7 @@ describe('#attackProtection handler', () => {
       ]);
     });
 
-    it('should handle 403 error when fetching bot detection and captcha configs', async () => {
+    it('should handle 403 error when fetching bot detection and preserve captcha data', async () => {
       const auth0 = {
         attackProtection: {
           botDetection: {
@@ -231,11 +231,10 @@ describe('#attackProtection handler', () => {
             },
           },
           captcha: {
-            get: () => {
-              const err = new Error('Forbidden');
-              err.statusCode = 403;
-              throw err;
-            },
+            get: () => ({
+              selected: 'friendly_captcha',
+              policy: 'always',
+            }),
           },
           breachedPasswordDetection: {
             get: () => ({
@@ -277,39 +276,76 @@ describe('#attackProtection handler', () => {
       const handler = new attackProtection.default({ client: auth0 });
       const data = await handler.getType();
 
-      // Should return data without botDetection and captcha
-      expect(data).to.deep.equal({
-        breachedPasswordDetection: {
-          admin_notification_frequency: [],
-          enabled: true,
-          method: 'standard',
-          shields: [],
-        },
-        bruteForceProtection: {
-          allowlist: [],
-          enabled: true,
-          max_attempts: 10,
-          mode: 'count_per_identifier_and_ip',
-          shields: ['block', 'user_notification'],
-        },
-        suspiciousIpThrottling: {
-          allowlist: ['127.0.0.1'],
-          enabled: true,
-          shields: ['block', 'admin_notification'],
-          stage: {
-            'pre-login': {
-              max_attempts: 100,
-              rate: 864000,
-            },
-            'pre-user-registration': {
-              max_attempts: 50,
-              rate: 1200,
+      // botDetection should be skipped, captcha should still be present
+      expect(data).to.not.have.property('botDetection');
+      expect(data).to.have.property('captcha').that.deep.equals({
+        selected: 'friendly_captcha',
+        policy: 'always',
+      });
+      expect(data).to.have.property('breachedPasswordDetection');
+      expect(data).to.have.property('bruteForceProtection');
+      expect(data).to.have.property('suspiciousIpThrottling');
+    });
+
+    it('should handle 403 error when fetching captcha and preserve bot detection data', async () => {
+      const auth0 = {
+        attackProtection: {
+          botDetection: {
+            get: () => ({
+              bot_detection_level: 'medium',
+              monitoring_mode_enabled: false,
+            }),
+          },
+          captcha: {
+            get: () => {
+              const err = new Error('Forbidden');
+              err.statusCode = 403;
+              throw err;
             },
           },
+          breachedPasswordDetection: {
+            get: () => ({
+              admin_notification_frequency: [],
+              enabled: true,
+              method: 'standard',
+              shields: [],
+            }),
+          },
+          bruteForceProtection: {
+            get: () => ({
+              allowlist: [],
+              enabled: true,
+              max_attempts: 10,
+              mode: 'count_per_identifier_and_ip',
+              shields: ['block', 'user_notification'],
+            }),
+          },
+          suspiciousIpThrottling: {
+            get: () => ({
+              allowlist: ['127.0.0.1'],
+              enabled: true,
+              shields: ['block', 'admin_notification'],
+              stage: {
+                'pre-login': { max_attempts: 100, rate: 864000 },
+                'pre-user-registration': { max_attempts: 50, rate: 1200 },
+              },
+            }),
+          },
         },
-      });
-      expect(data).to.not.have.property('botDetection');
+      };
+
+      const handler = new attackProtection.default({ client: auth0 });
+      const data = await handler.getType();
+
+      // captcha should be skipped, botDetection should still be present
       expect(data).to.not.have.property('captcha');
+      expect(data).to.have.property('botDetection').that.deep.equals({
+        bot_detection_level: 'medium',
+        monitoring_mode_enabled: false,
+      });
+      expect(data).to.have.property('breachedPasswordDetection');
+      expect(data).to.have.property('bruteForceProtection');
+      expect(data).to.have.property('suspiciousIpThrottling');
     });
 
     it('should skip updates when attackProtection is null', async () => {

--- a/test/tools/auth0/handlers/attackProtection.tests.js
+++ b/test/tools/auth0/handlers/attackProtection.tests.js
@@ -1,5 +1,8 @@
-const { expect } = require('chai');
+const { expect, use } = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const attackProtection = require('../../../../src/tools/auth0/handlers/attackProtection');
+
+use(chaiAsPromised);
 
 describe('#attackProtection handler', () => {
   describe('#attackProtection process', () => {
@@ -540,6 +543,66 @@ describe('#attackProtection handler', () => {
       expect(capturedCaptcha).to.not.have.property('simple_captcha');
       expect(capturedCaptcha).to.have.property('friendly_captcha');
       expect(handler.updated).to.equal(1);
+    });
+
+    it('should rethrow non-403 errors from botDetection.get()', async () => {
+      const serverError = new Error('Internal Server Error');
+      serverError.statusCode = 500;
+
+      const auth0 = {
+        attackProtection: {
+          botDetection: {
+            get: () => {
+              throw serverError;
+            },
+          },
+          captcha: {
+            get: () => ({ active_provider_id: 'friendly_captcha' }),
+          },
+          breachedPasswordDetection: {
+            get: () => ({ enabled: true }),
+          },
+          bruteForceProtection: {
+            get: () => ({ enabled: true }),
+          },
+          suspiciousIpThrottling: {
+            get: () => ({ enabled: true }),
+          },
+        },
+      };
+
+      const handler = new attackProtection.default({ client: auth0 });
+      await expect(handler.getType()).to.be.rejectedWith('Internal Server Error');
+    });
+
+    it('should rethrow non-403 errors from captcha.get()', async () => {
+      const serverError = new Error('Internal Server Error');
+      serverError.statusCode = 500;
+
+      const auth0 = {
+        attackProtection: {
+          botDetection: {
+            get: () => ({ bot_detection_level: 'medium' }),
+          },
+          captcha: {
+            get: () => {
+              throw serverError;
+            },
+          },
+          breachedPasswordDetection: {
+            get: () => ({ enabled: true }),
+          },
+          bruteForceProtection: {
+            get: () => ({ enabled: true }),
+          },
+          suspiciousIpThrottling: {
+            get: () => ({ enabled: true }),
+          },
+        },
+      };
+
+      const handler = new attackProtection.default({ client: auth0 });
+      await expect(handler.getType()).to.be.rejectedWith('Internal Server Error');
     });
 
     it('should return cached existing data on subsequent calls', async () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -149,10 +149,16 @@ export function mockMgmtClient() {
       getCustomTextByLanguage: () => Promise.resolve({}),
     },
     attackProtection: {
+      botDetection: {
+        get: () => ({}),
+      },
       breachedPasswordDetection: {
         get: () => ({}),
       },
       bruteForceProtection: {
+        get: () => ({}),
+      },
+      captcha: {
         get: () => ({}),
       },
       suspiciousIpThrottling: {


### PR DESCRIPTION
### 🔧 Changes

Fixes 403 entitlement error handling for bot detection and captcha on export, in preparation for ROAD-8051 (`free_bot_detection_deprecation` FF).                           
                                                                                                                                                                            
  Export (GET):                                                                                                                                                           
  - Decoupled `botDetection.get()` and `captcha.get()` into independent calls with independent error handling. Previously both were in a single `Promise.all`, a 403 on bot detection would silently discard captcha data even though captcha returned 200.                                                                                           
  - A 403 on either endpoint now logs a warning and skips that resource independently, without affecting the other.                                                         
  - Updated warning message to reference the tenant's plan rather than OAuth scopes.

  Deploy (PATCH):
  - Bot detection and captcha 403s surface to the user as errors (per API team confirmation that PATCH 403 should not be handled gracefully).

### 📚 References


### 🔬 Testing

Unit tests cover:
  - GET 403 on bot detection -  captcha data is preserved in the export
  - GET 403 on captcha - bot detection data is preserved in the export
  - Happy path export and import verified on real tenant

E2E verified against a real tenant with `free_bot_detection_deprecation` FF enabled and bot detection entitlement revoked:
  - Both `botDetection` and `captcha` 403s handled gracefully with correct warning messages
  - Export succeeds without those fields in the output
  - `breachedPasswordDetection`, `bruteForceProtection`, `suspiciousIpThrottling` unaffected

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
