### PR TITLE
fix: strip unresolved placeholders on deploy instead of throwing

### DIFF
--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -7,7 +7,7 @@ import {
   duplicateItems,
   obfuscateSensitiveValues,
   stripObfuscatedFieldsFromPayload,
-  validateNoUnresolvedPlaceholders,
+  stripUnresolvedPlaceholders,
   detectInsufficientScopeError,
 } from '../../utils';
 import log from '../../../logger';
@@ -457,12 +457,12 @@ export default class APIHandler {
             const updateFN = this.getClientFN(this.functions.update);
             const updatePayload = (() => {
               const data = stripFields({ ...updateItem }, this.stripUpdateFields);
-              const stripped = stripObfuscatedFieldsFromPayload(
+              const obfuscatedStripped = stripObfuscatedFieldsFromPayload(
                 data,
                 this.sensitiveFieldsToObfuscate
               );
-              return validateNoUnresolvedPlaceholders(
-                stripped as Asset,
+              return stripUnresolvedPlaceholders(
+                obfuscatedStripped as Asset,
                 this.type,
                 this.objString(updateItem)
               );
@@ -488,12 +488,12 @@ export default class APIHandler {
             const createFunction = this.getClientFN(this.functions.create);
             const createPayload = (() => {
               const strippedPayload = stripFields(createItem, this.stripCreateFields);
-              const stripped = stripObfuscatedFieldsFromPayload(
+              const obfuscatedStripped = stripObfuscatedFieldsFromPayload(
                 strippedPayload,
                 this.sensitiveFieldsToObfuscate
               );
-              return validateNoUnresolvedPlaceholders(
-                stripped as Asset,
+              return stripUnresolvedPlaceholders(
+                obfuscatedStripped as Asset,
                 this.type,
                 this.objString(createItem)
               );
@@ -521,12 +521,12 @@ export default class APIHandler {
             const updateFN = this.getClientFN(this.functions.update);
             const updatePayload = (() => {
               const data = stripFields({ ...updateItem }, this.stripUpdateFields);
-              const stripped = stripObfuscatedFieldsFromPayload(
+              const obfuscatedStripped = stripObfuscatedFieldsFromPayload(
                 data,
                 this.sensitiveFieldsToObfuscate
               );
-              return validateNoUnresolvedPlaceholders(
-                stripped as Asset,
+              return stripUnresolvedPlaceholders(
+                obfuscatedStripped as Asset,
                 this.type,
                 this.objString(updateItem)
               );

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -316,6 +316,33 @@ export const stripObfuscatedFieldsFromPayload = (
   return newAsset;
 };
 
+// Strips unresolved ##...## / @@...@@ placeholders before sending to Auth0.
+// Keyword replacement runs first; any remaining placeholder means no mapping was
+// provided. The field is dropped so Auth0 preserves its existing value.
+export const stripUnresolvedPlaceholders = (
+  data: Asset | null,
+  resourceType: string,
+  resourceName: string
+): Asset | null => {
+  if (data === null) return data;
+
+  const unresolved = collectUnresolvedPlaceholders(data);
+  if (unresolved.length === 0) return data;
+
+  const newAsset = { ...data };
+  unresolved.forEach(({ path, value }) => {
+    log.warn(
+      `Stripping unresolved placeholder for ${resourceType} "${resourceName}" field "${path}": ${value}. ` +
+        `To use this value, define ${path
+          .split('.')
+          .pop()
+          ?.toUpperCase()} in AUTH0_KEYWORD_REPLACE_MAPPINGS. The existing value on Auth0 will be preserved.`
+    );
+    dotProp.delete(newAsset, path);
+  });
+  return newAsset;
+};
+
 export const detectInsufficientScopeError = async <T>(
   fn: Function
 ): Promise<

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -333,10 +333,7 @@ export const stripUnresolvedPlaceholders = (
   unresolved.forEach(({ path, value }) => {
     log.warn(
       `Stripping unresolved placeholder for ${resourceType} "${resourceName}" field "${path}": ${value}. ` +
-        `To use this value, define ${path
-          .split('.')
-          .pop()
-          ?.toUpperCase()} in AUTH0_KEYWORD_REPLACE_MAPPINGS. The existing value on Auth0 will be preserved.`
+        `To use this value, define ${value.replace(/^##|##$|^@@|@@$/g, '')} in AUTH0_KEYWORD_REPLACE_MAPPINGS. The existing value on Auth0 will be preserved.`
     );
     dotProp.delete(newAsset, path);
   });

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -333,7 +333,10 @@ export const stripUnresolvedPlaceholders = (
   unresolved.forEach(({ path, value }) => {
     log.warn(
       `Stripping unresolved placeholder for ${resourceType} "${resourceName}" field "${path}": ${value}. ` +
-        `To use this value, define ${value.replace(/^##|##$|^@@|@@$/g, '')} in AUTH0_KEYWORD_REPLACE_MAPPINGS. The existing value on Auth0 will be preserved.`
+        `To use this value, define ${value.replace(
+          /^##|##$|^@@|@@$/g,
+          ''
+        )} in AUTH0_KEYWORD_REPLACE_MAPPINGS. The existing value on Auth0 will be preserved.`
     );
     dotProp.delete(newAsset, path);
   });

--- a/test/tools/auth0/handlers/default.tests.ts
+++ b/test/tools/auth0/handlers/default.tests.ts
@@ -250,6 +250,44 @@ describe('#default handler', () => {
     });
   });
 
+  it('should strip all unresolved placeholders and not throw when processing conflicts', async () => {
+    let capturedPayload: object | null = null;
+
+    const handler = new mockHandler({
+      client: mockApiClient,
+      config,
+      type: mockAssetType,
+      functions: {
+        //@ts-ignore
+        update: async (_id, payload) => {
+          capturedPayload = payload;
+          return payload;
+        },
+      },
+    });
+
+    await handler.processChanges({} as Assets, {
+      del: [],
+      create: [],
+      update: [],
+      conflicts: [
+        {
+          id: 'foo',
+          options: {
+            client_secret: '##CONNECTIONS_WAAD_SECRET##',
+            client_id: 'real-client-id',
+          },
+          non_sensitive_property: 'regular value',
+        },
+      ],
+    });
+
+    expect(capturedPayload).to.deep.equal({
+      options: { client_id: 'real-client-id' },
+      non_sensitive_property: 'regular value',
+    });
+  });
+
   describe('AUTH0_IGNORE_DRY_RUN_FIELDS', () => {
     it('should merge user-configured ignore fields with handler defaults', () => {
       const configWithIgnore = ((key: string) => {

--- a/test/tools/auth0/handlers/default.tests.ts
+++ b/test/tools/auth0/handlers/default.tests.ts
@@ -177,58 +177,77 @@ describe('#default handler', () => {
     expect(didCreateFunctionGetCalled).to.equal(true);
   });
 
-  it('should throw when creating an asset with an unresolved placeholder', async () => {
+  it('should strip all unresolved placeholders and not throw when creating', async () => {
+    let capturedPayload: object | null = null;
+
     const handler = new mockHandler({
       client: mockApiClient,
       config,
       type: mockAssetType,
       functions: {
         //@ts-ignore
-        create: async (payload) => payload,
+        create: async (payload) => {
+          capturedPayload = payload;
+          return payload;
+        },
       },
     });
 
-    await expect(
-      handler.processChanges({} as Assets, {
-        del: [],
-        update: [],
-        conflicts: [],
-        create: [
-          {
-            id: 'some-id',
-            unresolved_field: '##UNRESOLVED_PLACEHOLDER##',
-            resolved_field: 'a-real-value',
-          },
-        ],
-      })
-    ).to.be.rejectedWith(/Unresolved placeholder/);
+    await handler.processChanges({} as Assets, {
+      del: [],
+      update: [],
+      conflicts: [],
+      create: [
+        {
+          id: 'some-id',
+          unresolved_field: '##UNRESOLVED_PLACEHOLDER##',
+          resolved_field: 'a-real-value',
+        },
+      ],
+    });
+
+    expect(capturedPayload).to.deep.equal({
+      id: 'some-id',
+      resolved_field: 'a-real-value',
+    });
   });
 
-  it('should throw when updating an asset with an unresolved placeholder', async () => {
+  it('should strip all unresolved placeholders and not throw when updating', async () => {
+    let capturedPayload: object | null = null;
+
     const handler = new mockHandler({
       client: mockApiClient,
       config,
       type: mockAssetType,
       functions: {
         //@ts-ignore
-        update: async (_identifiers, payload) => payload,
+        update: async (_id, payload) => {
+          capturedPayload = payload;
+          return payload;
+        },
       },
     });
 
-    await expect(
-      handler.processChanges({} as Assets, {
-        del: [],
-        create: [],
-        conflicts: [],
-        update: [
-          {
-            id: 'foo',
-            secret: '##UNRESOLVED_SECRET##',
-            non_sensitive_property: 'regular value',
+    await handler.processChanges({} as Assets, {
+      del: [],
+      create: [],
+      conflicts: [],
+      update: [
+        {
+          id: 'foo',
+          options: {
+            client_secret: '##CONNECTIONS_WAAD_SECRET##',
+            client_id: 'real-client-id',
           },
-        ],
-      })
-    ).to.be.rejectedWith(/Unresolved placeholder/);
+          non_sensitive_property: 'regular value',
+        },
+      ],
+    });
+
+    expect(capturedPayload).to.deep.equal({
+      options: { client_id: 'real-client-id' },
+      non_sensitive_property: 'regular value',
+    });
   });
 
   describe('AUTH0_IGNORE_DRY_RUN_FIELDS', () => {

--- a/test/tools/utils.test.js
+++ b/test/tools/utils.test.js
@@ -698,6 +698,81 @@ describe('#filterExcluded', () => {
         });
     });
   });
+
+  describe('#stripUnresolvedPlaceholders', () => {
+    it('should strip a nested field containing an unresolved ##...## placeholder', () => {
+      const asset = {
+        id: 'con-1',
+        name: 'my-waad-connection',
+        options: {
+          client_id: 'real-client-id',
+          client_secret: '##CONNECTIONS_WAAD_SECRET##',
+          domain: 'example.onmicrosoft.com',
+        },
+      };
+
+      const result = utils.stripUnresolvedPlaceholders(asset, 'connections', 'my-waad-connection');
+      expect(result).to.deep.equal({
+        id: 'con-1',
+        name: 'my-waad-connection',
+        options: {
+          client_id: 'real-client-id',
+          domain: 'example.onmicrosoft.com',
+        },
+      });
+    });
+
+    it('should strip a field containing an unresolved @@...@@ placeholder', () => {
+      const asset = {
+        id: 'con-2',
+        options: {
+          client_secret: '@@CONNECTIONS_WAAD_SECRET@@',
+          client_id: 'abc',
+        },
+      };
+
+      const result = utils.stripUnresolvedPlaceholders(asset, 'connections', 'con-2');
+      expect(result).to.deep.equal({
+        id: 'con-2',
+        options: { client_id: 'abc' },
+      });
+    });
+
+    it('should strip ALL unresolved placeholders across all fields', () => {
+      const asset = {
+        id: 'con-3',
+        options: {
+          client_secret: '##CONNECTIONS_OIDC_SECRET##',
+          api_key: '##SOME_API_KEY##',
+          domain: 'real-domain.com',
+        },
+      };
+
+      const result = utils.stripUnresolvedPlaceholders(asset, 'connections', 'con-3');
+      expect(result).to.deep.equal({
+        id: 'con-3',
+        options: { domain: 'real-domain.com' },
+      });
+    });
+
+    it('should not strip a field that has a resolved (real) value', () => {
+      const asset = {
+        id: 'con-4',
+        options: {
+          client_secret: 'the-real-secret',
+          client_id: 'abc',
+        },
+      };
+
+      const result = utils.stripUnresolvedPlaceholders(asset, 'connections', 'con-4');
+      expect(result).to.deep.equal(asset);
+    });
+
+    it('should return null when input is null', () => {
+      const result = utils.stripUnresolvedPlaceholders(null, 'connections', 'con-5');
+      expect(result).to.be.null;
+    });
+  });
 });
 
 describe('#detectInsufficientScopeError', () => {


### PR DESCRIPTION
### 🔧 Changes

Previously, deploying a resource with an unresolved `##...##` or `@@...@@` placeholder would throw an error and abort the deploy. This caused the export→import round-trip to fail for connections and other resources where the CLI auto-generates secret placeholders on export (e.g. `##CONNECTIONS_WAAD_SECRET##`), since Auth0 does not expose the actual secret value, making it impossible for users to provide the keyword mapping.
                                                                                                                                                                            
**Change**: Instead of throwing, unresolved placeholders are now stripped from the payload before the API call, with a warn log per field. Auth0 preserves its existing value for any stripped field.                                                                                                                                                   

  - Added `stripUnresolvedPlaceholders` utility in `src/tools/utils.ts`
  - `APIHandler.processChanges` (create, update, conflict paths) now calls `stripUnresolvedPlaceholders` in place of `validateNoUnresolvedPlaceholders`

### 📚 References

- PR #1360 

### 🔬 Testing

 - Unit tests updated in `test/tools/utils.test.js` and `test/tools/auth0/handlers/default.tests.ts`
 - Tested against real tenant: exported a WAAD connection (producing `##CONNECTIONS_WAAD_SECRET##`), ran import without defining the mapping, field was stripped with a warning and the connection updated successfully

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
