### PR TITLE
fix: resolve spurious dry-run diffs for rules, themes, and hooks

### DIFF
--- a/src/tools/auth0/handlers/hooks.ts
+++ b/src/tools/auth0/handlers/hooks.ts
@@ -182,7 +182,7 @@ export default class HooksHandler extends DefaultHandler {
             .then((hookWithCode) =>
               this.client.hooks.secrets
                 .get(hook.id)
-                .then(({ data: secrets }) => ({ ...hookWithCode, secrets }))
+                .then((secrets) => ({ ...hookWithCode, secrets }))
             )
         )
       );

--- a/src/tools/auth0/handlers/rules.ts
+++ b/src/tools/auth0/handlers/rules.ts
@@ -4,6 +4,7 @@ import { convertJsonToString, stripFields, duplicateItems, isDeprecatedError } f
 import DefaultHandler from './default';
 import log from '../../../logger';
 import { calculateChanges } from '../../calculateChanges';
+import { calculateDryRunChanges } from '../../calculateDryRunChanges';
 import { Asset, Assets, CalculatedChanges } from '../../../types';
 import { paginate } from '../client';
 
@@ -152,14 +153,28 @@ export default class RulesHandler extends DefaultHandler {
   }
 
   async dryRunChanges(assets: Assets): Promise<CalculatedChanges> {
-    const { del, update, create, conflicts } = await this.calcChanges(assets);
+    let { rules } = assets;
 
-    return {
-      del,
-      update,
-      create,
-      conflicts,
-    };
+    if (!rules) {
+      return { del: [], create: [], conflicts: [], update: [] };
+    }
+
+    const excludedRules = (assets.exclude && assets.exclude.rules) || [];
+    rules = rules.filter((r) => !excludedRules.includes(r.name));
+
+    let existing = await this.getType();
+    if (existing === null) {
+      return { del: [], create: [], conflicts: [], update: [] };
+    }
+    existing = existing.filter((r) => !excludedRules.includes(r.name));
+
+    return calculateDryRunChanges({
+      type: this.type,
+      assets: rules,
+      existing,
+      identifiers: this.identifiers,
+      ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
+    });
   }
 
   async validate(assets: Assets): Promise<void> {

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -483,11 +483,17 @@ export default class ThemesHandler extends DefaultHandler {
 
     const existing = await this.getType();
 
+    // getType() returns null when Universal Login customizations are not enabled
+    // on the tenant (the 400 "no-code not enabled" path in getThemes).
+    if (existing === null) {
+      return { del: [], create: [], conflicts: [], update: [] };
+    }
+
     // Themes are singletons — at most one per tenant. If the local theme has no
     // themeId (stripped during export when --export_ids is not set), backfill it
     // from the remote so the matcher can find a match without requiring --export_ids.
     const normalizedThemes = themes.map((theme) => {
-      if (!theme.themeId && existing && existing.length > 0 && existing[0].themeId) {
+      if (!theme.themeId && existing.length > 0 && existing[0].themeId) {
         return { ...theme, themeId: existing[0].themeId };
       }
       return theme;
@@ -496,7 +502,6 @@ export default class ThemesHandler extends DefaultHandler {
     return calculateDryRunChanges({
       type: this.type,
       assets: normalizedThemes,
-      // @ts-ignore
       existing,
       identifiers: this.identifiers,
       ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),

--- a/src/tools/auth0/handlers/themes.ts
+++ b/src/tools/auth0/handlers/themes.ts
@@ -1,8 +1,9 @@
 import { Management } from 'auth0';
-import { Assets } from '../../../types';
+import { Assets, CalculatedChanges } from '../../../types';
 import log from '../../../logger';
 import DefaultHandler, { order } from './default';
 import { isDryRun } from '../../utils';
+import { calculateDryRunChanges } from '../../calculateDryRunChanges';
 
 /**
  * Schema
@@ -435,6 +436,35 @@ export default class ThemesHandler extends DefaultHandler {
 
   objString(theme: Theme): string {
     return theme.displayName || JSON.stringify(theme);
+  }
+
+  async dryRunChanges(assets: Assets): Promise<CalculatedChanges> {
+    const { themes } = assets;
+
+    if (!themes) {
+      return { del: [], create: [], conflicts: [], update: [] };
+    }
+
+    const existing = await this.getType();
+
+    // Themes are singletons — at most one per tenant. If the local theme has no
+    // themeId (stripped during export when --export_ids is not set), backfill it
+    // from the remote so the matcher can find a match without requiring --export_ids.
+    const normalizedThemes = themes.map((theme) => {
+      if (!theme.themeId && existing && existing.length > 0 && existing[0].themeId) {
+        return { ...theme, themeId: existing[0].themeId };
+      }
+      return theme;
+    });
+
+    return calculateDryRunChanges({
+      type: this.type,
+      assets: normalizedThemes,
+      // @ts-ignore
+      existing,
+      identifiers: this.identifiers,
+      ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
+    });
   }
 
   async getType(): Promise<Theme[] | null> {

--- a/test/tools/auth0/handlers/dryRun.tests.ts
+++ b/test/tools/auth0/handlers/dryRun.tests.ts
@@ -6,6 +6,7 @@ import DatabasesHandler from '../../../../src/tools/auth0/handlers/databases';
 import HooksHandler from '../../../../src/tools/auth0/handlers/hooks';
 import RulesConfigsHandler from '../../../../src/tools/auth0/handlers/rulesConfigs';
 import RulesHandler from '../../../../src/tools/auth0/handlers/rules';
+import ThemesHandler from '../../../../src/tools/auth0/handlers/themes';
 import DefaultHandler from '../../../../src/tools/auth0/handlers/default';
 import constants from '../../../../src/tools/constants';
 import { configFactory } from '../../../../src/configFactory';
@@ -276,7 +277,7 @@ describe('#handler dryRunChanges', () => {
           enabled: true,
         }),
         secrets: {
-          get: async () => ({ data: { SECRET_ONE: constants.HOOKS_HIDDEN_SECRET_VALUE } }),
+          get: async () => ({ SECRET_ONE: constants.HOOKS_HIDDEN_SECRET_VALUE }),
         },
       },
       pool,
@@ -299,12 +300,130 @@ describe('#handler dryRunChanges', () => {
     expect(changes.update).to.have.length(1);
     expect(changes.update[0].secrets).to.equal(undefined);
   });
+
+  it('rules should produce no changes on a clean export/dry-run cycle', async () => {
+    const auth0 = {
+      rules: {
+        list: (params: any) =>
+          mockPagedData(params, 'rules', [
+            {
+              id: 'rule-id-1',
+              name: 'Add voucherID to AccessToken',
+              order: 1,
+              stage: 'login_success',
+              enabled: true,
+              script: 'function (user, context, callback) { callback(null, user, context); }',
+            },
+            {
+              id: 'rule-id-2',
+              name: 'Block Implicit Grant',
+              order: 2,
+              stage: 'login_success',
+              enabled: true,
+              script: 'function (user, context, callback) { callback(null, user, context); }',
+            },
+          ]),
+      },
+      pool,
+    };
+
+    const handler = new RulesHandler({
+      client: pageClient(auth0 as any),
+      config,
+    } as any);
+
+    // Simulate what export produces: rules by name, no id
+    const changes = await handler.dryRunChanges({
+      rules: [
+        {
+          name: 'Add voucherID to AccessToken',
+          order: 1,
+          stage: 'login_success',
+          enabled: true,
+          script: 'function (user, context, callback) { callback(null, user, context); }',
+        },
+        {
+          name: 'Block Implicit Grant',
+          order: 2,
+          stage: 'login_success',
+          enabled: true,
+          script: 'function (user, context, callback) { callback(null, user, context); }',
+        },
+      ],
+    } as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.update).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+  });
+
+  it('themes should not propose create/delete when local theme lacks themeId (exported without --export_ids)', async () => {
+    const remoteTheme = {
+      themeId: 'remote-theme-id',
+      displayName: 'Default Theme',
+      colors: { primary_button: '#635dff', error: '#d32f2f' },
+    };
+
+    const auth0 = {
+      branding: {
+        themes: {
+          getDefault: async () => remoteTheme,
+        },
+      },
+    };
+
+    const handler = new ThemesHandler({ client: auth0, config } as any);
+
+    const changes = await handler.dryRunChanges({
+      themes: [
+        {
+          // no themeId — mirrors a default export where AUTH0_EXPORT_IDENTIFIERS is false
+          displayName: 'Default Theme',
+          colors: { primary_button: '#635dff', error: '#d32f2f' },
+        },
+      ],
+    } as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+  });
+
+  it('themes should propose update (not create/delete) when content differs and local theme lacks themeId', async () => {
+    const remoteTheme = {
+      themeId: 'remote-theme-id',
+      displayName: 'Default Theme',
+      colors: { primary_button: '#635dff', error: '#d32f2f' },
+    };
+
+    const auth0 = {
+      branding: {
+        themes: {
+          getDefault: async () => remoteTheme,
+        },
+      },
+    };
+
+    const handler = new ThemesHandler({ client: auth0, config } as any);
+
+    const changes = await handler.dryRunChanges({
+      themes: [
+        {
+          displayName: 'Default Theme',
+          colors: { primary_button: '#ff0000', error: '#d32f2f' }, // primary_button changed
+        },
+      ],
+    } as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+    expect(changes.update).to.have.length(1);
+  });
 });
 
 describe('#getResourceName', () => {
   function createHandler(type: string): DefaultHandler {
+    // @ts-ignore test stub — omits required runtime fields (client, functions, ignoreDryRunFields)
     return new DefaultHandler({
-      // @ts-ignore test stub
       config: configFactory(),
       type,
       id: 'id',

--- a/test/tools/auth0/handlers/dryRun.tests.ts
+++ b/test/tools/auth0/handlers/dryRun.tests.ts
@@ -258,6 +258,44 @@ describe('#handler dryRunChanges', () => {
     expect(changes.del).to.have.length(0);
   });
 
+  it('rules should return empty changes when rules asset is not provided', async () => {
+    const handler = new RulesHandler({
+      client: pageClient({
+        rules: { list: (params: any) => mockPagedData(params, 'rules', []) },
+        pool,
+      } as any),
+      config,
+    } as any);
+
+    const changes = await handler.dryRunChanges({} as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.update).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+    expect(changes.conflicts).to.have.length(0);
+  });
+
+  it('rules should return empty changes when getType returns null', async () => {
+    const handler = new RulesHandler({
+      client: pageClient({
+        rules: { list: (params: any) => mockPagedData(params, 'rules', []) },
+        pool,
+      } as any),
+      config,
+    } as any);
+
+    (handler as any).getType = async () => null;
+
+    const changes = await handler.dryRunChanges({
+      rules: [{ name: 'some-rule', script: 'function(){}', enabled: true }],
+    } as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.update).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+    expect(changes.conflicts).to.have.length(0);
+  });
+
   it('hooks should not expose secret values in dry run updates', async () => {
     const auth0 = {
       hooks: {

--- a/test/tools/auth0/handlers/themes.tests.js
+++ b/test/tools/auth0/handlers/themes.tests.js
@@ -322,6 +322,97 @@ describe('#themes handler', () => {
     expect(auth0.branding.themes.update.called).to.equal(false);
     expect(auth0.branding.themes.create.called).to.equal(false);
   });
+
+  describe('#themes dryRunChanges', () => {
+    it('should produce no create/delete when local theme lacks themeId (exported without --export_ids)', async () => {
+      const remoteTheme = mockTheme({ withThemeId: 'remote-theme-id' });
+      const localTheme = omit(cloneDeep(remoteTheme), 'themeId');
+
+      const auth0 = {
+        branding: {
+          themes: {
+            getDefault: stub().returns(Promise.resolve(remoteTheme)),
+          },
+        },
+      };
+
+      const handler = new ThemesHandler({ client: auth0 });
+      const changes = await handler.dryRunChanges({ themes: [localTheme] });
+
+      expect(changes.create).to.have.length(0);
+      expect(changes.del).to.have.length(0);
+    });
+
+    it('should produce no update when local theme lacks themeId and content is identical', async () => {
+      const remoteTheme = mockTheme({ withThemeId: 'remote-theme-id' });
+      const localTheme = omit(cloneDeep(remoteTheme), 'themeId');
+
+      const auth0 = {
+        branding: {
+          themes: {
+            getDefault: stub().returns(Promise.resolve(remoteTheme)),
+          },
+        },
+      };
+
+      const handler = new ThemesHandler({ client: auth0 });
+      const changes = await handler.dryRunChanges({ themes: [localTheme] });
+
+      expect(changes.update).to.have.length(0);
+    });
+
+    it('should propose update (not create/delete) when content differs and local theme lacks themeId', async () => {
+      const remoteTheme = mockTheme({ withThemeId: 'remote-theme-id' });
+      const localTheme = {
+        ...omit(cloneDeep(remoteTheme), 'themeId'),
+        colors: { ...remoteTheme.colors, primary_button: '#aabbcc' },
+      };
+
+      const auth0 = {
+        branding: {
+          themes: {
+            getDefault: stub().returns(Promise.resolve(remoteTheme)),
+          },
+        },
+      };
+
+      const handler = new ThemesHandler({ client: auth0 });
+      const changes = await handler.dryRunChanges({ themes: [localTheme] });
+
+      expect(changes.create).to.have.length(0);
+      expect(changes.del).to.have.length(0);
+      expect(changes.update).to.have.length(1);
+    });
+
+    it('should produce no changes when local theme already has themeId and content matches', async () => {
+      const remoteTheme = mockTheme({ withThemeId: 'remote-theme-id' });
+
+      const auth0 = {
+        branding: {
+          themes: {
+            getDefault: stub().returns(Promise.resolve(remoteTheme)),
+          },
+        },
+      };
+
+      const handler = new ThemesHandler({ client: auth0 });
+      const changes = await handler.dryRunChanges({ themes: [cloneDeep(remoteTheme)] });
+
+      expect(changes.create).to.have.length(0);
+      expect(changes.del).to.have.length(0);
+      expect(changes.update).to.have.length(0);
+    });
+
+    it('should return empty changes when themes is not present in assets', async () => {
+      const handler = new ThemesHandler({ client: {} });
+      const changes = await handler.dryRunChanges({});
+
+      expect(changes.create).to.have.length(0);
+      expect(changes.del).to.have.length(0);
+      expect(changes.update).to.have.length(0);
+      expect(changes.conflicts).to.have.length(0);
+    });
+  });
 });
 
 describe('#themes keyword preservation', () => {

--- a/test/tools/auth0/handlers/themes.tests.js
+++ b/test/tools/auth0/handlers/themes.tests.js
@@ -480,6 +480,31 @@ describe('#themes handler', () => {
       expect(changes.update).to.have.length(0);
       expect(changes.conflicts).to.have.length(0);
     });
+
+    it('should return empty changes when getType returns null (no-code not enabled on tenant)', async () => {
+      const auth0 = {
+        branding: {
+          themes: {
+            getDefault: stub().returns(
+              Promise.reject(
+                errorWithStatusCode(
+                  400,
+                  'Your account does not have universal login customizations enabled'
+                )
+              )
+            ),
+          },
+        },
+      };
+
+      const handler = new ThemesHandler({ client: auth0 });
+      const changes = await handler.dryRunChanges({ themes: [{ displayName: 'Default Theme' }] });
+
+      expect(changes.create).to.have.length(0);
+      expect(changes.del).to.have.length(0);
+      expect(changes.update).to.have.length(0);
+      expect(changes.conflicts).to.have.length(0);
+    });
   });
 });
 


### PR DESCRIPTION
### 🔧 Changes

Fixes three sources of spurious dry-run diffs that caused a clean export-then-dry-run cycle to propose changes when none existed.                                                                                                           
                                         
  **Rules** (`handlers/rules.ts`)                                                                                                                                           
`dryRunChanges` was delegating to `calcChanges`, which internally runs the `duplicateItems` suffix-generation path. This caused every rule in the tenant to appear twice in the diff, once under its real name and once with a random suffix (e.g. `Add voucherID to AccessToken-betv2`).
Fixed by calling `calculateDryRunChanges` directly, which performs a clean name-based comparison without any renaming side-effects.

  **Themes** (`handlers/themes.ts`)
Themes are singletons, but a default export strips `themeId` from the local file (because `AUTH0_EXPORT_IDENTIFIERS` defaults to `false`).
Without a `themeId`, the dry-run matcher found no match for the local theme and proposed a CREATE + DELETE on every run. Fixed by adding a `dryRunChanges` override that backfills `themeId` from the remote singleton before comparison, so the matcher resolves correctly without requiring `AUTH0_EXPORT_IDENTIFIERS`.

  **Hooks** (`handlers/hooks.ts`)
`getType` was destructuring `{ data: secrets }` from the secrets response, but the SDK returns the object directly. This meant secrets were always `undefined` locally, causing hooks with secrets to appear changed on every dry run. Fixed by removing the `.data` unwrap.

### 📚 References


### 🔬 Testing

Unit tests added/extended for all three fixes:

  - `test/tools/auth0/handlers/dryRun.tests.ts` - new rules clean-cycle test (no creates/updates/deletes after a clean export), and two new themes regression tests (no themeId → no create/delete; content diff → update only)
  - `test/tools/auth0/handlers/themes.tests.js` - new`#themes dryRunChanges` describe block with 5 cases covering the
    backfill logic, content-diff detection, and null-guard behaviour

All 37 affected tests pass (`npm test`).

For end-to-end validation: export any tenant, immediately run`--dry-run` against the same tenant with the same exported file - rules, themes, and hooks should all show zero proposed changes.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
