### PR TITLE
fix: exclude org-scoped roles from tenant export by filtering type='tenant'

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@clack/prompts": "1.4.0",
     "ajv": "^6.12.6",
-    "auth0": "^6.1.0",
+    "auth0": "^6.2.0",
     "chalk": "5.6.2",
     "dot-prop": "^5.3.0",
     "fs-extra": "^10.1.0",

--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -497,8 +497,25 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       return connection;
     });
 
+    // A connection can return both legacy password fields and `password_options` on read, but
+    // they're mutually exclusive on write. Strip the legacy fields to keep the export deployable.
+    const dbConnectionsNormalized = dbConnectionsWithActionNames.map((connection) => {
+      if (connection.options && 'password_options' in connection.options) {
+        const {
+          passwordPolicy,
+          password_complexity_options,
+          password_history,
+          password_no_personal_info,
+          password_dictionary,
+          ...options
+        } = connection.options as Record<string, unknown>;
+        return { ...connection, options };
+      }
+      return connection;
+    });
+
     // If options option is empty for all connection, log the missing options scope.
-    const isOptionExists = dbConnectionsWithActionNames.every(
+    const isOptionExists = dbConnectionsNormalized.every(
       (c) => c.options && Object.keys(c.options).length > 0
     );
     if (!isOptionExists) {
@@ -507,7 +524,7 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       );
     }
 
-    this.existing = dbConnectionsWithActionNames;
+    this.existing = dbConnectionsNormalized;
 
     return this.existing;
   }

--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -149,9 +149,12 @@ export default class RolesHandler extends DefaultHandler {
     }
 
     try {
+      // Only manage tenant-level roles; exclude org-scoped roles surfaced when
+      // the api2_org_level_roles_ea flag is enabled.
       const roles = await paginate<Role>(this.client.roles.list, {
         paginate: true,
         include_totals: true,
+        type: 'tenant',
       });
 
       for (let index = 0; index < roles.length; index++) {

--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -14,6 +14,7 @@ export const schema = {
       name: { type: 'string' },
       id: { type: 'string' },
       description: { type: 'string' },
+      type: { type: 'string', enum: ['tenant', 'organization'] },
       permissions: {
         type: 'array',
         items: {
@@ -110,6 +111,7 @@ export default class RolesHandler extends DefaultHandler {
 
     delete data.permissions;
     delete data.id;
+    delete data.type; // immutable; set at creation only, never send on update
 
     await this.client.roles.update(params.id, data);
 

--- a/src/tools/auth0/handlers/roles.ts
+++ b/src/tools/auth0/handlers/roles.ts
@@ -45,8 +45,8 @@ export default class RolesHandler extends DefaultHandler {
   async createRole(data): Promise<Asset> {
     const role = { ...data };
     delete role.permissions;
-    // `type` is a read-only field returned by the roles GET endpoint but rejected
-    // by the roles create/update endpoints. Strip it to keep exports round-trippable.
+    // deploy-cli only manages tenant-level roles, so `type` is stripped on write; it
+    // defaults to `tenant` on create. This keeps exports (which carry `type`) round-trippable.
     delete role.type;
 
     const created = await this.client.roles.create(role);
@@ -114,8 +114,8 @@ export default class RolesHandler extends DefaultHandler {
 
     delete data.permissions;
     delete data.id;
-    // `type` is read-only on the roles GET endpoint and rejected by update; strip it
-    // so files that already contain it (from a prior export) can still be imported.
+    // deploy-cli only manages tenant-level roles, so `type` is stripped on write; this
+    // lets files that already carry it (from a prior export) be imported cleanly.
     delete data.type;
 
     await this.client.roles.update(params.id, data);
@@ -211,9 +211,6 @@ export default class RolesHandler extends DefaultHandler {
         );
 
         (roles[index] as any).permissions = strippedPerms;
-        // `type` is a read-only field (e.g. 'tenant') that the roles create/update
-        // endpoints reject, so omit it from the export to keep the round-trip valid.
-        delete (roles[index] as any).type;
       }
       this.existing = roles;
       return this.existing;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ type SharedPaginationParams = {
   include_totals?: boolean;
   id?: string;
   strategy?: Management.ConnectionStrategyEnum[];
+  type?: Management.RoleTypeEnum;
 };
 
 export type CheckpointPaginationParams = SharedPaginationParams & {

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -122,7 +122,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -175,7 +175,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -228,7 +228,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -279,7 +279,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -292,7 +292,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -339,7 +339,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -392,7 +433,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -406,47 +447,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -493,7 +493,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -551,7 +551,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -575,7 +575,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa/credentials",
+        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -585,7 +585,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb/credentials",
+        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -595,7 +595,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx/credentials",
+        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -605,7 +605,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM/credentials",
+        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -615,7 +615,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi/credentials",
+        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -625,7 +625,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K/credentials",
+        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -1907,6 +1907,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -2043,7 +2075,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2096,7 +2128,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2149,7 +2181,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2200,7 +2232,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -2213,7 +2245,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -2260,7 +2292,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2313,7 +2386,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2327,47 +2400,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2414,7 +2446,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2472,7 +2504,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2496,18 +2528,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+                "id": "cred_d7qeana2JAao683Q2XUikK",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-17T06:07:17.374Z",
-                "updated_at": "2026-07-17T06:07:17.374Z"
+                "created_at": "2026-08-05T18:57:12.277Z",
+                "updated_at": "2026-08-05T18:57:12.277Z"
             }
         ],
         "rawHeaders": [],
@@ -2516,7 +2548,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
         "body": "",
         "status": 204,
         "response": "",
@@ -2526,7 +2558,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+        "path": "/api/v2/clients/luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
         "body": "",
         "status": 204,
         "response": "",
@@ -2536,7 +2568,107 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+        "body": {
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -2617,7 +2749,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                            "id": "cred_d7qeana2JAao683Q2XUikK"
                         }
                     ]
                 }
@@ -2630,7 +2762,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -2654,107 +2786,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
-        "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
         "body": {
             "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
@@ -2815,7 +2847,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+            "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2836,7 +2868,83 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -2929,7 +3037,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+            "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2956,83 +3064,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
         "body": {
             "name": "The Default App",
             "allowed_clients": [],
@@ -3114,7 +3146,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+            "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3138,7 +3170,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
         "body": {
             "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
@@ -3216,7 +3248,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+            "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3231,6 +3263,20 @@
                 "client_credentials"
             ],
             "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3266,20 +3312,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": true
@@ -3294,7 +3326,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -3322,7 +3354,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -3336,7 +3368,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -3420,6 +3452,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -3469,34 +3529,6 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/network-acls?page=0&per_page=100&include_totals=true",
         "body": "",
@@ -3522,7 +3554,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:06:58.205Z",
+                    "updated_at": "2026-08-05T18:56:55.136Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -3567,7 +3599,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-17T06:10:14.781Z",
+            "updated_at": "2026-08-05T18:58:39.345Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -3740,7 +3772,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3748,34 +3780,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3796,7 +3828,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0",
+        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -3812,7 +3844,7 @@
         },
         "status": 200,
         "response": {
-            "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+            "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -3820,34 +3852,34 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-07-17T06:06:59.806952575Z",
-            "updated_at": "2026-07-17T06:10:16.892278365Z",
+            "created_at": "2026-08-05T18:56:56.983801987Z",
+            "updated_at": "2026-08-05T18:58:41.315788603Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
             "status": "pending",
             "secrets": [],
             "current_version": {
-                "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "runtime": "node18",
                 "status": "BUILT",
                 "number": 1,
-                "build_time": "2026-07-17T06:07:00.515637114Z",
-                "created_at": "2026-07-17T06:07:00.450141003Z",
-                "updated_at": "2026-07-17T06:07:00.516137765Z"
+                "build_time": "2026-08-05T18:56:57.736560561Z",
+                "created_at": "2026-08-05T18:56:57.654938301Z",
+                "updated_at": "2026-08-05T18:56:57.737733915Z"
             },
             "deployed_version": {
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "dependencies": [],
-                "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                 "deployed": true,
                 "number": 1,
-                "built_at": "2026-07-17T06:07:00.515637114Z",
+                "built_at": "2026-08-05T18:56:57.736560561Z",
                 "secrets": [],
                 "status": "built",
-                "created_at": "2026-07-17T06:07:00.450141003Z",
-                "updated_at": "2026-07-17T06:07:00.516137765Z",
+                "created_at": "2026-08-05T18:56:57.654938301Z",
+                "updated_at": "2026-08-05T18:56:57.737733915Z",
                 "runtime": "node18",
                 "supported_triggers": [
                     {
@@ -3870,7 +3902,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3878,34 +3910,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:58:41.315788603Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3926,19 +3958,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0/deploy",
+        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+            "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
             "deployed": false,
             "number": 2,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-07-17T06:10:17.960682631Z",
-            "updated_at": "2026-07-17T06:10:17.960682631Z",
+            "created_at": "2026-08-05T18:58:41.994374412Z",
+            "updated_at": "2026-08-05T18:58:41.994374412Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -3947,7 +3979,7 @@
                 }
             ],
             "action": {
-                "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -3955,8 +3987,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-07-17T06:06:59.806952575Z",
-                "updated_at": "2026-07-17T06:10:16.883478043Z",
+                "created_at": "2026-08-05T18:56:56.983801987Z",
+                "updated_at": "2026-08-05T18:58:41.307216862Z",
                 "all_changes_deployed": false
             }
         },
@@ -3972,7 +4004,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3980,34 +4012,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:58:41.315788603Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-17T06:10:18.049664680Z",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                        "build_time": "2026-08-05T18:58:42.074685776Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "built_at": "2026-08-05T18:58:42.074685776Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -4028,13 +4060,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4059,6 +4091,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -4099,12 +4163,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4254,7 +4318,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4305,7 +4369,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -4318,7 +4382,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -4365,7 +4429,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4418,7 +4523,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4432,47 +4537,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4519,7 +4583,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4577,7 +4641,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4646,7 +4710,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4654,34 +4718,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:58:41.315788603Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-17T06:10:18.049664680Z",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                        "build_time": "2026-08-05T18:58:42.074685776Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "built_at": "2026-08-05T18:58:42.074685776Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -4702,13 +4766,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4733,6 +4797,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -4773,12 +4869,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4828,7 +4924,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -4844,16 +4940,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                 },
                 {
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
                 }
             ]
         },
@@ -4863,11 +4959,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-17T06:10:19.167Z"
+            "deleted_at": "2026-08-05T18:58:43.559Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4875,11 +4971,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_a2fdGQjZWlOIaBqp",
+            "id": "con_3a5w9rUEBfXfZnSs",
             "options": {
                 "mfa": {
                     "active": true,
@@ -4904,6 +5000,38 @@
                 "password_history": {
                     "size": 5,
                     "enable": false
+                },
+                "password_options": {
+                    "history": {
+                        "size": 3,
+                        "active": false
+                    },
+                    "complexity": {
+                        "min_length": 15,
+                        "character_types": [],
+                        "character_type_rule": "all",
+                        "max_length_exceeded": "error",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow"
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    }
                 },
                 "strategy_version": 2,
                 "requires_username": true,
@@ -4941,8 +5069,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -4954,7 +5082,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -5014,7 +5142,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_a2fdGQjZWlOIaBqp",
+            "id": "con_3a5w9rUEBfXfZnSs",
             "options": {
                 "mfa": {
                     "active": true,
@@ -5076,8 +5204,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -5189,7 +5317,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5240,7 +5368,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -5253,7 +5381,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -5300,7 +5428,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5353,7 +5522,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5367,47 +5536,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -5454,7 +5582,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5512,7 +5640,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5575,13 +5703,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5646,12 +5774,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5673,8 +5801,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 }
             ]
@@ -5700,13 +5828,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5771,12 +5899,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5798,8 +5926,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 }
             ]
@@ -5810,16 +5938,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                 },
                 {
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
                 }
             ]
         },
@@ -5829,7 +5957,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
         "body": {
             "is_domain_connection": false,
             "options": {
@@ -5843,7 +5971,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_u0jv1SLcz6oa6DT8",
+            "id": "con_wXkTr1DrHw8CrHg1",
             "options": {
                 "email": true,
                 "scope": [
@@ -5862,8 +5990,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
             ],
             "realms": [
                 "google-oauth2"
@@ -6012,7 +6140,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6063,7 +6191,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -6076,7 +6204,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -6123,7 +6251,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6176,7 +6345,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6190,47 +6359,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6277,7 +6405,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6335,7 +6463,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6398,14 +6526,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -6542,8 +6670,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -6927,7 +7055,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_QYueTYBZwIArLvJV",
+        "path": "/api/v2/client-grants/cgr_b9Nqc0prQVFMjIhm",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7064,8 +7192,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_QYueTYBZwIArLvJV",
-            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+            "id": "cgr_b9Nqc0prQVFMjIhm",
+            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7207,7 +7335,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_fNVNikQz3aWBSEna",
+        "path": "/api/v2/client-grants/cgr_kaiA3umN6yp9IOm9",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7344,8 +7472,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_fNVNikQz3aWBSEna",
-            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+            "id": "cgr_kaiA3umN6yp9IOm9",
+            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7487,30 +7615,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
             "roles": [
                 {
-                    "id": "rol_mWNhCNG1yuxyzRW0",
+                    "id": "rol_MzpnnGz6d68mbldY",
                     "name": "Admin",
-                    "description": "Can read and write things"
+                    "description": "Can read and write things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_KYekWOWLVpJeVWbL",
+                    "id": "rol_bUvFAw4rOYJNAocU",
                     "name": "Reader",
-                    "description": "Can only read things"
+                    "description": "Can only read things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_TK6bINiThEdD82uJ",
+                    "id": "rol_Ix7SQbb6p2t6dQRg",
                     "name": "read_only",
-                    "description": "Read Only"
+                    "description": "Read Only",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_9k41FO3KxqnRLjSO",
+                    "id": "rol_C6IFQdUiqeNqfYe3",
                     "name": "read_osnly",
-                    "description": "Readz Only"
+                    "description": "Readz Only",
+                    "type": "tenant"
                 }
             ],
             "start": 0,
@@ -7523,7 +7655,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7538,7 +7670,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7553,7 +7685,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7568,7 +7700,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7583,16 +7715,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY",
         "body": {
             "name": "Admin",
             "description": "Can read and write things"
         },
         "status": 200,
         "response": {
-            "id": "rol_mWNhCNG1yuxyzRW0",
+            "id": "rol_MzpnnGz6d68mbldY",
             "name": "Admin",
-            "description": "Can read and write things"
+            "description": "Can read and write things",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7600,16 +7733,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_KYekWOWLVpJeVWbL",
+            "id": "rol_bUvFAw4rOYJNAocU",
             "name": "Reader",
-            "description": "Can only read things"
+            "description": "Can only read things",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7617,16 +7751,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg",
         "body": {
             "name": "read_only",
             "description": "Read Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_TK6bINiThEdD82uJ",
+            "id": "rol_Ix7SQbb6p2t6dQRg",
             "name": "read_only",
-            "description": "Read Only"
+            "description": "Read Only",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7634,16 +7769,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_9k41FO3KxqnRLjSO",
+            "id": "rol_C6IFQdUiqeNqfYe3",
             "name": "read_osnly",
-            "description": "Readz Only"
+            "description": "Readz Only",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7677,7 +7813,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:07:13.803Z",
+                    "updated_at": "2026-08-05T18:57:08.272Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7753,7 +7889,7 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-17T06:10:27.587Z",
+            "updated_at": "2026-08-05T18:58:51.655Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
@@ -7820,13 +7956,499 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "total": 9,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "client_authentication_methods": {
+                        "private_key_jwt": {
+                            "credentials": [
+                                {
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                }
+                            ]
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "callback_url_template": false,
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com",
+                        "mr|google-oauth2|109614534713742077035",
+                        "mr|google-oauth2|116771660953104383819",
+                        "mr|google-oauth2|112839029247827700155",
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "cross_origin_authentication": true,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "organizations": [
                 {
-                    "id": "org_qdYzZeCFDLEiVOCL",
+                    "id": "org_U7hHFWA8LmetETGu",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -7835,13 +8457,209 @@
                             "primary": "#57ddff"
                         }
                     },
-                    "third_party_client_access": "block"
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
                 },
                 {
-                    "id": "org_o0aVwomUlzXKMyv5",
+                    "id": "org_KvyIU8ipa4KpyL0n",
                     "name": "org2",
                     "display_name": "Organization2",
-                    "third_party_client_access": "block"
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [],
+            "start": 0,
+            "limit": 50,
+            "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "client_grants": [],
+            "start": 0,
+            "limit": 50,
+            "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [],
+            "start": 0,
+            "limit": 50,
+            "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "client_grants": [],
+            "start": 0,
+            "limit": 50,
+            "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": [
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    ]
+                },
+                {
+                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": [
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    ]
                 }
             ]
         },
@@ -7951,7 +8769,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8002,7 +8820,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -8015,7 +8833,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -8062,7 +8880,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8115,7 +8974,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8129,47 +8988,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8216,7 +9034,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8274,7 +9092,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8337,208 +9155,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_a2fdGQjZWlOIaBqp",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
-                    ]
-                },
-                {
-                    "id": "con_u0jv1SLcz6oa6DT8",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -8675,8 +9299,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -9059,494 +9683,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 9,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
-                                }
-                            ]
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                    "callback_url_template": false,
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com",
-                        "mr|google-oauth2|109614534713742077035",
-                        "mr|google-oauth2|116771660953104383819",
-                        "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com",
-                        "mr|google-oauth2|113227425378005249939",
-                        "mr|google-oauth2|111201688215901175487"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "cross_origin_authentication": true,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu",
         "body": {
             "branding": {
                 "colors": {
@@ -9564,10 +9702,11 @@
                     "primary": "#57ddff"
                 }
             },
-            "id": "org_qdYzZeCFDLEiVOCL",
+            "id": "org_U7hHFWA8LmetETGu",
             "display_name": "Organization",
             "name": "org1",
-            "third_party_client_access": "block"
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9575,16 +9714,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n",
         "body": {
             "display_name": "Organization2"
         },
         "status": 200,
         "response": {
-            "id": "org_o0aVwomUlzXKMyv5",
+            "id": "org_KvyIU8ipa4KpyL0n",
             "display_name": "Organization2",
             "name": "org2",
-            "third_party_client_access": "block"
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9597,7 +9737,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029822",
+                "id": "lst_0000000000030152",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -9608,14 +9748,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029823",
+                "id": "lst_0000000000030153",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
                 },
                 "filters": [
                     {
@@ -9664,7 +9804,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000029822",
+        "path": "/api/v2/log-streams/lst_0000000000030152",
         "body": {
             "name": "Suspended DD Log Stream",
             "sink": {
@@ -9674,7 +9814,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029822",
+            "id": "lst_0000000000030152",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -9690,7 +9830,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000029823",
+        "path": "/api/v2/log-streams/lst_0000000000030153",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -9735,14 +9875,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029823",
+            "id": "lst_0000000000030153",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
             },
             "filters": [
                 {
@@ -9890,7 +10030,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9941,7 +10081,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -9954,7 +10094,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -10001,7 +10141,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10054,7 +10235,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10068,47 +10249,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -10155,7 +10295,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10213,7 +10353,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10237,18 +10377,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+                "id": "cred_d7qeana2JAao683Q2XUikK",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-17T06:07:17.374Z",
-                "updated_at": "2026-07-17T06:07:17.374Z"
+                "created_at": "2026-08-05T18:57:12.277Z",
+                "updated_at": "2026-08-05T18:57:12.277Z"
             }
         ],
         "rawHeaders": [],
@@ -10257,13 +10397,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                            "id": "cred_d7qeana2JAao683Q2XUikK"
                         }
                     ]
                 }
@@ -10306,7 +10446,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                            "id": "cred_d7qeana2JAao683Q2XUikK"
                         }
                     ]
                 }
@@ -10319,7 +10459,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -10349,7 +10489,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10357,34 +10497,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:58:41.315788603Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-17T06:10:18.049664680Z",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                        "build_time": "2026-08-05T18:58:42.074685776Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "built_at": "2026-08-05T18:58:42.074685776Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -10423,7 +10563,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:07:18.621Z",
+                    "updated_at": "2026-08-05T18:57:13.648Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -10479,7 +10619,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-17T06:10:33.528Z",
+            "updated_at": "2026-08-05T18:58:58.445Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -10525,7 +10665,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-17T06:07:22.179Z"
+                    "updated_at": "2026-08-05T18:57:17.452Z"
                 }
             ]
         },
@@ -10611,7 +10751,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:07:22.179Z"
+            "updated_at": "2026-08-05T18:57:17.452Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10751,7 +10891,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:10:37.024Z"
+            "updated_at": "2026-08-05T18:59:02.351Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10993,7 +11133,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11044,7 +11184,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -11057,7 +11197,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11104,7 +11244,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11157,7 +11338,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11171,47 +11352,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11258,7 +11398,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11316,7 +11456,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12431,6 +12571,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -12577,7 +12749,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12628,7 +12800,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -12641,7 +12813,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12688,7 +12860,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12741,7 +12954,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12755,47 +12968,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -12842,7 +13014,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12900,7 +13072,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12924,18 +13096,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+                "id": "cred_d7qeana2JAao683Q2XUikK",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-17T06:07:17.374Z",
-                "updated_at": "2026-07-17T06:07:17.374Z"
+                "created_at": "2026-08-05T18:57:12.277Z",
+                "updated_at": "2026-08-05T18:57:12.277Z"
             }
         ],
         "rawHeaders": [],
@@ -12944,7 +13116,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
         "body": "",
         "status": 204,
         "response": "",
@@ -12954,7 +13126,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
         "body": "",
         "status": 204,
         "response": "",
@@ -12964,7 +13136,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
         "body": "",
         "status": 204,
         "response": "",
@@ -12974,7 +13146,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
         "body": "",
         "status": 204,
         "response": "",
@@ -12984,7 +13156,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
         "body": "",
         "status": 204,
         "response": "",
@@ -12994,7 +13166,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
         "body": "",
         "status": 204,
         "response": "",
@@ -13004,7 +13176,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
         "body": "",
         "status": 204,
         "response": "",
@@ -13075,7 +13247,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+            "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -13111,20 +13283,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
@@ -13139,7 +13297,35 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -13182,20 +13368,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -13275,34 +13447,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -13350,6 +13494,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/actions/modules?page=0&per_page=100",
         "body": "",
@@ -13372,7 +13544,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -13380,34 +13552,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:10:16.892278365Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:58:41.315788603Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-07-17T06:10:18.049664680Z",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z"
+                        "build_time": "2026-08-05T18:58:42.074685776Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "adcfafa8-ab57-4913-a116-3f48c8aa734f",
+                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-07-17T06:10:18.049664680Z",
+                        "built_at": "2026-08-05T18:58:42.074685776Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:10:17.960682631Z",
-                        "updated_at": "2026-07-17T06:10:18.050629481Z",
+                        "created_at": "2026-08-05T18:58:41.994374412Z",
+                        "updated_at": "2026-08-05T18:58:42.076111094Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -13428,7 +13600,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0?force=true",
+        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d?force=true",
         "body": "",
         "status": 204,
         "response": "",
@@ -13541,7 +13713,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13617,13 +13789,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13710,13 +13882,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13790,7 +13962,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13802,11 +13974,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-17T06:10:48.753Z"
+            "deleted_at": "2026-08-05T18:59:15.687Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13835,7 +14007,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_GCIw7tDhSMeiCyeZ",
+            "id": "con_tWXLXEcrqENnFdJ2",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13845,6 +14017,38 @@
                 "strategy_version": 2,
                 "brute_force_protection": true,
                 "disable_self_service_change_password": false,
+                "password_options": {
+                    "complexity": {
+                        "character_type_rule": "all",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow",
+                        "max_length_exceeded": "error",
+                        "min_length": 15,
+                        "character_types": []
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    },
+                    "history": {
+                        "active": false,
+                        "size": 3
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    }
+                },
                 "authentication_methods": {
                     "password": {
                         "enabled": true,
@@ -13881,13 +14085,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=1&name=Username-Password-Authentication&include_fields=true",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=Username-Password-Authentication&include_fields=true",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13898,6 +14102,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -13935,14 +14171,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients",
+        "path": "/api/v2/connections/con_tWXLXEcrqENnFdJ2/clients",
         "body": [
             {
                 "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                 "status": true
             },
             {
-                "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                 "status": true
             }
         ],
@@ -14044,7 +14280,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14107,13 +14343,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14137,7 +14373,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14148,6 +14384,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -14177,7 +14445,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                     ]
                 }
             ]
@@ -14203,13 +14471,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14233,7 +14501,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14244,6 +14512,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -14273,7 +14573,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                     ]
                 }
             ]
@@ -14284,7 +14584,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -14296,11 +14596,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-07-17T06:10:54.004Z"
+            "deleted_at": "2026-08-05T18:59:21.264Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -14432,7 +14732,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14495,7 +14795,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -14748,30 +15048,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
             "roles": [
                 {
-                    "id": "rol_mWNhCNG1yuxyzRW0",
+                    "id": "rol_MzpnnGz6d68mbldY",
                     "name": "Admin",
-                    "description": "Can read and write things"
+                    "description": "Can read and write things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_KYekWOWLVpJeVWbL",
+                    "id": "rol_bUvFAw4rOYJNAocU",
                     "name": "Reader",
-                    "description": "Can only read things"
+                    "description": "Can only read things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_TK6bINiThEdD82uJ",
+                    "id": "rol_Ix7SQbb6p2t6dQRg",
                     "name": "read_only",
-                    "description": "Read Only"
+                    "description": "Read Only",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_9k41FO3KxqnRLjSO",
+                    "id": "rol_C6IFQdUiqeNqfYe3",
                     "name": "read_osnly",
-                    "description": "Readz Only"
+                    "description": "Readz Only",
+                    "type": "tenant"
                 }
             ],
             "start": 0,
@@ -14784,7 +15088,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14799,7 +15103,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14814,7 +15118,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14829,7 +15133,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -14844,7 +15148,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY",
         "body": "",
         "status": 200,
         "response": {},
@@ -14854,7 +15158,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU",
         "body": "",
         "status": 200,
         "response": {},
@@ -14864,7 +15168,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg",
         "body": "",
         "status": 200,
         "response": {},
@@ -14874,41 +15178,10 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3",
         "body": "",
         "status": 200,
         "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": [
-                {
-                    "id": "org_qdYzZeCFDLEiVOCL",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_o0aVwomUlzXKMyv5",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                }
-            ]
-        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -15005,7 +15278,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15068,7 +15341,40 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": [
+                {
+                    "id": "org_U7hHFWA8LmetETGu",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    },
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_KvyIU8ipa4KpyL0n",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15083,7 +15389,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15098,7 +15404,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15110,7 +15416,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15125,7 +15431,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15140,7 +15446,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15152,13 +15458,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15169,6 +15475,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -15198,7 +15536,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                     ]
                 }
             ]
@@ -15209,7 +15547,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15552,7 +15890,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15615,7 +15953,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu",
         "body": "",
         "status": 204,
         "response": "",
@@ -15625,7 +15963,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n",
         "body": "",
         "status": 204,
         "response": "",
@@ -15640,7 +15978,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029822",
+                "id": "lst_0000000000030152",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -15651,14 +15989,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029823",
+                "id": "lst_0000000000030153",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
                 },
                 "filters": [
                     {
@@ -15707,7 +16045,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000029822",
+        "path": "/api/v2/log-streams/lst_0000000000030152",
         "body": "",
         "status": 204,
         "response": "",
@@ -15717,7 +16055,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000029823",
+        "path": "/api/v2/log-streams/lst_0000000000030153",
         "body": "",
         "status": 204,
         "response": "",
@@ -17040,6 +17378,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -17176,7 +17546,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17200,13 +17570,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17217,6 +17587,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -17246,7 +17648,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                     ]
                 }
             ]
@@ -17270,16 +17672,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/connections/con_tWXLXEcrqENnFdJ2/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 },
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                 }
             ]
         },
@@ -17289,13 +17691,28 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections-directory-provisionings?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:directory_provisionings",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_tWXLXEcrqENnFdJ2",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17306,6 +17723,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -17335,25 +17784,10 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
                     ]
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections-directory-provisionings?take=50",
-        "body": "",
-        "status": 403,
-        "response": {
-            "statusCode": 403,
-            "error": "Forbidden",
-            "message": "Insufficient scope, expected any of: read:directory_provisionings",
-            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -17449,21 +17883,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -17482,37 +17901,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -17561,67 +17980,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
         "response": {
@@ -17651,7 +18010,82 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -17955,7 +18389,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
         "response": {},
@@ -17965,7 +18399,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/sms/providers/twilio",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
         "body": "",
         "status": 200,
         "response": {},
@@ -18022,7 +18456,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
@@ -18083,7 +18517,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T13:25:18.228Z"
+                    "updated_at": "2026-07-17T06:13:20.998Z"
                 }
             ]
         },
@@ -18099,13 +18533,29 @@
         "response": {
             "templates": [
                 {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-07-17T06:13:22.584Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T13:25:19.811Z",
+                    "updated_at": "2026-07-17T06:13:22.508Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18121,28 +18571,12 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T13:25:19.812Z",
+                    "updated_at": "2026-07-17T06:13:22.506Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T13:25:19.898Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
                 },
@@ -18153,7 +18587,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T13:25:20.111Z",
+                    "updated_at": "2026-07-17T06:13:22.815Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18267,7 +18701,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18277,7 +18711,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18337,16 +18771,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
@@ -18357,7 +18781,27 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18387,16 +18831,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/customized-consent/custom-text/en",
         "body": "",
         "status": 200,
@@ -18417,27 +18851,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18477,6 +18901,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-email/custom-text/en",
         "body": "",
         "status": 200,
@@ -18497,7 +18931,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18517,7 +18951,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18577,6 +19011,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/passkeys/custom-text/en",
         "body": "",
         "status": 200,
@@ -18588,16 +19032,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/captcha/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18627,16 +19061,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/partials",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-passwordless/partials",
         "body": "",
         "status": 200,
@@ -18657,7 +19081,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/login-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -18668,6 +19092,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/signup-password/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -18846,6 +19280,17 @@
                 },
                 {
                     "id": "post-change-password",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-change-password",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -18853,17 +19298,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-change-password",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19148,7 +19582,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -19250,7 +19684,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19313,6 +19747,25 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
@@ -19329,25 +19782,6 @@
                     "shields": []
                 }
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19438,11 +19872,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "remember_for": 30
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19450,11 +19884,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19497,6 +19931,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -19510,24 +19959,9 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-17T06:10:37.024Z"
+                    "updated_at": "2026-08-05T18:59:02.351Z"
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19596,7 +20030,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:10:37.024Z"
+            "updated_at": "2026-08-05T18:59:02.351Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19675,7 +20109,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:10:27.587Z",
+                    "updated_at": "2026-08-05T18:58:51.655Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -19727,7 +20161,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:10:14.781Z",
+                    "updated_at": "2026-08-05T18:58:39.345Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -19878,7 +20312,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:10:33.528Z",
+                    "updated_at": "2026-08-05T18:58:58.445Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {

--- a/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
+++ b/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
@@ -194,8 +194,7 @@
                 "html": "<html>Change Password</html>\n"
             },
             "enabled_locales": [
-                "en",
-                "es"
+                "en"
             ],
             "error_page": {
                 "html": "<html>Error Page</html>\n",
@@ -1305,6 +1304,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -1441,7 +1472,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1494,7 +1525,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1511,6 +1542,109 @@
                     "custom_login_page_on": true
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "app_type": "non_interactive",
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "API Explorer Application",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -1606,7 +1740,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1633,12 +1767,11 @@
         "method": "POST",
         "path": "/api/v2/clients",
         "body": {
-            "name": "API Explorer Application",
-            "allowed_clients": [],
+            "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
+            "client_metadata": {
+                "foo": "bar"
+            },
             "cross_origin_authentication": false,
             "custom_login_page_on": true,
             "grant_types": [
@@ -1650,14 +1783,6 @@
                 "alg": "RS256",
                 "lifetime_in_seconds": 36000,
                 "secret_encoded": false
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
             },
             "oidc_conformant": true,
             "refresh_token": {
@@ -1677,20 +1802,12 @@
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
             "is_token_endpoint_ip_header_trusted": false,
-            "name": "API Explorer Application",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
+            "name": "Quickstarts API (Test Application)",
+            "client_metadata": {
+                "foo": "bar"
+            },
             "cross_origin_authentication": false,
             "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
             "oidc_conformant": true,
             "refresh_token": {
                 "expiration_type": "non-expiring",
@@ -1712,7 +1829,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+            "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1720,7 +1837,6 @@
                 "lifetime_in_seconds": 36000,
                 "secret_encoded": false
             },
-            "client_aliases": [],
             "token_endpoint_auth_method": "client_secret_post",
             "app_type": "non_interactive",
             "grant_types": [
@@ -1736,11 +1852,8 @@
         "method": "POST",
         "path": "/api/v2/clients",
         "body": {
-            "name": "Quickstarts API (Test Application)",
+            "name": "Terraform Provider",
             "app_type": "non_interactive",
-            "client_metadata": {
-                "foo": "bar"
-            },
             "cross_origin_authentication": false,
             "custom_login_page_on": true,
             "grant_types": [
@@ -1771,10 +1884,7 @@
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
             "is_token_endpoint_ip_header_trusted": false,
-            "name": "Quickstarts API (Test Application)",
-            "client_metadata": {
-                "foo": "bar"
-            },
+            "name": "Terraform Provider",
             "cross_origin_authentication": false,
             "is_first_party": true,
             "oidc_conformant": true,
@@ -1798,7 +1908,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1904,7 +2014,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+            "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1918,85 +2028,6 @@
                 "authorization_code",
                 "implicit",
                 "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/clients",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 201,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "encrypted": true,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "key": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
                 "client_credentials"
             ],
             "custom_login_page_on": true
@@ -2103,7 +2134,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+            "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2211,7 +2242,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+            "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2233,7 +2264,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
         },
@@ -2261,21 +2292,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -2317,7 +2334,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -2332,6 +2349,20 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
@@ -2517,7 +2548,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-10T07:03:31.872Z",
+                    "updated_at": "2026-07-17T06:13:14.009Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -2562,7 +2593,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-17T06:06:58.205Z",
+            "updated_at": "2026-08-05T18:56:55.136Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -2758,7 +2789,7 @@
         },
         "status": 201,
         "response": {
-            "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+            "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -2766,8 +2797,8 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-07-17T06:06:59.806952575Z",
-            "updated_at": "2026-07-17T06:06:59.821829361Z",
+            "created_at": "2026-08-05T18:56:56.983801987Z",
+            "updated_at": "2026-08-05T18:56:56.991550383Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
@@ -2787,7 +2818,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -2795,8 +2826,8 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
@@ -2814,19 +2845,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/6aafc9ae-906a-47db-8e47-72529eb143d0/deploy",
+        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+            "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
             "deployed": false,
             "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-07-17T06:07:00.450141003Z",
-            "updated_at": "2026-07-17T06:07:00.450141003Z",
+            "created_at": "2026-08-05T18:56:57.654938301Z",
+            "updated_at": "2026-08-05T18:56:57.654938301Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -2835,7 +2866,7 @@
                 }
             ],
             "action": {
-                "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -2843,8 +2874,8 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-07-17T06:06:59.806952575Z",
-                "updated_at": "2026-07-17T06:06:59.806952575Z",
+                "created_at": "2026-08-05T18:56:56.983801987Z",
+                "updated_at": "2026-08-05T18:56:56.983801987Z",
                 "all_changes_deployed": false
             }
         },
@@ -2854,75 +2885,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2962,10 +2931,72 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3063,7 +3094,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3116,7 +3147,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3169,7 +3200,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3224,7 +3255,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3272,7 +3303,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3325,7 +3397,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3339,47 +3411,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3426,7 +3457,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3484,7 +3515,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3553,7 +3584,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3561,34 +3592,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3609,13 +3640,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3655,7 +3686,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -3666,16 +3697,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 }
             ]
         },
@@ -3732,13 +3763,12 @@
         },
         "status": 201,
         "response": {
-            "id": "con_a2fdGQjZWlOIaBqp",
+            "id": "con_3a5w9rUEBfXfZnSs",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "low",
                 "import_mode": false,
                 "customScripts": {
                     "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
@@ -3749,6 +3779,7 @@
                     "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
                 },
                 "disable_signup": false,
+                "passwordPolicy": "low",
                 "password_history": {
                     "size": 5,
                     "enable": false
@@ -3768,6 +3799,38 @@
                 },
                 "enabledDatabaseCustomization": true,
                 "disable_self_service_change_password": false,
+                "password_options": {
+                    "complexity": {
+                        "character_type_rule": "all",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow",
+                        "max_length_exceeded": "error",
+                        "min_length": 15,
+                        "character_types": []
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    },
+                    "history": {
+                        "active": false,
+                        "size": 3
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    }
+                },
                 "authentication_methods": {
                     "password": {
                         "enabled": true,
@@ -3804,13 +3867,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=1&name=boo-baz-db-connection-test&include_fields=true",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=boo-baz-db-connection-test&include_fields=true",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3835,6 +3898,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -3884,14 +3979,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients",
         "body": [
             {
-                "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                 "status": true
             },
             {
-                "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                 "status": true
             }
         ],
@@ -3993,7 +4088,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4046,7 +4141,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4099,7 +4194,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4154,7 +4249,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4202,7 +4297,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4255,7 +4391,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4269,47 +4405,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4356,7 +4451,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4414,7 +4509,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4477,13 +4572,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4508,6 +4603,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -4548,12 +4675,39 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    ]
+                },
+                {
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4593,7 +4747,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -4619,13 +4773,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4650,6 +4804,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -4690,12 +4876,39 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    ]
+                },
+                {
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4735,7 +4948,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -4745,11 +4958,28 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/connections",
+        "method": "GET",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "clients": [
+                {
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                },
+                {
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
         "body": {
-            "name": "google-oauth2",
-            "strategy": "google-oauth2",
             "is_domain_connection": false,
             "options": {
                 "email": true,
@@ -4760,9 +4990,9 @@
                 "profile": true
             }
         },
-        "status": 201,
+        "status": 200,
         "response": {
-            "id": "con_u0jv1SLcz6oa6DT8",
+            "id": "con_wXkTr1DrHw8CrHg1",
             "options": {
                 "email": true,
                 "scope": [
@@ -4780,7 +5010,10 @@
             "connected_accounts": {
                 "active": false
             },
-            "enabled_clients": [],
+            "enabled_clients": [
+                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+            ],
             "realms": [
                 "google-oauth2"
             ]
@@ -4790,53 +5023,24 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=1&name=google-oauth2&include_fields=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_u0jv1SLcz6oa6DT8",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": []
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients",
         "body": [
             {
-                "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                 "status": true
             },
             {
-                "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                 "status": true
+            },
+            {
+                "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                "status": false
+            },
+            {
+                "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                "status": false
             }
         ],
         "status": 204,
@@ -4974,7 +5178,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5027,7 +5231,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5080,7 +5284,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5135,7 +5339,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5183,7 +5387,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5236,7 +5481,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5250,47 +5495,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -5337,7 +5541,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5395,7 +5599,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5458,7 +5662,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -5713,7 +5917,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5850,8 +6054,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_QYueTYBZwIArLvJV",
-            "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+            "id": "cgr_kaiA3umN6yp9IOm9",
+            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -5995,7 +6199,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6132,8 +6336,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_fNVNikQz3aWBSEna",
-            "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+            "id": "cgr_b9Nqc0prQVFMjIhm",
+            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6275,7 +6479,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
@@ -6297,9 +6501,10 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_KYekWOWLVpJeVWbL",
+            "id": "rol_bUvFAw4rOYJNAocU",
             "name": "Reader",
-            "description": "Can only read things"
+            "description": "Can only read things",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6314,9 +6519,10 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_mWNhCNG1yuxyzRW0",
+            "id": "rol_MzpnnGz6d68mbldY",
             "name": "Admin",
-            "description": "Can read and write things"
+            "description": "Can read and write things",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6331,9 +6537,10 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_TK6bINiThEdD82uJ",
+            "id": "rol_Ix7SQbb6p2t6dQRg",
             "name": "read_only",
-            "description": "Read Only"
+            "description": "Read Only",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6348,9 +6555,10 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_9k41FO3KxqnRLjSO",
+            "id": "rol_C6IFQdUiqeNqfYe3",
             "name": "read_osnly",
-            "description": "Readz Only"
+            "description": "Readz Only",
+            "type": "tenant"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6384,7 +6592,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-10T07:03:42.648Z",
+                    "updated_at": "2026-07-17T06:13:21.914Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -6460,40 +6668,12 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-17T06:07:13.803Z",
+            "updated_at": "2026-08-05T18:57:08.272Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
                 }
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "enabled": false,
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600
-        },
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6526,12 +6706,28 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations?take=50",
-        "body": "",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "enabled": false,
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600
+        },
         "status": 200,
         "response": {
-            "organizations": []
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6629,7 +6825,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6682,7 +6878,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6735,7 +6931,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6790,7 +6986,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6838,7 +7034,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6891,7 +7128,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6905,47 +7142,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6992,7 +7188,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7050,7 +7246,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7113,13 +7309,25 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7144,6 +7352,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -7184,12 +7424,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7211,12 +7451,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7256,7 +7496,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -7267,14 +7507,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -7411,8 +7651,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -7886,7 +8126,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7939,7 +8179,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7992,7 +8232,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8047,7 +8287,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8095,7 +8335,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8148,7 +8429,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8162,47 +8443,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8249,7 +8489,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8307,7 +8547,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8383,7 +8623,7 @@
         },
         "status": 201,
         "response": {
-            "id": "org_qdYzZeCFDLEiVOCL",
+            "id": "org_U7hHFWA8LmetETGu",
             "display_name": "Organization",
             "name": "org1",
             "branding": {
@@ -8392,7 +8632,8 @@
                     "primary": "#57ddff"
                 }
             },
-            "third_party_client_access": "block"
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8407,10 +8648,11 @@
         },
         "status": 201,
         "response": {
-            "id": "org_o0aVwomUlzXKMyv5",
+            "id": "org_KvyIU8ipa4KpyL0n",
             "display_name": "Organization2",
             "name": "org2",
-            "third_party_client_access": "block"
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8439,7 +8681,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029822",
+            "id": "lst_0000000000030152",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -8504,14 +8746,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000029823",
+            "id": "lst_0000000000030153",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
             },
             "filters": [
                 {
@@ -8649,7 +8891,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8702,7 +8944,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8755,7 +8997,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8810,7 +9052,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8858,7 +9100,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8911,7 +9194,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8925,47 +9208,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -9012,7 +9254,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9070,7 +9312,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9094,7 +9336,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -9104,7 +9346,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": {
             "name": "e2e-test-key",
             "pem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs8/9RN2qV8HZMunRt8mx\nihqnIX726YqxGwF+7x1A0gpk4TWRpMUWnaaL2D3Nt/Kd5obKM0THZPCuE+Xwncf4\nQloizZEn4jM3PNldweL9qwG160o2wXif2R5zLVQat9/188+Ko/sU/LorHgh23DMp\nznSwIN30AdLG1WRPxqP5s9abVT0WgBt1VuQobw4TS6QltFUnMSEMBsNtMSPK+NPJ\npz9s3ozqkNMLNSLZMTwgODQWchUr2YJeZa5RbM0u5Xt9oF0HtXH8db3L6Rp3TdIA\nuISnZ+mC7zRiCzWljkJZSBrqgtx6Su5wSve9cYGPS23zu3yeSapJWP7pki3G/GBz\nJQIDAQAB\n-----END PUBLIC KEY-----\n",
@@ -9112,13 +9354,13 @@
         },
         "status": 201,
         "response": {
-            "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+            "id": "cred_d7qeana2JAao683Q2XUikK",
             "credential_type": "public_key",
             "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
             "alg": "RS256",
             "name": "e2e-test-key",
-            "created_at": "2026-07-17T06:07:17.374Z",
-            "updated_at": "2026-07-17T06:07:17.374Z"
+            "created_at": "2026-08-05T18:57:12.277Z",
+            "updated_at": "2026-08-05T18:57:12.277Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9126,13 +9368,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                            "id": "cred_d7qeana2JAao683Q2XUikK"
                         }
                     ]
                 }
@@ -9175,7 +9417,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                            "id": "cred_d7qeana2JAao683Q2XUikK"
                         }
                     ]
                 }
@@ -9188,7 +9430,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -9218,7 +9460,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -9226,34 +9468,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -9292,7 +9534,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-10T07:03:48.737Z",
+                    "updated_at": "2026-07-17T06:13:27.176Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -9348,7 +9590,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-17T06:07:18.621Z",
+            "updated_at": "2026-08-05T18:57:13.648Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -9394,7 +9636,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-16T08:47:14.857Z"
+                    "updated_at": "2026-07-30T13:01:57.535Z"
                 }
             ]
         },
@@ -9480,7 +9722,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-16T08:47:14.857Z"
+            "updated_at": "2026-07-30T13:01:57.535Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9620,7 +9862,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:07:22.179Z"
+            "updated_at": "2026-08-05T18:57:17.452Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10843,6 +11085,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -10979,7 +11253,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11032,7 +11306,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11085,7 +11359,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11136,7 +11410,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -11149,7 +11423,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11196,7 +11470,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11249,7 +11564,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11263,47 +11578,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11350,7 +11624,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11408,7 +11682,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11432,18 +11706,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+                "id": "cred_d7qeana2JAao683Q2XUikK",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-17T06:07:17.374Z",
-                "updated_at": "2026-07-17T06:07:17.374Z"
+                "created_at": "2026-08-05T18:57:12.277Z",
+                "updated_at": "2026-08-05T18:57:12.277Z"
             }
         ],
         "rawHeaders": [],
@@ -11452,7 +11726,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -11510,7 +11784,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -11546,49 +11820,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -11630,7 +11862,49 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -11675,34 +11949,6 @@
         "status": 200,
         "response": {
             "message_types": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -11785,6 +12031,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/actions/modules?page=0&per_page=100",
         "body": "",
@@ -11807,7 +12081,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11815,34 +12089,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11869,7 +12143,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11877,34 +12151,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11931,7 +12205,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -11939,34 +12213,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -11987,13 +12261,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12018,6 +12292,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -12058,12 +12364,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12103,7 +12409,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -12204,7 +12510,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12257,7 +12563,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12310,7 +12616,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12361,7 +12667,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -12374,7 +12680,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12421,7 +12727,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12474,7 +12821,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12488,47 +12835,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -12575,7 +12881,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12633,7 +12939,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12696,75 +13002,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12789,6 +13033,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -12829,12 +13105,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -12874,7 +13150,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -12885,16 +13161,97 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
+                {
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                },
+                {
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "clients": [
+                {
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                },
-                {
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
                 }
             ]
         },
@@ -12904,30 +13261,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": "",
         "status": 200,
         "response": {
-            "clients": [
-                {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
-                },
-                {
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
-        "body": "",
-        "status": 200,
-        "response": {
-            "id": "con_sZmrptRT1dRkGEaU",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -12964,7 +13302,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -12976,7 +13314,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -13010,7 +13348,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_sZmrptRT1dRkGEaU",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13047,7 +13385,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -13149,7 +13487,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13202,7 +13540,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13255,7 +13593,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13306,7 +13644,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -13319,7 +13657,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -13366,7 +13704,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13419,7 +13798,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13433,47 +13812,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -13520,7 +13858,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13578,7 +13916,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13641,13 +13979,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13672,6 +14010,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -13712,12 +14082,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -13739,12 +14109,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13784,7 +14154,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -13810,13 +14180,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13841,6 +14211,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -13881,12 +14283,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -13908,12 +14310,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13953,7 +14355,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -13964,16 +14366,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                 },
                 {
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
                 }
             ]
         },
@@ -14088,7 +14490,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14141,7 +14543,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14194,7 +14596,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14245,7 +14647,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -14258,7 +14660,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -14305,7 +14707,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14358,7 +14801,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14372,47 +14815,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -14459,7 +14861,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14517,7 +14919,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14580,14 +14982,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -14724,8 +15126,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -15109,30 +15511,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
             "roles": [
                 {
-                    "id": "rol_mWNhCNG1yuxyzRW0",
+                    "id": "rol_MzpnnGz6d68mbldY",
                     "name": "Admin",
-                    "description": "Can read and write things"
+                    "description": "Can read and write things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_KYekWOWLVpJeVWbL",
+                    "id": "rol_bUvFAw4rOYJNAocU",
                     "name": "Reader",
-                    "description": "Can only read things"
+                    "description": "Can only read things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_TK6bINiThEdD82uJ",
+                    "id": "rol_Ix7SQbb6p2t6dQRg",
                     "name": "read_only",
-                    "description": "Read Only"
+                    "description": "Read Only",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_9k41FO3KxqnRLjSO",
+                    "id": "rol_C6IFQdUiqeNqfYe3",
                     "name": "read_osnly",
-                    "description": "Readz Only"
+                    "description": "Readz Only",
+                    "type": "tenant"
                 }
             ],
             "start": 0,
@@ -15145,7 +15551,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15160,7 +15566,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15175,7 +15581,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15190,7 +15596,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15198,37 +15604,6 @@
             "start": 0,
             "limit": 100,
             "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": [
-                {
-                    "id": "org_qdYzZeCFDLEiVOCL",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block"
-                },
-                {
-                    "id": "org_o0aVwomUlzXKMyv5",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block"
-                }
-            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -15326,7 +15701,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15379,7 +15754,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15432,7 +15807,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15483,7 +15858,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -15496,7 +15871,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -15543,7 +15918,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15596,7 +16012,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15610,47 +16026,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -15697,7 +16072,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15755,7 +16130,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15818,7 +16193,40 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": [
+                {
+                    "id": "org_U7hHFWA8LmetETGu",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    },
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_KvyIU8ipa4KpyL0n",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15833,7 +16241,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15848,7 +16256,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15860,7 +16268,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15875,7 +16283,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15890,7 +16298,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15902,13 +16310,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15933,6 +16341,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -15973,12 +16413,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -16000,12 +16440,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -16045,7 +16485,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -16056,14 +16496,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -16200,8 +16640,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -16675,7 +17115,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16728,7 +17168,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16781,7 +17221,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16832,7 +17272,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -16845,7 +17285,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -16892,7 +17332,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16945,7 +17426,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16959,47 +17440,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -17046,7 +17486,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17104,7 +17544,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17172,7 +17612,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029822",
+                "id": "lst_0000000000030152",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -17183,14 +17623,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029823",
+                "id": "lst_0000000000030153",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
                 },
                 "filters": [
                     {
@@ -18552,6 +18992,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -18688,7 +19160,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18741,7 +19213,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18794,7 +19266,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18845,7 +19317,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -18858,7 +19330,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -18905,7 +19377,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18958,7 +19471,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -18972,47 +19485,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -19059,7 +19531,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19117,7 +19589,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19141,18 +19613,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS/credentials",
+        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d9sjSFVjh1qjguwWYV9TEY",
+                "id": "cred_d7qeana2JAao683Q2XUikK",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-07-17T06:07:17.374Z",
-                "updated_at": "2026-07-17T06:07:17.374Z"
+                "created_at": "2026-08-05T18:57:12.277Z",
+                "updated_at": "2026-08-05T18:57:12.277Z"
             }
         ],
         "rawHeaders": [],
@@ -19161,13 +19633,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19192,6 +19664,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -19232,12 +19736,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19277,7 +19781,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -19294,7 +19798,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -19302,34 +19806,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -19350,16 +19854,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_a2fdGQjZWlOIaBqp/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 }
             ]
         },
@@ -19369,16 +19873,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_sZmrptRT1dRkGEaU/clients?take=100",
+        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                 },
                 {
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
                 }
             ]
         },
@@ -19403,13 +19907,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_a2fdGQjZWlOIaBqp",
+                    "id": "con_3a5w9rUEBfXfZnSs",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19434,6 +19938,38 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -19474,12 +20010,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_u0jv1SLcz6oa6DT8",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -19501,12 +20037,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
-                        "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                     ]
                 },
                 {
-                    "id": "con_sZmrptRT1dRkGEaU",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19546,7 +20082,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -19557,16 +20093,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_u0jv1SLcz6oa6DT8/clients?take=100",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K"
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
                 },
                 {
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM"
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
                 }
             ]
         },
@@ -19664,6 +20200,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -19682,37 +20233,71 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
         "response": {
@@ -19757,7 +20342,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -19787,7 +20387,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
+        "path": "/api/v2/email-templates/reset_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -19802,78 +20402,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_QYueTYBZwIArLvJV",
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "id": "cgr_b9Nqc0prQVFMjIhm",
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -20010,8 +20546,8 @@
                     "subject_type": "client"
                 },
                 {
-                    "id": "cgr_fNVNikQz3aWBSEna",
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
+                    "id": "cgr_kaiA3umN6yp9IOm9",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -20513,30 +21049,34 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
             "roles": [
                 {
-                    "id": "rol_mWNhCNG1yuxyzRW0",
+                    "id": "rol_MzpnnGz6d68mbldY",
                     "name": "Admin",
-                    "description": "Can read and write things"
+                    "description": "Can read and write things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_KYekWOWLVpJeVWbL",
+                    "id": "rol_bUvFAw4rOYJNAocU",
                     "name": "Reader",
-                    "description": "Can only read things"
+                    "description": "Can only read things",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_TK6bINiThEdD82uJ",
+                    "id": "rol_Ix7SQbb6p2t6dQRg",
                     "name": "read_only",
-                    "description": "Read Only"
+                    "description": "Read Only",
+                    "type": "tenant"
                 },
                 {
-                    "id": "rol_9k41FO3KxqnRLjSO",
+                    "id": "rol_C6IFQdUiqeNqfYe3",
                     "name": "read_osnly",
-                    "description": "Readz Only"
+                    "description": "Readz Only",
+                    "type": "tenant"
                 }
             ],
             "start": 0,
@@ -20549,7 +21089,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_mWNhCNG1yuxyzRW0/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20564,7 +21104,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_KYekWOWLVpJeVWbL/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20579,7 +21119,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_TK6bINiThEdD82uJ/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20594,7 +21134,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_9k41FO3KxqnRLjSO/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -20655,7 +21195,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T13:25:18.228Z"
+                    "updated_at": "2026-07-17T06:13:20.998Z"
                 }
             ]
         },
@@ -20671,13 +21211,29 @@
         "response": {
             "templates": [
                 {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-07-17T06:13:22.584Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T13:25:19.811Z",
+                    "updated_at": "2026-07-17T06:13:22.508Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -20693,28 +21249,12 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T13:25:19.812Z",
+                    "updated_at": "2026-07-17T06:13:22.506Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T13:25:19.898Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
                 },
@@ -20725,7 +21265,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T13:25:20.111Z",
+                    "updated_at": "2026-07-17T06:13:22.815Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -20829,26 +21369,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
@@ -20859,7 +21379,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20879,7 +21399,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup/custom-text/en",
+        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20899,27 +21429,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/signup/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/signup-password/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20939,7 +21459,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -20979,17 +21509,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/logout/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21009,6 +21529,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/logout/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
@@ -21019,7 +21559,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21029,7 +21569,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21069,7 +21609,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21089,7 +21629,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21099,7 +21639,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21119,16 +21659,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/organizations/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/invitation/custom-text/en",
         "body": "",
         "status": 200,
@@ -21139,27 +21669,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/common/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "path": "/api/v2/prompts/organizations/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21179,7 +21689,27 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/partials",
+        "path": "/api/v2/prompts/common/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21199,7 +21729,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/partials",
+        "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21209,7 +21739,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/partials",
+        "path": "/api/v2/prompts/login-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21239,7 +21769,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/login-passwordless/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21250,6 +21780,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/signup-password/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21280,7 +21820,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -21288,34 +21828,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -21358,6 +21898,17 @@
             "triggers": [
                 {
                     "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v2",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -21386,7 +21937,7 @@
                     ]
                 },
                 {
-                    "id": "post-login",
+                    "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -21409,7 +21960,7 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "credentials-exchange",
+                    "id": "pre-user-registration",
                     "version": "v1",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -21428,17 +21979,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "pre-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -21467,29 +22007,18 @@
                 },
                 {
                     "id": "post-change-password",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
+                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
                 {
                     "id": "post-change-password",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node18-actions",
-                        "node22"
-                    ],
-                    "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "send-phone-message",
                     "version": "v1",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -21508,6 +22037,17 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "send-phone-message",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -21769,13 +22309,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "organizations": [
                 {
-                    "id": "org_qdYzZeCFDLEiVOCL",
+                    "id": "org_U7hHFWA8LmetETGu",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -21784,13 +22324,15 @@
                             "primary": "#57ddff"
                         }
                     },
-                    "third_party_client_access": "block"
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
                 },
                 {
-                    "id": "org_o0aVwomUlzXKMyv5",
+                    "id": "org_KvyIU8ipa4KpyL0n",
                     "name": "org2",
                     "display_name": "Organization2",
-                    "third_party_client_access": "block"
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
                 }
             ]
         },
@@ -21890,7 +22432,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "yBGKxdDE9GQp5KdkS2RzBG4pS7Heh4xE",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -21943,7 +22485,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "L9TJ1VoMTPnBSwuUwnFvNdwdn8PnIdHx",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -21996,7 +22538,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "6J5FPvqL2SaZMLhW3sy32IqpHJGphaCa",
+                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22047,7 +22589,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d9sjSFVjh1qjguwWYV9TEY"
+                                    "id": "cred_d7qeana2JAao683Q2XUikK"
                                 }
                             ]
                         }
@@ -22060,7 +22602,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "QqKIjEn8FQaVoZWgRYX9CXchGBX4plvS",
+                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -22107,7 +22649,48 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "y59jty42quoV6ZLyRwAk51P7psUA5YWb",
+                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22160,7 +22743,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QuqK4Hfo1gFFsBKiNgBJ8l8QrtkCd2PM",
+                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22174,47 +22757,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jcs0mWUt9as9fPOwFcn7U8ALcm7A9HPx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -22261,7 +22803,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "pW0UCiV62aN9LF50fuslVyvfPZ23atbi",
+                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22319,7 +22861,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ibc3w1xs2dD4z0ZCAt8xo27A0Osdit2K",
+                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22382,7 +22924,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22397,7 +22939,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22412,7 +22954,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_qdYzZeCFDLEiVOCL/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -22424,7 +22966,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22439,7 +22981,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22454,30 +22996,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_o0aVwomUlzXKMyv5/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
             "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22501,6 +23024,25 @@
                     "shields": []
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22591,18 +23133,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
@@ -22615,12 +23145,24 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/risk-assessments/settings",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000029822",
+                "id": "lst_0000000000030152",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -22631,14 +23173,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000029823",
+                "id": "lst_0000000000030153",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-23af11b4-c939-42b9-a02d-b0e02ffc0681/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
                 },
                 "filters": [
                     {
@@ -22712,21 +23254,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -22740,9 +23267,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-17T06:07:22.179Z"
+                    "updated_at": "2026-08-05T18:57:17.452Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22811,22 +23353,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:07:22.179Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows/vault/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 50,
-            "start": 0,
-            "total": 0,
-            "connections": []
+            "updated_at": "2026-08-05T18:57:17.452Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22842,6 +23369,21 @@
             "start": 0,
             "total": 0,
             "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows/vault/connections?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 50,
+            "start": 0,
+            "total": 0,
+            "connections": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -22890,7 +23432,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:07:13.803Z",
+                    "updated_at": "2026-08-05T18:57:08.272Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -22942,7 +23484,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:06:58.205Z",
+                    "updated_at": "2026-08-05T18:56:55.136Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -23038,7 +23580,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23046,34 +23588,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -23142,7 +23684,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:07:18.621Z",
+                    "updated_at": "2026-08-05T18:57:13.648Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -23167,7 +23709,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "6aafc9ae-906a-47db-8e47-72529eb143d0",
+                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23175,34 +23717,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-07-17T06:06:59.806952575Z",
-                    "updated_at": "2026-07-17T06:06:59.821829361Z",
+                    "created_at": "2026-08-05T18:56:56.983801987Z",
+                    "updated_at": "2026-08-05T18:56:56.991550383Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-07-17T06:07:00.515637114Z",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z"
+                        "build_time": "2026-08-05T18:56:57.736560561Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "78b88df0-6e18-4a92-89e7-47ce736ac5fb",
+                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-07-17T06:07:00.515637114Z",
+                        "built_at": "2026-08-05T18:56:57.736560561Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-07-17T06:07:00.450141003Z",
-                        "updated_at": "2026-07-17T06:07:00.516137765Z",
+                        "created_at": "2026-08-05T18:56:57.654938301Z",
+                        "updated_at": "2026-08-05T18:56:57.737733915Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {

--- a/test/e2e/recordings/should-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-deploy-without-throwing-an-error.json
@@ -1053,6 +1053,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -1103,7 +1135,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 2,
+            "total": 3,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -1189,7 +1221,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1204,6 +1236,59 @@
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -1213,7 +1298,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -1271,7 +1356,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1307,7 +1392,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -1322,6 +1407,48 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
         },
@@ -1350,48 +1477,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
         },
@@ -1471,34 +1556,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -1538,6 +1595,34 @@
                 "pre-custom-token-exchange": {
                     "max_attempts": 10,
                     "rate": 600000
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
                 }
             }
         },
@@ -1611,68 +1696,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_YcKCzdFwUUtLhLx8",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 4,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -1758,7 +1786,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1770,6 +1798,59 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -1821,26 +1902,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [],
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_YcKCzdFwUUtLhLx8",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1880,7 +1948,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -1891,16 +1959,67 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_YcKCzdFwUUtLhLx8/clients?take=100",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
         "body": "",
         "status": 200,
         "response": {
-            "clients": [
+            "actions": [],
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                },
-                {
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    ]
                 }
             ]
         },
@@ -1910,11 +2029,30 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_YcKCzdFwUUtLhLx8",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_YcKCzdFwUUtLhLx8",
+            "clients": [
+                {
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                },
+                {
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "body": "",
+        "status": 200,
+        "response": {
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -1951,7 +2089,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -1963,7 +2101,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_YcKCzdFwUUtLhLx8",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -1997,7 +2135,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_YcKCzdFwUUtLhLx8",
+            "id": "con_GCIw7tDhSMeiCyeZ",
             "options": {
                 "mfa": {
                     "active": true,
@@ -2034,7 +2172,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -2050,7 +2188,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 4,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -2136,7 +2274,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2148,6 +2286,59 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2199,13 +2390,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_YcKCzdFwUUtLhLx8",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2245,7 +2436,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -2271,13 +2462,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_YcKCzdFwUUtLhLx8",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2317,7 +2508,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -2344,7 +2535,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_jj2L916iOjWNz9f7",
+            "id": "con_wXkTr1DrHw8CrHg1",
             "options": {
                 "email": true,
                 "scope": [
@@ -2373,13 +2564,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=1&name=google-oauth2&include_fields=true",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=google-oauth2&include_fields=true",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_jj2L916iOjWNz9f7",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -2410,14 +2601,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_jj2L916iOjWNz9f7/clients",
+        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients",
         "body": [
             {
                 "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                 "status": true
             },
             {
-                "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                 "status": true
             }
         ],
@@ -2448,7 +2639,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 4,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -2534,7 +2725,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2546,6 +2737,59 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2597,7 +2841,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -2850,7 +3094,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
@@ -2865,11 +3109,23 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 4,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -2955,7 +3211,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2967,6 +3223,59 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3018,25 +3327,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_jj2L916iOjWNz9f7",
+                    "id": "con_wXkTr1DrHw8CrHg1",
                     "options": {
                         "email": true,
                         "scope": [
@@ -3059,11 +3356,11 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 },
                 {
-                    "id": "con_YcKCzdFwUUtLhLx8",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3103,7 +3400,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "ypunbRZxckR3aszgS4xLejT3L1l8qhdX"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -3114,7 +3411,213 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "total": 4,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Auth0 CLI - dev",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "oidc_conformant": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com",
+                        "mr|google-oauth2|109614534713742077035",
+                        "mr|google-oauth2|116771660953104383819",
+                        "mr|google-oauth2|112839029247827700155",
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "cross_origin_authentication": true,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -3367,294 +3870,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 3,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com",
-                        "mr|google-oauth2|109614534713742077035",
-                        "mr|google-oauth2|116771660953104383819",
-                        "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com",
-                        "mr|google-oauth2|113227425378005249939",
-                        "mr|google-oauth2|111201688215901175487"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "cross_origin_authentication": true,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/log-streams",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true&is_global=false",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 2,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "ypunbRZxckR3aszgS4xLejT3L1l8qhdX",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/ypunbRZxckR3aszgS4xLejT3L1l8qhdX/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -3694,7 +3910,7 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://mycompany.org/logoutCallback"
+                "https://travel0.com/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
@@ -3730,7 +3946,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "My Test Tenant",
+            "friendly_name": "This tenant name should be preserved",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -3739,8 +3955,8 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@mycompany.org",
-            "support_url": "https://mycompany.org/support",
+            "support_email": "support@travel0.com",
+            "support_url": "https://travel0.com/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",

--- a/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-dump-and-deploy-without-throwing-an-error.json
@@ -1221,6 +1221,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -1357,7 +1389,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1381,26 +1413,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [],
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1411,6 +1430,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -1440,7 +1491,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -1451,13 +1502,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [],
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -1485,13 +1549,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1502,6 +1566,38 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -1531,7 +1627,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -1630,6 +1726,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -1648,7 +1759,37 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/mfa_oob_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
         "response": {
@@ -1678,6 +1819,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/welcome_email",
         "body": "",
         "status": 200,
@@ -1690,6 +1846,51 @@
             "syntax": "liquid",
             "urlLifetimeInSeconds": 3600,
             "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -1727,112 +1928,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -2203,7 +2299,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
@@ -2264,7 +2360,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T13:25:18.228Z"
+                    "updated_at": "2026-07-17T06:13:20.998Z"
                 }
             ]
         },
@@ -2280,13 +2376,29 @@
         "response": {
             "templates": [
                 {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-07-17T06:13:22.584Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T13:25:19.811Z",
+                    "updated_at": "2026-07-17T06:13:22.508Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2302,28 +2414,12 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T13:25:19.812Z",
+                    "updated_at": "2026-07-17T06:13:22.506Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T13:25:19.898Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
                 },
@@ -2334,7 +2430,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T13:25:20.111Z",
+                    "updated_at": "2026-07-17T06:13:22.815Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -2438,7 +2534,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/custom-text/en",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2448,7 +2544,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
+        "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2478,7 +2574,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup/custom-text/en",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2488,7 +2584,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "path": "/api/v2/prompts/signup/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2518,16 +2614,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
@@ -2548,6 +2634,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/custom-form/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/reset-password/custom-text/en",
         "body": "",
         "status": 200,
@@ -2559,16 +2665,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/consent/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/custom-form/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2608,16 +2704,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
@@ -2628,7 +2714,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2648,7 +2744,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2678,16 +2774,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
@@ -2699,6 +2785,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2758,16 +2854,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/captcha/custom-text/en",
         "body": "",
         "status": 200,
@@ -2778,7 +2864,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2788,7 +2874,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/partials",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -2818,7 +2904,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/partials",
+        "path": "/api/v2/prompts/login-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2838,7 +2924,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/login-passwordless/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2859,6 +2945,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/signup-password/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -2958,24 +3054,24 @@
                 },
                 {
                     "id": "credentials-exchange",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
+                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
                 {
                     "id": "credentials-exchange",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -3027,6 +3123,17 @@
                 },
                 {
                     "id": "post-change-password",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-change-password",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -3034,17 +3141,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-change-password",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -3329,7 +3425,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -3431,7 +3527,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3619,11 +3715,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "remember_for": 30
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3631,11 +3727,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3678,21 +3774,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -3706,9 +3787,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-17T06:10:37.024Z"
+                    "updated_at": "2026-08-06T07:11:38.364Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3777,22 +3873,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:10:37.024Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-08-06T07:11:38.364Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3808,6 +3889,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3856,7 +3952,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:10:27.587Z",
+                    "updated_at": "2026-08-06T07:11:28.859Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -3908,7 +4004,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:10:14.781Z",
+                    "updated_at": "2026-08-06T07:11:18.795Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -4059,7 +4155,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:10:33.528Z",
+                    "updated_at": "2026-08-06T07:11:34.782Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -5393,6 +5489,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -5529,7 +5657,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5553,7 +5681,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+        "path": "/api/v2/clients/4KWdBigdmxBionUsdewvtlj7npUfWHTA",
         "body": {
             "name": "Default App",
             "callbacks": [],
@@ -5611,7 +5739,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+            "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -5647,63 +5775,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
         },
@@ -5732,6 +5804,62 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
         "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -5799,46 +5927,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/attack-protection/captcha",
-        "body": {
-            "active_provider_id": "auth_challenge",
-            "auth_challenge": {
-                "fail_open": false
-            }
-        },
-        "status": 200,
-        "response": {
-            "active_provider_id": "auth_challenge",
-            "simple_captcha": {},
-            "auth_challenge": {
-                "fail_open": false
-            },
-            "recaptcha_v2": {
-                "site_key": ""
-            },
-            "recaptcha_enterprise": {
-                "site_key": "",
-                "project_id": ""
-            },
-            "hcaptcha": {
-                "site_key": ""
-            },
-            "friendly_captcha": {
-                "site_key": ""
-            },
-            "arkose": {
-                "site_key": "",
-                "client_subdomain": "client-api",
-                "verify_subdomain": "verify-api",
-                "fail_open": false
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/attack-protection/suspicious-ip-throttling",
         "body": {
             "enabled": true,
@@ -5883,6 +5971,74 @@
                     "max_attempts": 10,
                     "rate": 600000
                 }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/captcha",
+        "body": {
+            "active_provider_id": "auth_challenge",
+            "auth_challenge": {
+                "fail_open": false
+            }
+        },
+        "status": 200,
+        "response": {
+            "active_provider_id": "auth_challenge",
+            "simple_captcha": {},
+            "auth_challenge": {
+                "fail_open": false
+            },
+            "recaptcha_v2": {
+                "site_key": ""
+            },
+            "recaptcha_enterprise": {
+                "site_key": "",
+                "project_id": ""
+            },
+            "hcaptcha": {
+                "site_key": ""
+            },
+            "friendly_captcha": {
+                "site_key": ""
+            },
+            "arkose": {
+                "site_key": "",
+                "client_subdomain": "client-api",
+                "verify_subdomain": "verify-api",
+                "fail_open": false
             }
         },
         "rawHeaders": [],
@@ -5944,34 +6100,6 @@
                     "shields": []
                 }
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -6041,7 +6169,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:10:14.781Z",
+                    "updated_at": "2026-08-06T07:11:18.795Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -6086,7 +6214,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-07-17T06:13:14.009Z",
+            "updated_at": "2026-08-07T09:04:14.288Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -6314,63 +6442,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -6461,7 +6532,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6515,6 +6586,184 @@
                     "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
                     "client_secret": "[REDACTED]",
                     "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
+                    ]
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
+                    ]
                 }
             ]
         },
@@ -6537,70 +6786,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -6613,11 +6805,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_GCIw7tDhSMeiCyeZ",
+            "id": "con_zXAdAJ7zaBMcTUlE",
             "options": {
                 "mfa": {
                     "active": true,
@@ -6628,6 +6820,38 @@
                     "challenge_ui": "both",
                     "local_enrollment_enabled": true,
                     "progressive_enrollment_enabled": true
+                },
+                "password_options": {
+                    "history": {
+                        "size": 3,
+                        "active": false
+                    },
+                    "complexity": {
+                        "min_length": 15,
+                        "character_types": [],
+                        "character_type_rule": "all",
+                        "max_length_exceeded": "error",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow"
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    }
                 },
                 "strategy_version": 2,
                 "authentication_methods": {
@@ -6654,7 +6878,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -6666,7 +6890,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
         "body": {
             "authentication": {
                 "active": true
@@ -6683,11 +6907,42 @@
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "good",
                 "passkey_options": {
                     "challenge_ui": "both",
                     "local_enrollment_enabled": true,
                     "progressive_enrollment_enabled": true
+                },
+                "password_options": {
+                    "history": {
+                        "size": 3,
+                        "active": false
+                    },
+                    "complexity": {
+                        "min_length": 15,
+                        "character_types": [],
+                        "character_type_rule": "all",
+                        "max_length_exceeded": "error",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow"
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    }
                 },
                 "strategy_version": 2,
                 "authentication_methods": {
@@ -6706,17 +6961,48 @@
         },
         "status": 200,
         "response": {
-            "id": "con_GCIw7tDhSMeiCyeZ",
+            "id": "con_zXAdAJ7zaBMcTUlE",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "good",
                 "passkey_options": {
                     "challenge_ui": "both",
                     "local_enrollment_enabled": true,
                     "progressive_enrollment_enabled": true
+                },
+                "password_options": {
+                    "history": {
+                        "size": 3,
+                        "active": false
+                    },
+                    "complexity": {
+                        "min_length": 15,
+                        "character_types": [],
+                        "character_type_rule": "all",
+                        "max_length_exceeded": "error",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow"
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    }
                 },
                 "strategy_version": 2,
                 "authentication_methods": {
@@ -6743,7 +7029,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -6845,7 +7131,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6908,23 +7194,54 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -6954,7 +7271,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -6980,23 +7297,54 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -7026,7 +7374,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -7164,7 +7512,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7227,7 +7575,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -7480,7 +7828,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
@@ -7515,7 +7863,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-09T13:25:18.228Z"
+                    "updated_at": "2026-07-17T06:13:20.998Z"
                 }
             ]
         },
@@ -7555,7 +7903,7 @@
                 ]
             },
             "created_at": "2025-12-09T12:24:00.604Z",
-            "updated_at": "2026-07-17T06:13:20.998Z"
+            "updated_at": "2026-08-07T09:04:29.688Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7589,7 +7937,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:10:27.587Z",
+                    "updated_at": "2026-08-06T07:11:28.859Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7665,7 +8013,7 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-07-17T06:13:21.914Z",
+            "updated_at": "2026-08-07T09:04:30.894Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
@@ -7684,13 +8032,29 @@
         "response": {
             "templates": [
                 {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-07-17T06:13:22.584Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-09T13:25:19.811Z",
+                    "updated_at": "2026-07-17T06:13:22.508Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7706,28 +8070,12 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-09T13:25:19.812Z",
+                    "updated_at": "2026-07-17T06:13:22.506Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-09T13:25:19.898Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
                 },
@@ -7738,7 +8086,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-09T13:25:20.111Z",
+                    "updated_at": "2026-07-17T06:13:22.815Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -7756,30 +8104,30 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/branding/phone/templates/tem_xqbUSF83fpnRv8r8rqXFDZ",
+        "path": "/api/v2/branding/phone/templates/tem_o4LBTt4NQyX8K4vC9dPafR",
         "body": {
             "content": {
                 "body": {
-                    "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
-                    "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
+                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                 }
             },
             "disabled": false
         },
         "status": 200,
         "response": {
-            "id": "tem_xqbUSF83fpnRv8r8rqXFDZ",
+            "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
             "tenant": "auth0-deploy-cli-e2e",
             "channel": "phone",
-            "type": "change_password",
+            "type": "otp_verify",
             "disabled": false,
-            "created_at": "2025-12-09T12:26:20.243Z",
-            "updated_at": "2026-07-17T06:13:22.506Z",
+            "created_at": "2025-12-09T12:26:30.547Z",
+            "updated_at": "2026-08-07T09:04:31.494Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
-                    "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
-                    "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
+                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                 }
             }
         },
@@ -7807,7 +8155,7 @@
             "type": "otp_enroll",
             "disabled": false,
             "created_at": "2025-12-09T12:26:25.327Z",
-            "updated_at": "2026-07-17T06:13:22.508Z",
+            "updated_at": "2026-08-07T09:04:31.611Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
@@ -7822,30 +8170,30 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/branding/phone/templates/tem_o4LBTt4NQyX8K4vC9dPafR",
+        "path": "/api/v2/branding/phone/templates/tem_xqbUSF83fpnRv8r8rqXFDZ",
         "body": {
             "content": {
                 "body": {
-                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                    "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
+                    "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
                 }
             },
             "disabled": false
         },
         "status": 200,
         "response": {
-            "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+            "id": "tem_xqbUSF83fpnRv8r8rqXFDZ",
             "tenant": "auth0-deploy-cli-e2e",
             "channel": "phone",
-            "type": "otp_verify",
+            "type": "change_password",
             "disabled": false,
-            "created_at": "2025-12-09T12:26:30.547Z",
-            "updated_at": "2026-07-17T06:13:22.584Z",
+            "created_at": "2025-12-09T12:26:20.243Z",
+            "updated_at": "2026-08-07T09:04:31.621Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
-                    "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                    "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                    "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
+                    "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
                 }
             }
         },
@@ -7874,7 +8222,7 @@
             "type": "blocked_account",
             "disabled": false,
             "created_at": "2025-12-09T12:22:47.683Z",
-            "updated_at": "2026-07-17T06:13:22.815Z",
+            "updated_at": "2026-08-07T09:04:31.802Z",
             "content": {
                 "syntax": "liquid",
                 "body": {
@@ -8020,11 +8368,252 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "total": 3,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com",
+                        "mr|google-oauth2|109614534713742077035",
+                        "mr|google-oauth2|116771660953104383819",
+                        "mr|google-oauth2|112839029247827700155",
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "cross_origin_authentication": true,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "organizations": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
+                    ]
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8122,7 +8711,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8185,64 +8774,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -8495,159 +9027,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 3,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com",
-                        "mr|google-oauth2|109614534713742077035",
-                        "mr|google-oauth2|116771660953104383819",
-                        "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com",
-                        "mr|google-oauth2|113227425378005249939",
-                        "mr|google-oauth2|111201688215901175487"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "cross_origin_authentication": true,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
@@ -8704,7 +9083,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:10:33.528Z",
+                    "updated_at": "2026-08-06T07:11:34.782Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -8760,7 +9139,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-07-17T06:13:27.176Z",
+            "updated_at": "2026-08-07T09:04:43.820Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -8866,7 +9245,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-17T06:10:37.024Z"
+                    "updated_at": "2026-08-06T07:11:38.364Z"
                 }
             ]
         },
@@ -8937,7 +9316,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:10:37.024Z"
+            "updated_at": "2026-08-06T07:11:38.364Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9077,7 +9456,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-17T06:13:31.396Z"
+            "updated_at": "2026-08-07T09:04:48.059Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false

--- a/test/e2e/recordings/should-dump-without-throwing-an-error.json
+++ b/test/e2e/recordings/should-dump-without-throwing-an-error.json
@@ -72,7 +72,9 @@
                         "mr|google-oauth2|109614534713742077035",
                         "mr|google-oauth2|116771660953104383819",
                         "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com"
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "cross_origin_authentication": true,
@@ -100,14 +102,15 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://mycompany.org/logoutCallback"
+                "https://travel0.com/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
                 "html": "<html>Change Password</html>\n"
             },
             "enabled_locales": [
-                "en"
+                "en",
+                "es"
             ],
             "error_page": {
                 "html": "<html>Error Page</html>\n",
@@ -134,7 +137,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "My Test Tenant",
+            "friendly_name": "This tenant name should be preserved",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -143,8 +146,8 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@mycompany.org",
-            "support_url": "https://mycompany.org/support",
+            "support_email": "support@travel0.com",
+            "support_url": "https://travel0.com/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",
@@ -1219,6 +1222,38 @@
                             "value": "delete:rate_limit_policies"
                         },
                         {
+                            "description": "Create Portals",
+                            "value": "create:portals"
+                        },
+                        {
+                            "description": "Read Portals",
+                            "value": "read:portals"
+                        },
+                        {
+                            "description": "Update Portals",
+                            "value": "update:portals"
+                        },
+                        {
+                            "description": "Delete Portals",
+                            "value": "delete:portals"
+                        },
+                        {
+                            "description": "Create Network ACL Keys",
+                            "value": "create:network_acl_keys"
+                        },
+                        {
+                            "description": "Update Network ACL Keys",
+                            "value": "update:network_acl_keys"
+                        },
+                        {
+                            "description": "Read Network ACL Keys",
+                            "value": "read:network_acl_keys"
+                        },
+                        {
+                            "description": "Delete Network ACL Keys",
+                            "value": "delete:network_acl_keys"
+                        },
+                        {
                             "value": "read:security_metrics",
                             "description": "Read Security Metrics"
                         },
@@ -1269,7 +1304,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 9,
+            "total": 3,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -1355,7 +1390,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QJ4KnTIgxpV9smmOROhaeayD069j1z9S",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1375,12 +1410,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
+                    "name": "Auth0 CLI - dev",
                     "allowed_clients": [],
                     "callbacks": [],
-                    "client_metadata": {},
                     "cross_origin_authentication": false,
                     "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
                     "native_social_login": {
                         "apple": {
                             "enabled": false
@@ -1389,7 +1424,6 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
@@ -1401,204 +1435,7 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "La9DphbEYrdQLiAzYDaIpjTf0rtQxfoe",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "FyYRQWOGxeZxIOmOP1cucKjKm42oo2op",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jB49BBNQIy2EueRrNLz4UrJiE5cOwYZd",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "VIixs9C8rfhfA9XNMT5AI540v5h5pjS0",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -1606,125 +1443,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IqDkcKsVMjwKTMdcKNivtUPjPDz0HDeH",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "UzMEaN7bo52EOXkJxjP5rHlRwfQxHAA2",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1748,83 +1467,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_BaGOBb9CcatoyPyA",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "FyYRQWOGxeZxIOmOP1cucKjKm42oo2op",
-                        "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG"
-                    ]
-                },
-                {
-                    "id": "con_JuGBjlu1y7AUbrK6",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -1864,7 +1513,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "QJ4KnTIgxpV9smmOROhaeayD069j1z9S"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
                 }
             ]
@@ -1879,56 +1528,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "487002bc-2d50-46c7-b851-90dba0d88367",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-06-29T09:35:35.280148075Z",
-                    "updated_at": "2026-06-29T10:01:48.722760571Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 7,
-                        "build_time": "2026-06-29T10:01:49.378030974Z",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "deployed": true,
-                        "number": 7,
-                        "built_at": "2026-06-29T10:01:49.378030974Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -1937,35 +1537,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_JuGBjlu1y7AUbrK6/clients?take=100",
+        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "QJ4KnTIgxpV9smmOROhaeayD069j1z9S"
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_BaGOBb9CcatoyPyA/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG"
-                },
-                {
-                    "client_id": "FyYRQWOGxeZxIOmOP1cucKjKm42oo2op"
                 }
             ]
         },
@@ -1990,110 +1571,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?take=50",
+        "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_BaGOBb9CcatoyPyA",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "FyYRQWOGxeZxIOmOP1cucKjKm42oo2op",
-                        "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG"
-                    ]
-                },
-                {
-                    "id": "con_lJTI9NaothQPvYe8",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "IqDkcKsVMjwKTMdcKNivtUPjPDz0HDeH",
-                        "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG"
-                    ]
-                },
-                {
-                    "id": "con_JuGBjlu1y7AUbrK6",
+                    "id": "con_GCIw7tDhSMeiCyeZ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -2133,27 +1617,8 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "QJ4KnTIgxpV9smmOROhaeayD069j1z9S"
+                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
                     ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_lJTI9NaothQPvYe8/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG"
-                },
-                {
-                    "client_id": "IqDkcKsVMjwKTMdcKNivtUPjPDz0HDeH"
                 }
             ]
         },
@@ -2168,14 +1633,15 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://mycompany.org/logoutCallback"
+                "https://travel0.com/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
                 "html": "<html>Change Password</html>\n"
             },
             "enabled_locales": [
-                "en"
+                "en",
+                "es"
             ],
             "error_page": {
                 "html": "<html>Error Page</html>\n",
@@ -2202,7 +1668,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "My Test Tenant",
+            "friendly_name": "This tenant name should be preserved",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -2211,8 +1677,8 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@mycompany.org",
-            "support_url": "https://mycompany.org/support",
+            "support_email": "support@travel0.com",
+            "support_url": "https://travel0.com/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",
@@ -2251,6 +1717,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -2269,146 +1750,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": "",
-        "status": 200,
-        "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
         "body": "",
         "status": 404,
         "response": {
@@ -2453,149 +1795,135 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/client-grants?take=50",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": "",
+        "status": 200,
+        "response": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome to This tenant name should be preserved!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://travel0.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/async_approval",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
-                {
-                    "id": "cgr_fJt6x6NOTZhG8YfJ",
-                    "client_id": "La9DphbEYrdQLiAzYDaIpjTf0rtQxfoe",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
                 {
                     "id": "cgr_pbwejzhwoujrsNE8",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
@@ -2835,144 +2163,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_zjpIzaBsCwAEx9Mc",
-                    "client_id": "VIixs9C8rfhfA9XNMT5AI540v5h5pjS0",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -3100,92 +2290,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles?per_page=100&page=0&include_totals=true&type=tenant",
         "body": "",
         "status": 200,
         "response": {
-            "roles": [
-                {
-                    "id": "rol_jFtdTcZ9z45CJGyz",
-                    "name": "Admin",
-                    "description": "Can read and write things"
-                },
-                {
-                    "id": "rol_kJy3rboyeb5xQMXx",
-                    "name": "Reader",
-                    "description": "Can only read things"
-                },
-                {
-                    "id": "rol_3pAH8x5DplKo3rnQ",
-                    "name": "read_only",
-                    "description": "Read Only"
-                },
-                {
-                    "id": "rol_6frQawgWi9v2jodK",
-                    "name": "read_osnly",
-                    "description": "Readz Only"
-                }
-            ],
-            "start": 0,
-            "limit": 100,
-            "total": 4
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_jFtdTcZ9z45CJGyz/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_kJy3rboyeb5xQMXx/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_3pAH8x5DplKo3rnQ/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_6frQawgWi9v2jodK/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
+            "roles": [],
             "start": 0,
             "limit": 100,
             "total": 0
@@ -3242,7 +2351,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-06-29T10:01:57.386Z"
+                    "updated_at": "2026-07-17T06:13:20.998Z"
                 }
             ]
         },
@@ -3258,13 +2367,29 @@
         "response": {
             "templates": [
                 {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-07-17T06:13:22.584Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-06-29T10:01:59.017Z",
+                    "updated_at": "2026-07-17T06:13:22.508Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -3280,28 +2405,12 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-06-29T10:01:59.002Z",
+                    "updated_at": "2026-07-17T06:13:22.506Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your password change code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your password change code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your password change code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-06-29T10:01:58.987Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
                 },
@@ -3312,7 +2421,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-06-29T10:01:59.285Z",
+                    "updated_at": "2026-07-17T06:13:22.815Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -3348,14 +2457,15 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://mycompany.org/logoutCallback"
+                "https://travel0.com/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
                 "html": "<html>Change Password</html>\n"
             },
             "enabled_locales": [
-                "en"
+                "en",
+                "es"
             ],
             "error_page": {
                 "html": "<html>Error Page</html>\n",
@@ -3382,7 +2492,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "My Test Tenant",
+            "friendly_name": "This tenant name should be preserved",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -3391,8 +2501,8 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@mycompany.org",
-            "support_url": "https://mycompany.org/support",
+            "support_email": "support@travel0.com",
+            "support_url": "https://travel0.com/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",
@@ -3410,6 +2520,16 @@
                 "12"
             ]
         },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -3436,7 +2556,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3447,16 +2567,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login-passwordless/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3496,7 +2606,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3516,7 +2626,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3536,27 +2646,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/custom-form/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/consent/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/logout/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3576,7 +2666,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/custom-form/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/logout/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3596,7 +2696,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-push/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3606,7 +2706,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-push/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3626,7 +2726,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3636,7 +2736,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3656,17 +2756,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/device-flow/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
+        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3686,7 +2776,27 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/device-flow/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -3736,16 +2846,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/captcha/custom-text/en",
         "body": "",
         "status": 200,
@@ -3756,7 +2856,367 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/brute-force-protection/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-id/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-password/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-passwordless/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-password/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/custom-form/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/consent/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/customized-consent/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/logout/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-push/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-recovery-code/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa-email/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/mfa/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/status/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/device-flow/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/email-verification/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/organizations/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/invitation/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/common/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/captcha/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/passkeys/custom-text/es",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/brute-force-protection/custom-text/es",
         "body": "",
         "status": 200,
         "response": {},
@@ -3796,16 +3256,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/partials",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/signup/partials",
         "body": "",
         "status": 200,
@@ -3816,7 +3266,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/partials",
+        "path": "/api/v2/prompts/login-passwordless/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -3836,7 +3296,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/partials",
+        "path": "/api/v2/prompts/passkeys/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -3865,56 +3325,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "487002bc-2d50-46c7-b851-90dba0d88367",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-06-29T09:35:35.280148075Z",
-                    "updated_at": "2026-06-29T10:01:48.722760571Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 7,
-                        "build_time": "2026-06-29T10:01:49.378030974Z",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "deployed": true,
-                        "number": 7,
-                        "built_at": "2026-06-29T10:01:49.378030974Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -3945,6 +3356,17 @@
             "triggers": [
                 {
                     "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -3973,28 +3395,6 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "credentials-exchange",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "credentials-exchange",
                     "version": "v2",
                     "status": "CURRENT",
@@ -4003,6 +3403,17 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "credentials-exchange",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -4031,35 +3442,24 @@
                 },
                 {
                     "id": "post-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
                 {
                     "id": "post-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
+                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-change-password",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -4076,14 +3476,13 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "send-phone-message",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "id": "post-change-password",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -4095,6 +3494,18 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "send-phone-message",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node18-actions",
+                        "node22"
+                    ],
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -4356,28 +3767,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?take=50",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_Z2HdeVzRXFWOB9XS",
-                    "name": "org2",
-                    "display_name": "Organization2"
-                },
-                {
-                    "id": "org_Ozta2aF1Z9uH5fpR",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    }
-                }
-            ]
+            "organizations": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4389,7 +3783,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 10,
+            "total": 4,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -4475,7 +3869,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "QJ4KnTIgxpV9smmOROhaeayD069j1z9S",
+                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4495,12 +3889,12 @@
                     "tenant": "auth0-deploy-cli-e2e",
                     "global": false,
                     "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
+                    "name": "Auth0 CLI - dev",
                     "allowed_clients": [],
                     "callbacks": [],
-                    "client_metadata": {},
                     "cross_origin_authentication": false,
                     "is_first_party": true,
+                    "logo_uri": "https://dev.assets.com/photos/foo",
                     "native_social_login": {
                         "apple": {
                             "enabled": false
@@ -4509,7 +3903,6 @@
                             "enabled": false
                         }
                     },
-                    "oidc_conformant": true,
                     "refresh_token": {
                         "expiration_type": "non-expiring",
                         "leeway": 0,
@@ -4521,204 +3914,7 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "La9DphbEYrdQLiAzYDaIpjTf0rtQxfoe",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "FyYRQWOGxeZxIOmOP1cucKjKm42oo2op",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "jB49BBNQIy2EueRrNLz4UrJiE5cOwYZd",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "VIixs9C8rfhfA9XNMT5AI540v5h5pjS0",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
                     "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -4726,125 +3922,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "IqDkcKsVMjwKTMdcKNivtUPjPDz0HDeH",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "UzMEaN7bo52EOXkJxjP5rHlRwfQxHAA2",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "edegYlwGoRjM4OOjdNtFLDJxNR75TVtG",
+                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4882,7 +3960,9 @@
                         "mr|google-oauth2|109614534713742077035",
                         "mr|google-oauth2|116771660953104383819",
                         "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com"
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
                     ],
                     "custom_login_page": "<html>TEST123</html>\n",
                     "cross_origin_authentication": true,
@@ -4898,90 +3978,6 @@
                     "custom_login_page_on": true
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Z2HdeVzRXFWOB9XS/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Z2HdeVzRXFWOB9XS/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Z2HdeVzRXFWOB9XS/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Ozta2aF1Z9uH5fpR/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Ozta2aF1Z9uH5fpR/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_Ozta2aF1Z9uH5fpR/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5141,69 +4137,7 @@
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000029495",
-                "name": "Suspended DD Log Stream",
-                "type": "datadog",
-                "status": "active",
-                "sink": {
-                    "datadogApiKey": "some-sensitive-api-key",
-                    "datadogRegion": "us"
-                },
-                "isPriority": false
-            },
-            {
-                "id": "lst_0000000000029496",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-45ebb8da-8dfb-4e0e-8b08-1225bde13946/auth0.logs"
-                },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ],
-                "isPriority": false
-            }
-        ],
+        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -5235,6 +4169,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -5248,24 +4197,9 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-06-29T09:35:55.973Z"
+                    "updated_at": "2026-07-30T13:01:57.535Z"
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5334,22 +4268,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-06-29T09:35:55.973Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-07-30T13:01:57.535Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5365,6 +4284,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5413,7 +4347,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-06-29T10:01:58.361Z",
+                    "updated_at": "2026-07-17T06:13:21.914Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -5465,7 +4399,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-06-29T10:01:46.790Z",
+                    "updated_at": "2026-07-17T06:13:14.009Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -5559,56 +4493,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "487002bc-2d50-46c7-b851-90dba0d88367",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-06-29T09:35:35.280148075Z",
-                    "updated_at": "2026-06-29T10:01:48.722760571Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 7,
-                        "build_time": "2026-06-29T10:01:49.378030974Z",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "deployed": true,
-                        "number": 7,
-                        "built_at": "2026-06-29T10:01:49.378030974Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -5632,11 +4517,51 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/rate-limit-policies?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:rate_limit_policies",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/event-streams?take=50",
         "body": "",
         "status": 200,
         "response": {
-            "eventStreams": []
+            "eventStreams": [
+                {
+                    "id": "est_3jM6JQ7F5sXyYeudsCsiWX",
+                    "status": "disabled",
+                    "name": "e2e-webhook-stream",
+                    "subscriptions": [
+                        {
+                            "event_type": "user.created"
+                        },
+                        {
+                            "event_type": "user.deleted"
+                        }
+                    ],
+                    "created_at": "2026-06-29T10:28:33.962Z",
+                    "updated_at": "2026-07-17T06:13:27.176Z",
+                    "destination": {
+                        "type": "webhook",
+                        "configuration": {
+                            "webhook_endpoint": "https://example.com/test/v2/check/webhook",
+                            "webhook_authorization": {
+                                "method": "bearer"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -5648,73 +4573,8 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "487002bc-2d50-46c7-b851-90dba0d88367",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-06-29T09:35:35.280148075Z",
-                    "updated_at": "2026-06-29T10:01:48.722760571Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 7,
-                        "build_time": "2026-06-29T10:01:49.378030974Z",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "e1ec9484-f43e-4437-9cc1-1cf5bb616c15",
-                        "deployed": true,
-                        "number": 7,
-                        "built_at": "2026-06-29T10:01:49.378030974Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-06-29T10:01:49.304924046Z",
-                        "updated_at": "2026-06-29T10:01:49.378713309Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    }
-,
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/rate-limit-policies?take=50",
-        "body": "",
-        "status": 403,
-        "response": {
-            "statusCode": 403,
-            "error": "Forbidden",
-            "message": "Rate Limit Policies feature is not enabled for this tenant.",
-            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false

--- a/test/tools/auth0/handlers/databases.tests.js
+++ b/test/tools/auth0/handlers/databases.tests.js
@@ -842,6 +842,114 @@ describe('#databases handler', () => {
       ]);
     });
 
+    it('should strip legacy password fields on export when password_options is present', async () => {
+      const auth0 = {
+        connections: {
+          list: function (params) {
+            (() => expect(this).to.not.be.undefined)();
+            return mockPagedData(params, 'connections', [
+              {
+                id: 'con1',
+                strategy: 'auth0',
+                name: 'Username-Password-Authentication',
+                options: {
+                  password_options: { complexity: { min_length: 10 } },
+                  passwordPolicy: 'good',
+                  password_complexity_options: { min_length: 8 },
+                  password_history: { enable: true, size: 5 },
+                  password_no_personal_info: { enable: true },
+                  password_dictionary: { enable: true, dictionary: [] },
+                  brute_force_protection: true,
+                },
+              },
+            ]);
+          },
+          clients: {
+            get: () => Promise.resolve(mockPagedData({}, 'clients', [])),
+          },
+        },
+        clients: {
+          list: function (params) {
+            (() => expect(this).to.not.be.undefined)();
+            return mockPagedData(params, 'clients', []);
+          },
+        },
+        actions: {
+          list: (params) => mockPagedData(params, 'actions', []),
+        },
+        pool,
+      };
+
+      const handler = new databases.default({ client: pageClient(auth0), config });
+      const data = await handler.getType();
+
+      // Legacy password fields must be stripped when password_options is present,
+      // leaving password_options and unrelated options intact so the export stays deployable.
+      expect(data).to.deep.equal([
+        {
+          id: 'con1',
+          strategy: 'auth0',
+          name: 'Username-Password-Authentication',
+          options: {
+            password_options: { complexity: { min_length: 10 } },
+            brute_force_protection: true,
+          },
+        },
+      ]);
+    });
+
+    it('should preserve legacy password fields on export when password_options is absent', async () => {
+      const auth0 = {
+        connections: {
+          list: function (params) {
+            (() => expect(this).to.not.be.undefined)();
+            return mockPagedData(params, 'connections', [
+              {
+                id: 'con1',
+                strategy: 'auth0',
+                name: 'Username-Password-Authentication',
+                options: {
+                  passwordPolicy: 'good',
+                  password_history: { enable: true, size: 5 },
+                  brute_force_protection: true,
+                },
+              },
+            ]);
+          },
+          clients: {
+            get: () => Promise.resolve(mockPagedData({}, 'clients', [])),
+          },
+        },
+        clients: {
+          list: function (params) {
+            (() => expect(this).to.not.be.undefined)();
+            return mockPagedData(params, 'clients', []);
+          },
+        },
+        actions: {
+          list: (params) => mockPagedData(params, 'actions', []),
+        },
+        pool,
+      };
+
+      const handler = new databases.default({ client: pageClient(auth0), config });
+      const data = await handler.getType();
+
+      // A legacy-only connection must be untouched.
+      expect(data).to.deep.equal([
+        {
+          id: 'con1',
+          strategy: 'auth0',
+          name: 'Username-Password-Authentication',
+          options: {
+            passwordPolicy: 'good',
+            password_history: { enable: true, size: 5 },
+            brute_force_protection: true,
+          },
+        },
+      ]);
+    });
+
     it('should update database', async () => {
       const auth0 = {
         connections: {

--- a/test/tools/auth0/handlers/roles.tests.js
+++ b/test/tools/auth0/handlers/roles.tests.js
@@ -110,16 +110,19 @@ describe('#roles handler', () => {
         resource_server_identifier: 'organise',
       });
 
+      let listParams;
       const auth0 = {
         roles: {
-          list: (params) =>
-            mockPagedData({ ...params, include_totals: true }, 'roles', [
+          list: (params) => {
+            listParams = params;
+            return mockPagedData({ ...params, include_totals: true }, 'roles', [
               {
                 name: 'myRole',
                 id: 'myRoleId',
                 description: 'myDescription',
               },
-            ]),
+            ]);
+          },
           permissions: {
             list: (roleId, params) =>
               mockPagedData({ ...params, include_totals: true }, 'permissions', permissions),
@@ -130,6 +133,8 @@ describe('#roles handler', () => {
 
       const handler = new roles.default({ client: pageClient(auth0), config });
       const data = await handler.getType();
+      // org-scoped roles must be excluded from the tenant baseline
+      expect(listParams.type).to.equal('tenant');
       expect(data).to.deep.equal([
         {
           name: 'myRole',

--- a/test/tools/auth0/handlers/roles.tests.js
+++ b/test/tools/auth0/handlers/roles.tests.js
@@ -120,6 +120,7 @@ describe('#roles handler', () => {
                 name: 'myRole',
                 id: 'myRoleId',
                 description: 'myDescription',
+                type: 'tenant',
               },
             ]);
           },
@@ -135,11 +136,13 @@ describe('#roles handler', () => {
       const data = await handler.getType();
       // org-scoped roles must be excluded from the tenant baseline
       expect(listParams.type).to.equal('tenant');
+      // the type field is preserved on the exported role shape
       expect(data).to.deep.equal([
         {
           name: 'myRole',
           id: 'myRoleId',
           description: 'myDescription',
+          type: 'tenant',
           permissions: new Array(150).fill({
             permission_name: 'Create:cal_entry',
             resource_server_identifier: 'organise',


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Excludes organization-scoped roles from the tenant roles export/import flow.

When the `api2_org_level_roles_ea` feature flag is enabled on a tenant, `GET /api/v2/roles` starts returning organization-scoped roles (those with `type: "organization"`) mixed in with tenant-level roles. The deploy CLI treats every listed role as tenant configuration, so without this change it would:

- pull org-scoped roles into the tenant baseline (`tenant.yaml` / `roles/*.json`)
- report spurious diffs for them on every run
- flag them for deletion when `AUTH0_ALLOW_DELETE` is enabled, since they are not present in the local config files

The roles handler now passes `type: 'tenant'` to `roles.list` so only tenant-level roles are managed. Org-scoped roles are managed within an organization context and are intentionally out of scope here.

The endpoint stays on offset pagination. Although the API spec moves `/roles` to checkpoint pagination, node-auth0 deliberately kept offset pagination for `/roles` for backward compatibility (checkpoint is deferred to a future major SDK), so `paginate: true` is retained rather than switching to checkpoint.

Bumps `auth0` to `^6.2.0`, which adds the `type` filter parameter and includes `type` on the `Role` response.

**Shape change:** exported roles now include a `type` field (returned by the 6.2.0 `Role` response). This is additive and backward compatible on import. Role IDs are stripped on export as before, so no `id` is written.

YAML (`tenant.yaml`):

```yaml
roles:
  - name: Test Role
    description: Role to reproduce the error
    permissions: []
    type: tenant   # new: present on exported roles
```

JSON(`roles/Test Role.json`):

```json
{
  "name": "Test Role",
  "description": "Role to reproduce the error",
  "type": "tenant",
  "permissions": []
}
```

#### Migration note

Configs exported while the `api2_org_level_roles_ea` flag was on may contain organization-scoped roles. After upgrading, these are no longer read from the tenant, so they appear local-only and would be recreated as tenant roles on deploy. Affected roles should be removed from local config after a re-export.

### 🔬 Testing

Unit tests: `test/tools/auth0/handlers/roles.tests.js` asserts `roles.list` is called with `type: 'tenant'`.

Manual end-to-end against a live tenant with `api2_org_level_roles_ea` enabled:

1. Created an org-scoped role via the Management API (`POST /api/v2/roles` with `type: "organization"` and an `owner_id`).
2. Confirmed at the API level that `GET /api/v2/roles` returns it (3 roles) while `GET /api/v2/roles?type=tenant` does not (2 roles).
3. Ran `export` in both YAML and directory formats: the org-scoped role was excluded from the output; only tenant roles were written, each with a `type` field and no `id`.
4. Ran `import --dry-run` with the org role present on the tenant: the proposed-changes plan was empty, confirming the org role is not pulled into the baseline and not flagged for deletion (even with `AUTH0_ALLOW_DELETE` enabled).
5. Deleted the temporary org-scoped role to restore tenant state.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
