### PR TITLE
fix: strip read-only  field from roles to fix export/import round-trip (#1439)

### DIFF
--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -44,6 +44,9 @@ export default class RolesHandler extends DefaultHandler {
   async createRole(data): Promise<Asset> {
     const role = { ...data };
     delete role.permissions;
+    // `type` is a read-only field returned by the roles GET endpoint but rejected
+    // by the roles create/update endpoints. Strip it to keep exports round-trippable.
+    delete role.type;
 
     const created = await this.client.roles.create(role);
 
@@ -110,6 +113,9 @@ export default class RolesHandler extends DefaultHandler {
 
     delete data.permissions;
     delete data.id;
+    // `type` is read-only on the roles GET endpoint and rejected by update; strip it
+    // so files that already contain it (from a prior export) can still be imported.
+    delete data.type;
 
     await this.client.roles.update(params.id, data);
 
@@ -201,6 +207,9 @@ export default class RolesHandler extends DefaultHandler {
         );
 
         (roles[index] as any).permissions = strippedPerms;
+        // `type` is a read-only field (e.g. 'tenant') that the roles create/update
+        // endpoints reject, so omit it from the export to keep the round-trip valid.
+        delete (roles[index] as any).type;
       }
       this.existing = roles;
       return this.existing;

--- a/test/tools/auth0/handlers/roles.tests.js
+++ b/test/tools/auth0/handlers/roles.tests.js
@@ -66,6 +66,7 @@ describe('#roles handler', () => {
             expect(data).to.be.an('object');
             expect(data.name).to.equal('myRole');
             expect(data.description).to.equal('myDescription');
+            expect(data).to.not.have.property('type');
             return Promise.resolve(data);
           },
           update: () => Promise.resolve([]),
@@ -97,6 +98,7 @@ describe('#roles handler', () => {
               name: 'myRole',
               id: 'myRoleId',
               description: 'myDescription',
+              type: 'tenant',
               permissions: [],
             },
           ],
@@ -118,6 +120,7 @@ describe('#roles handler', () => {
                 name: 'myRole',
                 id: 'myRoleId',
                 description: 'myDescription',
+                type: 'tenant',
               },
             ]),
           permissions: {
@@ -261,6 +264,7 @@ describe('#roles handler', () => {
             expect(data).to.be.an('object');
             expect(data.name).to.equal('myRole');
             expect(data.description).to.equal('myDescription');
+            expect(data).to.not.have.property('type');
 
             return Promise.resolve(data);
           },
@@ -306,6 +310,7 @@ describe('#roles handler', () => {
               name: 'myRole',
               id: 'myRoleId',
               description: 'myDescription',
+              type: 'tenant',
               permissions: [
                 {
                   permission_name: 'Create:cal_entry',


### PR DESCRIPTION
### 🔧 Changes

Tenant roles could not be round-tripped: `export` → `import` failed with a `400`.

The roles **GET** endpoint returns a read-only `type` field (e.g. `tenant`), but the roles **create/update** endpoints reject it with `Payload validation error: 'Additional properties not allowed: type'`. The handler wrote the exported `type` straight back on import, breaking the round-trip.

This strips `type` in two places in `src/tools/auth0/handlers/roles.ts`:

- **`getType()` (export)** - omit `type` from exported output so new exports stay round-trippable.
- **`createRole()` / `updateRole()` (import write paths)** - strip `type` before calling the API so files that were *already* exported with the field (pre-fix) can still be imported without re-exporting.


#### Shape (export output)

The only shape change is on the **export** side - the `type` field no longer appears on roles. Import accepts both shapes (with or without `type`).

**Before (YAML):**
```yaml
roles:
  - name: Test Role
    description: Role to reproduce the error
    permissions:
      - permission_name: some:perm
        resource_server_identifier: https://example.com/
    type: tenant          # read-only, rejected on import
```

**After (YAML):**
```yaml
roles:
  - name: Test Role
    description: Role to reproduce the error
    permissions:
      - permission_name: some:perm
        resource_server_identifier: https://example.com/
```

**Before (directory JSON - roles/Test Role.json):**
```json
{
  "name": "Test Role",
  "description": "Role to reproduce the error",
  "permissions": [
    {
      "permission_name": "some:perm",
      "resource_server_identifier": "https://example.com/"
    }
  ],
  "type": "tenant"
}
```

**After (Directory JSON - roles/Test Role.json):**
```json
{
  "name": "Test Role",
  "description": "Role to reproduce the error",
  "permissions": [
    {
      "permission_name": "some:perm",
      "resource_server_identifier": "https://example.com/"
    }
  ]
}
```

### 📚 References

- Fixes #1439

### 🔬 Testing

- **Unit tests** (`test/tools/auth0/handlers/roles.tests.js`): assert `type` never reaches the `roles.create`/`roles.update` payloads, and that it is stripped from `getType()` output.
- **Live tenant** (dev): verified `export -f yaml` produces roles with no `type` field; re-importing that export succeeds. Also injected `type: tenant` into an export file (simulating a pre-fix file) and confirmed it now imports cleanly - while the same file reproduces the original `400` on `master`.
- Full regression: auth0 handler suite (680) and context handler suite (411) pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A) - N/A, no public API or config surface change

---