### PR TITLE
fix: apply AUTH0_INCLUDED_CONNECTIONS on export

### DIFF
--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -75,6 +75,12 @@ async function dump(context: DirectoryContext): Promise<void> {
     );
   }
 
+  // Filter to included connections
+  const includedConnections = (context.assets.include && context.assets.include.connections) || [];
+  if (includedConnections.length) {
+    connections = connections.filter((connection) => includedConnections.includes(connection.name));
+  }
+
   const connectionsFolder = path.join(context.filePath, constants.CONNECTIONS_DIRECTORY);
   fs.ensureDirSync(connectionsFolder);
 
@@ -131,11 +137,23 @@ async function dump(context: DirectoryContext): Promise<void> {
     if (dumpedConnection.strategy === 'email') expectedFiles.add(`${connectionName}.html`);
   });
 
+  // With an include list configured, connections outside it are unmanaged, so limit pruning
+  // to the listed names rather than every file in the folder.
+  const prunableFiles = includedConnections.length
+    ? new Set(
+        includedConnections.flatMap((name) => [`${sanitize(name)}.json`, `${sanitize(name)}.html`])
+      )
+    : null;
+
   // Remove files that belong to connections no longer present (and not excluded)
   if (fs.existsSync(connectionsFolder)) {
     for (const existing of fs.readdirSync(connectionsFolder)) {
       const fullPath = path.join(connectionsFolder, existing);
-      if (fs.statSync(fullPath).isFile() && !expectedFiles.has(existing)) {
+      if (
+        fs.statSync(fullPath).isFile() &&
+        !expectedFiles.has(existing) &&
+        (prunableFiles === null || prunableFiles.has(existing))
+      ) {
         fs.removeSync(fullPath);
       }
     }

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -61,6 +61,12 @@ async function dump(context: YAMLContext): Promise<ParsedConnections> {
     );
   }
 
+  // Filter to included connections
+  const includedConnections = (context.assets.include && context.assets.include.connections) || [];
+  if (includedConnections.length) {
+    connections = connections.filter((connection) => includedConnections.includes(connection.name));
+  }
+
   return {
     connections: connections.map((connection) => {
       let dumpedConnection = {

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -266,6 +266,69 @@ describe('#directory context connections', () => {
     expect(fs.existsSync(path.join(connectionsFolder, 'excludedConnection.json'))).to.equal(true);
   });
 
+  it('should only dump included connections', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsDumpInclude');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.connections = [
+      { name: 'includedConnection', strategy: 'waad' },
+      { name: 'unmanagedConnection', strategy: 'samlp' },
+    ];
+    context.assets.include = { connections: ['includedConnection'] };
+
+    await handler.dump(context);
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+
+    expect(fs.existsSync(path.join(connectionsFolder, 'includedConnection.json'))).to.equal(true);
+    expect(fs.existsSync(path.join(connectionsFolder, 'unmanagedConnection.json'))).to.equal(false);
+  });
+
+  it('should preserve pre-existing files for connections outside the include list on re-dump', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsDumpInclude');
+    cleanThenMkdir(dir);
+
+    // Simulate a prior export that wrote a connection now outside the include list
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    fs.ensureDirSync(connectionsFolder);
+    fs.writeFileSync(
+      path.join(connectionsFolder, 'unmanagedConnection.json'),
+      '{"name":"unmanagedConnection"}'
+    );
+
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    context.assets.connections = [
+      { name: 'includedConnection', strategy: 'waad' },
+      { name: 'unmanagedConnection', strategy: 'samlp' },
+    ];
+    context.assets.include = { connections: ['includedConnection'] };
+
+    await handler.dump(context);
+
+    expect(fs.existsSync(path.join(connectionsFolder, 'includedConnection.json'))).to.equal(true);
+    expect(fs.existsSync(path.join(connectionsFolder, 'unmanagedConnection.json'))).to.equal(true);
+  });
+
+  it('should remove stale files for included connections no longer present on the tenant', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsIncludeStaleFiles');
+    cleanThenMkdir(dir);
+
+    // Simulate a previous export of two included connections, one since deleted on the tenant
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    fs.ensureDirSync(connectionsFolder);
+    fs.writeFileSync(path.join(connectionsFolder, 'facebook.json'), '{"name":"facebook"}');
+    fs.writeFileSync(path.join(connectionsFolder, 'github.json'), '{"name":"github"}');
+
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+    context.assets.connections = [{ name: 'github', strategy: 'github' }];
+    context.assets.include = { connections: ['facebook', 'github'] };
+
+    await handler.dump(context);
+
+    expect(fs.existsSync(path.join(connectionsFolder, 'github.json'))).to.equal(true);
+    expect(fs.existsSync(path.join(connectionsFolder, 'facebook.json'))).to.equal(false);
+  });
+
   it('should remove stale connection files when connections are removed from source', async () => {
     const dir = path.join(testDataDir, 'directory', 'connectionsStaleFiles');
     cleanThenMkdir(dir);

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -276,4 +276,24 @@ describe('#YAML context connections', () => {
     expect(dumped.connections).to.have.length(1);
     expect(dumped.connections[0].name).to.equal('includedConnection');
   });
+
+  it('should only dump included connections', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'connectionsDumpInclude');
+    cleanThenMkdir(dir);
+    const context = new Context(
+      { AUTH0_INPUT_FILE: path.join(dir, 'tenant.yaml') },
+      mockMgmtClient()
+    );
+
+    context.assets.connections = [
+      { name: 'includedConnection', strategy: 'waad' },
+      { name: 'unmanagedConnection', strategy: 'samlp' },
+    ];
+    context.assets.include = { connections: ['includedConnection'] };
+
+    const dumped = await handler.dump(context);
+
+    expect(dumped.connections).to.have.length(1);
+    expect(dumped.connections[0].name).to.equal('includedConnection');
+  });
 });


### PR DESCRIPTION
### 🔧 Changes

`AUTH0_INCLUDED_CONNECTIONS` was only honoured on `import`. The value was read into `assets.include.connections` on both code paths — including inside `dump()` at `src/context/directory/index.ts:124` — but the only consumer was `filterIncluded` in the connections handler's `processChanges`. `filterIncluded` operates on `CalculatedChanges`, a structure the export path never builds, so exports wrote every connection on the tenant regardless of the include list.

This contradicts the documented behaviour:

> **Important:** This setting affects all operations (export and import). Connections not in this list will not appear in exports and will not be modified during imports.

**`src/context/directory/handlers/connections.ts`** and **`src/context/yaml/handlers/connections.ts`** — `dump()` now filters to the included connections, immediately after the existing exclude filter and mirroring its shape:

```ts
// Filter to included connections
const includedConnections = (context.assets.include && context.assets.include.connections) || [];
if (includedConnections.length) {
  connections = connections.filter((connection) => includedConnections.includes(connection.name));
}
```

**`src/context/directory/handlers/connections.ts`** — pruning is scoped to the listed names when an include list is configured:

```ts
// With an include list configured, connections outside it are unmanaged, so limit pruning
// to the listed names rather than every file in the folder.
const prunableFiles = includedConnections.length
  ? new Set(
      includedConnections.flatMap((name) => [`${sanitize(name)}.json`, `${sanitize(name)}.html`])
    )
  : null;
```

Without this, the folder-pruning logic added alongside export-side exclude filtering would delete the files of every connection outside the include list. Those connections are unmanaged, so their files are preserved across re-dumps — the same guarantee excluded connections already get via the `expectedFiles` seeding. Stale files for connections that *are* in the include list but no longer exist on the tenant are still removed.

No behaviour change when `AUTH0_INCLUDED_CONNECTIONS` is unset: both filters are no-ops on an empty list, and `prunableFiles` stays `null`, leaving the existing prune semantics intact.

### 📚 References

Fixes #1441

The asymmetry this closes: `AUTH0_EXCLUDED_CONNECTIONS`, documented as the deprecated counterpart, gained export filtering while `AUTH0_INCLUDED_CONNECTIONS` did not — and the two cannot be combined, since `src/context/index.ts:148` throws when both are set. That left no way to express the keep-list use case the docs call out explicitly:

> Managing only specific connections while preserving others (e.g., self-service SSO connections, third-party integrations)

A keep-list is the only maintainable shape for that case, because Self-Service SSO mints new connections with generated UUID names over time — expressing the same intent through an exclude list means amending it every time a connection is created.

### 🔬 Testing

Four new tests, placed alongside the existing exclude-dump tests:

`test/context/directory/connections.test.js`

- `should only dump included connections` — a `waad` connection in the list is written; a `samlp` connection outside it is not.
- `should preserve pre-existing files for connections outside the include list on re-dump` — a file written by a prior export survives when its connection is outside the list. Fails without the `prunableFiles` scoping.
- `should remove stale files for included connections no longer present on the tenant` — pruning still works within the include list.

`test/context/yaml/connections.test.js`

- `should only dump included connections` — the returned `connections` array contains just the listed connection.

Full suite: **1342 passing, 1 pending**, no regressions. `npm run build`, `npm run lint` (eslint + kacl), and `npx prettier --check` all clean.

Manual end-to-end verification against a real tenant holding 34 connections — 4 named in `AUTH0_INCLUDED_CONNECTIONS`, the rest mostly UUID-named `samlp` connections created by Self-Service SSO. Identical config file and output folder for both runs, with `AUTH0_INCLUDED_ONLY: ["connections"]`:

- built from `master`: 34 files written to `connections/`
- built from this branch: 4 files — `google-oauth2.json`, `okta-sandbox-oidc-test.json`, `waad.json`, `windowslive.json`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A) — `docs/configuring-the-deploy-cli.md` already documents this behaviour; this change makes the implementation match it, so no doc edit is needed.
