### PR TITLE
feat: add auth0_managed field support for network ACLs (Curated Blocklists - EA)

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -975,6 +975,7 @@ Folder structure when in directory mode.
 ./networkACLs/
     ./Allow Specific Countries-p-2.json
     ./Redirect Specific User Agents-p-3.json
+    ./Block iCloud Private Relay Exits-p-4.json
 ```
 
 Contents of `Allow Specific Countries-p-2.json`:
@@ -1010,6 +1011,25 @@ Contents of `Redirect Specific User Agents-p-3.json`:
     "scope": "management",
     "match": {
       "user_agents": ["BadBot/1.0"]
+    }
+  }
+}
+```
+
+Contents of `Block iCloud Private Relay Exits-p-4.json`:
+
+```json
+{
+  "description": "Block iCloud Private Relay Exits",
+  "active": true,
+  "priority": 4,
+  "rule": {
+    "action": {
+      "block": true
+    },
+    "scope": "tenant",
+    "match": {
+      "auth0_managed": ["auth0.icloud_relay_proxy"]
     }
   }
 }

--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -870,6 +870,8 @@ NetworkACLs have the following key properties:
   - `scope`: The scope of the rule ('management', 'authentication', or 'tenant')
   - `match` or `not_match`: Criteria for matching requests
 
+The `match` and `not_match` criteria also support an `auth0_managed` array for matching Auth0-managed IP ranges (e.g. `auth0.icloud_relay_proxy`, `auth0.low_reputation`). Each value must follow the pattern `^auth0\.[^.\s]+$`. This is an Early Access feature gated behind the `tenant_acl_curated_blocklists` feature flag and requires the `advanced-breached-password-detection` entitlement; the API rejects rules using `auth0_managed` with an HTTP 403 if the tenant is not entitled.
+
 **YAML Example**
 
 ```yaml
@@ -893,6 +895,15 @@ networkACLs:
       scope: 'management'
       not_match:
         user_agents: ['BadBot/1.0']
+  - description: 'Block iCloud Private Relay Exits'
+    active: true
+    priority: 4
+    rule:
+      action:
+        block: true
+      scope: 'tenant'
+      match:
+        auth0_managed: ['auth0.icloud_relay_proxy']
 ```
 
 **Directory Example**

--- a/src/tools/auth0/handlers/networkACLs.ts
+++ b/src/tools/auth0/handlers/networkACLs.ts
@@ -73,6 +73,15 @@ const MatchSchema = {
       uniqueItems: true,
       minItems: 1,
     },
+    auth0_managed: {
+      type: 'array',
+      items: {
+        type: 'string',
+        pattern: '^auth0\\.[^.\\s]+$',
+      },
+      uniqueItems: true,
+      minItems: 1,
+    },
     geo_country_codes: {
       type: 'array',
       items: {

--- a/test/tools/auth0/handlers/networkACLs.test.ts
+++ b/test/tools/auth0/handlers/networkACLs.test.ts
@@ -1,7 +1,8 @@
 import { PromisePoolExecutor } from 'promise-pool-executor';
 import { expect } from 'chai';
+const Ajv = require('ajv');
 
-import NetworkACLsHandler from '../../../../src/tools/auth0/handlers/networkACLs';
+import NetworkACLsHandler, { schema } from '../../../../src/tools/auth0/handlers/networkACLs';
 import pageClient from '../../../../src/tools/auth0/client';
 import { mockPagedData } from '../../../utils';
 
@@ -87,6 +88,66 @@ describe('#networkACLs handler', () => {
       ];
 
       await stageFn.apply(handler, [{ networkACLs: data }]);
+    });
+  });
+
+  describe('#networkACLs schema', () => {
+    const ajv = new Ajv({ useDefaults: true, nullable: true });
+
+    it('should pass schema validation for auth0_managed in match', () => {
+      const valid = ajv.validate(schema, [
+        {
+          description: 'Block iCloud Private Relay Exits',
+          active: true,
+          priority: 1,
+          rule: {
+            action: { block: true },
+            scope: 'tenant',
+            match: {
+              auth0_managed: ['auth0.icloud_relay_proxy'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should pass schema validation for auth0_managed in not_match', () => {
+      const valid = ajv.validate(schema, [
+        {
+          description: 'Allow unless low-reputation',
+          active: true,
+          priority: 1,
+          rule: {
+            action: { allow: true },
+            scope: 'tenant',
+            not_match: {
+              auth0_managed: ['auth0.low_reputation'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should fail schema validation for auth0_managed values not matching the pattern', () => {
+      const valid = ajv.validate(schema, [
+        {
+          description: 'Invalid auth0_managed value',
+          active: true,
+          priority: 1,
+          rule: {
+            action: { block: true },
+            scope: 'tenant',
+            match: {
+              auth0_managed: ['icloud_relay_proxy'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(false);
     });
   });
 

--- a/test/tools/auth0/handlers/networkACLs.test.ts
+++ b/test/tools/auth0/handlers/networkACLs.test.ts
@@ -1,6 +1,6 @@
 import { PromisePoolExecutor } from 'promise-pool-executor';
 import { expect } from 'chai';
-const Ajv = require('ajv');
+import Ajv from 'ajv';
 
 import NetworkACLsHandler, { schema } from '../../../../src/tools/auth0/handlers/networkACLs';
 import pageClient from '../../../../src/tools/auth0/client';


### PR DESCRIPTION
### 🔧 Changes

Adds Deploy CLI support for the new `auth0_managed` field on Network ACL rules, part of the Curated Blocklists Early Access feature.

The Auth0 Node SDK (`auth0@6.1.0`) already types this field on `NetworkAclMatch`, so it flows through create/update/import automatically. However, the handler maintains its own hand-written validation schema (`MatchSchema`) with `additionalProperties: false`, which rejected any config containing `auth0_managed` at the validation gate. This change adds the field to that schema so configs using it pass validation.

- Added `auth0_managed` to `MatchSchema` in `networkACLs` handler (string array, `uniqueItems`, validated against the pattern `^auth0\.[^.\s]+$`). Applies to both `match` and `not_match`.
- No SDK bump required.
- Mutual exclusivity of `auth0_managed` across `match`/`not_match` and the `advanced-breached-password-detection` entitlement remain enforced by the API (returns HTTP 400/403), not replicated client-side.

The field accepts Auth0-managed IP range identifiers such as `auth0.icloud_relay_proxy` and `auth0.low_reputation`. The feature is gated behind the `tenant_acl_curated_blocklists` feature flag and requires the `advanced-breached-password-detection` entitlement.

**YAML example**

```yaml
networkACLs:
  - description: 'Block iCloud Private Relay Exits'
    active: true
    priority: 4
    rule:
      action:
        block: true
      scope: 'tenant'
      match:
        auth0_managed: ['auth0.icloud_relay_proxy']
```

**Directory (JSON) example**

Contents of `./networkACLs/Block iCloud Private Relay Exits-p-4.json`:

```json
{
  "description": "Block iCloud Private Relay Exits",
  "active": true,
  "priority": 4,
  "rule": {
    "action": {
      "block": true
    },
    "scope": "tenant",
    "match": {
      "auth0_managed": ["auth0.icloud_relay_proxy"]
    }
  }
}
```

### 📚 References

- DXCDT-1970
- API Spec: Curated Blocklists (auth0_managed) - Q2 FY26
- Initiative: Curated Blocklists - Edge Enforcement (PNT-2638)

### 🔬 Testing

Added schema-level unit tests in `test/tools/auth0/handlers/networkACLs.test.ts` that run ajv against the exported handler schema:

- `auth0_managed` in `match` passes validation
- `auth0_managed` in `not_match` passes validation
- `auth0_managed` values not matching `^auth0\.[^.\s]+$` are rejected

Existing directory and YAML context tests continue to pass, confirming the field round-trips on import/export without changes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
