### PR TITLE
feat: add org-to-app entitlement (EA) support for organizations

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -1128,6 +1128,55 @@ Contents of `Block iCloud Private Relay Exits-p-4.json`:
 }
 ```
 
+## Organizations
+
+The deploy CLI supports managing organizations, including their connections, client grants, discovery domains, and org-to-app entitlement settings.
+
+### Org-to-App Entitlement (`is_app_entitlement_active` / `clients`)
+
+> **Note:** Requires the `org_to_app_entitlement_enabled` feature flag to be enabled on the tenant.
+
+`is_app_entitlement_active` controls whether org-to-app entitlement is active for an organization. When active, the `clients` array specifies which client applications org members are entitled to use for login.
+
+Each entry in `clients` has:
+
+- `client_id` — the **name** of the client application (resolved to the actual ID at deploy time)
+- `use_for_member_access` — when `true`, org members can use this client to log in
+
+**YAML Example**
+
+```yaml
+organizations:
+  - name: my-organization
+    display_name: My Organization
+    is_app_entitlement_active: true
+    clients:
+      - client_id: My App
+        use_for_member_access: true
+```
+
+**Directory Example**
+
+```
+./organizations/my-organization.json
+```
+
+```json
+{
+  "name": "my-organization",
+  "display_name": "My Organization",
+  "is_app_entitlement_active": true,
+  "clients": [
+    {
+      "client_id": "My App",
+      "use_for_member_access": true
+    }
+  ]
+}
+```
+
+> **Note:** When exporting, `client_id` values are resolved to client **names** for portability across environments. On deploy, names are resolved back to IDs. The M2M application used by the deploy CLI requires the `read:organization_clients`, `create:organization_clients`, `update:organization_clients`, and `delete:organization_clients` scopes.
+
 ## PhoneProviders
 
 When managing phone providers, credentials are never exported.

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -671,3 +671,12 @@ organizations:
     # Requires the organizations_third_party_client_support feature flag to be enabled on the tenant.
     # Allowed values: allow, block (defaults to block)
     third_party_client_access: block
+    # Controls whether org-to-app entitlement is active for this organization.
+    # Requires the org_to_app_entitlement_enabled feature flag to be enabled on the tenant.
+    is_app_entitlement_active: false
+    # List of client applications that org members are entitled to use for login.
+    # Only relevant when is_app_entitlement_active is true.
+    # use_for_member_access: when true, org members can use this client to log in.
+    clients:
+      - client_id: My App
+        use_for_member_access: true

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -505,9 +505,20 @@ export default class OrganizationsHandler extends DefaultHandler {
     }
 
     if (orgClientsToRemove.length > 0) {
-      await this.deleteOrganizationClients(params.id, orgClientsToRemove).catch((err) => {
-        throw new Error(`Problem removing org clients for organization ${params.id}\n${err}`);
-      });
+      if (
+        this.config('AUTH0_ALLOW_DELETE') === 'true' ||
+        this.config('AUTH0_ALLOW_DELETE') === true
+      ) {
+        await this.deleteOrganizationClients(params.id, orgClientsToRemove).catch((err) => {
+          throw new Error(`Problem removing org clients for organization ${params.id}\n${err}`);
+        });
+      } else {
+        log.warn(
+          `Detected the following organization client associations should be removed. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config\n${orgClientsToRemove.join(
+            '\n'
+          )}`
+        );
+      }
     }
 
     await Promise.all(

--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -91,6 +91,19 @@ export const schema = {
         type: 'string',
         enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
       },
+      is_app_entitlement_active: { type: 'boolean' },
+      clients: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            client_id: { type: 'string' },
+            use_for_member_access: { type: 'boolean' },
+          },
+          required: ['client_id', 'use_for_member_access'],
+        },
+        default: [],
+      },
     },
     required: ['name'],
   },
@@ -105,10 +118,17 @@ type FormattedClientGrants = {
   client_id: string | undefined;
 };
 
+type OrgClientAssociation = {
+  client_id: string | undefined;
+  use_for_member_access: boolean | undefined;
+};
+
 export default class OrganizationsHandler extends DefaultHandler {
   existing: Asset[];
 
   formattedClientGrants: FormattedClientGrants[];
+
+  allClients: Client[];
 
   constructor(config: DefaultHandler) {
     super({
@@ -151,6 +171,7 @@ export default class OrganizationsHandler extends DefaultHandler {
     const organization = { ...org };
     delete organization.connections;
     delete organization.client_grants;
+    delete organization.clients;
 
     if ('discovery_domains' in organization) {
       delete organization.discovery_domains;
@@ -204,6 +225,22 @@ export default class OrganizationsHandler extends DefaultHandler {
         )
       );
     }
+
+    if (typeof org.clients !== 'undefined' && org.clients.length > 0) {
+      const clientsToCreate = (org.clients as OrgClientAssociation[])
+        .map((oc) => ({
+          client_id: this.getClientIdByClientName(oc.client_id as string),
+          use_for_member_access: oc.use_for_member_access as boolean,
+        }))
+        .filter((oc) => !!oc.client_id);
+
+      if (clientsToCreate.length > 0) {
+        await this.createOrganizationClients(createdId, clientsToCreate).catch((err) => {
+          throw new Error(`Problem creating org clients for organization ${createdId}\n${err}`);
+        });
+      }
+    }
+
     return created;
   }
 
@@ -229,6 +266,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       connections: existingConnections,
       client_grants: existingClientGrants,
       discovery_domains: existingDiscoveryDomains,
+      clients: existingOrgClients = [],
     } = await organizations.find((orgToUpdate) => orgToUpdate.name === org.name);
 
     const params = { id: org.id };
@@ -236,6 +274,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       connections,
       client_grants: organizationClientGrants,
       discovery_domains: organizationDiscoveryDomains,
+      clients: organizationClients,
     } = org;
 
     delete org.connections;
@@ -243,6 +282,7 @@ export default class OrganizationsHandler extends DefaultHandler {
     delete org.id;
     delete org.client_grants;
     delete org.discovery_domains;
+    delete org.clients;
 
     await this.client.organizations.update(params.id, org);
 
@@ -423,12 +463,78 @@ export default class OrganizationsHandler extends DefaultHandler {
       }
     }
 
+    // organization clients
+    const orgClientsToAdd = ((organizationClients as OrgClientAssociation[]) || [])
+      .filter(
+        (c) =>
+          !(existingOrgClients as OrgClientAssociation[]).find((x) => x.client_id === c.client_id)
+      )
+      .map((oc) => ({
+        client_id: this.getClientIdByClientName(oc.client_id as string),
+        use_for_member_access: oc.use_for_member_access as boolean,
+      }))
+      .filter((oc) => !!oc.client_id);
+
+    const orgClientsToRemove = ((existingOrgClients as OrgClientAssociation[]) || [])
+      .filter(
+        (c) =>
+          !((organizationClients as OrgClientAssociation[]) || []).find(
+            (x) => x.client_id === c.client_id
+          )
+      )
+      .map((oc) => this.getClientIdByClientName(oc.client_id as string))
+      .filter(Boolean);
+
+    const orgClientsToUpdate = ((organizationClients as OrgClientAssociation[]) || [])
+      .filter((c) => {
+        const existing = (existingOrgClients as OrgClientAssociation[]).find(
+          (x) => x.client_id === c.client_id
+        );
+        return existing && existing.use_for_member_access !== c.use_for_member_access;
+      })
+      .map((oc) => ({
+        client_id: this.getClientIdByClientName(oc.client_id as string),
+        use_for_member_access: oc.use_for_member_access as boolean,
+      }))
+      .filter((oc) => !!oc.client_id);
+
+    if (orgClientsToAdd.length > 0) {
+      await this.createOrganizationClients(params.id, orgClientsToAdd).catch((err) => {
+        throw new Error(`Problem adding org clients for organization ${params.id}\n${err}`);
+      });
+    }
+
+    if (orgClientsToRemove.length > 0) {
+      await this.deleteOrganizationClients(params.id, orgClientsToRemove).catch((err) => {
+        throw new Error(`Problem removing org clients for organization ${params.id}\n${err}`);
+      });
+    }
+
+    await Promise.all(
+      orgClientsToUpdate.map((oc) =>
+        this.client.organizations.clients
+          .update(params.id, oc.client_id, {
+            use_for_member_access: oc.use_for_member_access,
+          })
+          .catch((err) => {
+            throw new Error(
+              `Problem updating org client ${oc.client_id} for organization ${params.id}\n${err}`
+            );
+          })
+      )
+    );
+
     return params;
   }
 
   getClientGrantIDByClientName(clientsName: string): string {
     const found = this.formattedClientGrants.find((c) => c.client_id === clientsName);
     return found?.grant_id || '';
+  }
+
+  getClientIdByClientName(clientName: string): string {
+    const found = this.allClients?.find((c) => c.name === clientName);
+    return found?.client_id || '';
   }
 
   async getFormattedClientGrants(): Promise<FormattedClientGrants[]> {
@@ -440,6 +546,9 @@ export default class OrganizationsHandler extends DefaultHandler {
         paginate: true,
       }),
     ]);
+
+    // Store clients for org-client name→ID resolution
+    this.allClients = clients;
 
     // Convert clients by name to the id and store it in the formattedClientGrants
     const formattedClientGrantsMapping = clientGrants?.map((clientGrant) => {
@@ -505,6 +614,15 @@ export default class OrganizationsHandler extends DefaultHandler {
         const organizationDiscoveryDomains = await this.getAllOrganizationDiscoveryDomains(org.id);
         if (organizationDiscoveryDomains) {
           org.discovery_domains = organizationDiscoveryDomains;
+        }
+
+        // Get org-client associations
+        const orgClients = await this.getAllOrganizationClients(org.id);
+        if (orgClients) {
+          org.clients = orgClients.map((oc) => ({
+            client_id: convertClientIdToName(oc.client_id, clients),
+            use_for_member_access: oc.use_for_member_access,
+          }));
         }
       }
 
@@ -736,5 +854,56 @@ export default class OrganizationsHandler extends DefaultHandler {
   ): Promise<void> {
     log.debug(`Deleting discovery domain ${discoveryDomain} for organization ${organizationId}`);
     await this.client.organizations.discoveryDomains.delete(organizationId, discoveryDomainId);
+  }
+
+  async getAllOrganizationClients(
+    organizationId: string
+  ): Promise<Management.OrganizationClient[] | null> {
+    const allOrgClients: Management.OrganizationClient[] = [];
+
+    try {
+      let orgClients = await this.client.organizations.clients.list(organizationId);
+
+      allOrgClients.push(...orgClients.data);
+
+      while (orgClients.hasNextPage()) {
+        orgClients = await orgClients.getNextPage();
+        allOrgClients.push(...orgClients.data);
+      }
+
+      return allOrgClients;
+    } catch (err) {
+      if (err.statusCode === 404 || err.statusCode === 501) {
+        return null;
+      }
+      if (err.statusCode === 403 || err.errorCode === 'feature_not_enabled') {
+        log.debug(
+          'Org-to-app entitlement is not enabled for this tenant. Skipping org-client associations.'
+        );
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async createOrganizationClients(
+    organizationId: string,
+    clients: Array<{ client_id: string; use_for_member_access: boolean }>
+  ): Promise<void> {
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < clients.length; i += BATCH_SIZE) {
+      const batch = clients.slice(i, i + BATCH_SIZE);
+      log.debug(`Creating ${batch.length} org client(s) for organization ${organizationId}`);
+      await this.client.organizations.clients.create(organizationId, { clients: batch });
+    }
+  }
+
+  async deleteOrganizationClients(organizationId: string, clientIds: string[]): Promise<void> {
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < clientIds.length; i += BATCH_SIZE) {
+      const batch = clientIds.slice(i, i + BATCH_SIZE);
+      log.debug(`Deleting ${batch.length} org client(s) for organization ${organizationId}`);
+      await this.client.organizations.clients.delete(organizationId, { clients: batch });
+    }
   }
 }

--- a/test/context/yaml/organizations.test.js
+++ b/test/context/yaml/organizations.test.js
@@ -76,6 +76,7 @@ describe('#YAML context organizations', () => {
           },
         ],
         client_grants: [],
+        clients: [],
         discovery_domains: [
           {
             domain: 'login.acme.com',
@@ -102,6 +103,7 @@ describe('#YAML context organizations', () => {
           },
         ],
         client_grants: [],
+        clients: [],
       },
       {
         name: 'org-snow',
@@ -125,6 +127,7 @@ describe('#YAML context organizations', () => {
             client_id: 'Org Snow app',
           },
         ],
+        clients: [],
       },
     ];
 

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -36,7 +36,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 10,
+            "total": 9,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -122,7 +122,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -134,59 +134,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -228,7 +175,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -279,7 +226,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -292,7 +239,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -339,7 +286,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -380,7 +327,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -433,7 +380,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -493,7 +440,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -551,7 +498,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -575,7 +522,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn/credentials",
+        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -585,7 +532,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4/credentials",
+        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -595,7 +542,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3/credentials",
+        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -605,7 +552,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL/credentials",
+        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -615,7 +562,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs/credentials",
+        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -625,7 +572,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE/credentials",
+        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -1989,7 +1936,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 10,
+            "total": 9,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -2075,7 +2022,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2087,59 +2034,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2181,7 +2075,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2232,7 +2126,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -2245,7 +2139,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -2292,7 +2186,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2333,7 +2227,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2386,7 +2280,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2446,7 +2340,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2504,7 +2398,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2528,18 +2422,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d7qeana2JAao683Q2XUikK",
+                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-08-05T18:57:12.277Z",
-                "updated_at": "2026-08-05T18:57:12.277Z"
+                "created_at": "2026-08-10T13:55:22.110Z",
+                "updated_at": "2026-08-10T13:55:22.110Z"
             }
         ],
         "rawHeaders": [],
@@ -2548,17 +2442,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-        "body": "",
-        "status": 204,
-        "response": "",
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "DELETE",
-        "path": "/api/v2/clients/luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
+        "path": "/api/v2/clients/4KWdBigdmxBionUsdewvtlj7npUfWHTA",
         "body": "",
         "status": 204,
         "response": "",
@@ -2568,7 +2452,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
         "body": {
             "name": "API Explorer Application",
             "allowed_clients": [],
@@ -2646,7 +2530,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2668,7 +2552,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -2749,7 +2633,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d7qeana2JAao683Q2XUikK"
+                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                         }
                     ]
                 }
@@ -2762,7 +2646,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -2786,7 +2670,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
         "body": {
             "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
@@ -2847,7 +2731,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+            "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2868,7 +2752,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
         "body": {
             "name": "Terraform Provider",
             "app_type": "non_interactive",
@@ -2923,7 +2807,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2944,7 +2828,113 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -3037,7 +3027,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+            "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3064,113 +3054,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-        "body": {
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
         "body": {
             "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
@@ -3248,7 +3132,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+            "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3284,20 +3168,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
         "path": "/api/v2/guardian/factors/otp",
         "body": {
             "enabled": false
@@ -3319,6 +3189,20 @@
         "status": 200,
         "response": {
             "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3368,7 +3252,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -3554,7 +3438,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-08-05T18:56:55.136Z",
+                    "updated_at": "2026-08-10T13:55:03.319Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -3599,7 +3483,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-08-05T18:58:39.345Z",
+            "updated_at": "2026-08-10T13:58:56.622Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -3772,7 +3656,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3780,34 +3664,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3828,7 +3712,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -3844,7 +3728,7 @@
         },
         "status": 200,
         "response": {
-            "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+            "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -3852,34 +3736,34 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-08-05T18:56:56.983801987Z",
-            "updated_at": "2026-08-05T18:58:41.315788603Z",
+            "created_at": "2026-08-10T13:55:04.937881440Z",
+            "updated_at": "2026-08-10T13:58:58.256171458Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
             "status": "pending",
             "secrets": [],
             "current_version": {
-                "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "runtime": "node18",
                 "status": "BUILT",
                 "number": 1,
-                "build_time": "2026-08-05T18:56:57.736560561Z",
-                "created_at": "2026-08-05T18:56:57.654938301Z",
-                "updated_at": "2026-08-05T18:56:57.737733915Z"
+                "build_time": "2026-08-10T13:55:05.631088679Z",
+                "created_at": "2026-08-10T13:55:05.534632268Z",
+                "updated_at": "2026-08-10T13:55:05.632719953Z"
             },
             "deployed_version": {
                 "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                 "dependencies": [],
-                "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                 "deployed": true,
                 "number": 1,
-                "built_at": "2026-08-05T18:56:57.736560561Z",
+                "built_at": "2026-08-10T13:55:05.631088679Z",
                 "secrets": [],
                 "status": "built",
-                "created_at": "2026-08-05T18:56:57.654938301Z",
-                "updated_at": "2026-08-05T18:56:57.737733915Z",
+                "created_at": "2026-08-10T13:55:05.534632268Z",
+                "updated_at": "2026-08-10T13:55:05.632719953Z",
                 "runtime": "node18",
                 "supported_triggers": [
                     {
@@ -3902,7 +3786,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3910,34 +3794,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:58:41.315788603Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:58:58.256171458Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3958,19 +3842,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d/deploy",
+        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+            "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
             "deployed": false,
             "number": 2,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-08-05T18:58:41.994374412Z",
-            "updated_at": "2026-08-05T18:58:41.994374412Z",
+            "created_at": "2026-08-10T13:58:58.846471999Z",
+            "updated_at": "2026-08-10T13:58:58.846471999Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -3979,7 +3863,7 @@
                 }
             ],
             "action": {
-                "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -3987,72 +3871,10 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-08-05T18:56:56.983801987Z",
-                "updated_at": "2026-08-05T18:58:41.307216862Z",
+                "created_at": "2026-08-10T13:55:04.937881440Z",
+                "updated_at": "2026-08-10T13:58:58.246770448Z",
                 "all_changes_deployed": false
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:58:41.315788603Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-08-05T18:58:42.074685776Z",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-08-05T18:58:42.074685776Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4066,7 +3888,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4163,12 +3985,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4318,7 +4140,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4369,7 +4191,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -4382,7 +4204,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -4429,7 +4251,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4470,7 +4292,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4523,7 +4345,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4583,7 +4405,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4641,7 +4463,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4710,7 +4532,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4718,34 +4540,96 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:58:41.315788603Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:58:58.256171458Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-08-05T18:58:42.074685776Z",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z"
+                        "build_time": "2026-08-10T13:58:58.918670443Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-08-05T18:58:42.074685776Z",
+                        "built_at": "2026-08-10T13:58:58.918670443Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:58:58.256171458Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 2,
+                        "build_time": "2026-08-10T13:58:58.918670443Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "deployed": true,
+                        "number": 2,
+                        "built_at": "2026-08-10T13:58:58.918670443Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -4772,7 +4656,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4869,12 +4753,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4924,7 +4808,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -4940,16 +4824,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                 },
                 {
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw"
                 }
             ]
         },
@@ -4959,11 +4843,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-08-05T18:58:43.559Z"
+            "deleted_at": "2026-08-10T13:59:00.087Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4971,11 +4855,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_3a5w9rUEBfXfZnSs",
+            "id": "con_u6eDOnzfycy2sDLb",
             "options": {
                 "mfa": {
                     "active": true,
@@ -5069,8 +4953,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -5082,7 +4966,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -5142,7 +5026,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_3a5w9rUEBfXfZnSs",
+            "id": "con_u6eDOnzfycy2sDLb",
             "options": {
                 "mfa": {
                     "active": true,
@@ -5204,8 +5088,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
             ],
             "realms": [
                 "boo-baz-db-connection-test"
@@ -5317,7 +5201,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5368,7 +5252,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -5381,7 +5265,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -5428,7 +5312,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5469,7 +5353,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5522,7 +5406,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5582,7 +5466,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5640,7 +5524,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5709,7 +5593,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5774,12 +5658,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5801,8 +5685,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 }
             ]
@@ -5834,7 +5718,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5899,12 +5783,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5926,8 +5810,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 }
             ]
@@ -5938,16 +5822,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i"
                 },
                 {
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                 }
             ]
         },
@@ -5957,7 +5841,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0",
         "body": {
             "is_domain_connection": false,
             "options": {
@@ -5971,7 +5855,7 @@
         },
         "status": 200,
         "response": {
-            "id": "con_wXkTr1DrHw8CrHg1",
+            "id": "con_Dyc8vFGQ4ncArPi0",
             "options": {
                 "email": true,
                 "scope": [
@@ -5990,8 +5874,8 @@
                 "active": false
             },
             "enabled_clients": [
-                "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
             ],
             "realms": [
                 "google-oauth2"
@@ -6140,7 +6024,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6191,7 +6075,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -6204,7 +6088,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -6251,7 +6135,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6292,7 +6176,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6345,7 +6229,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6405,7 +6289,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6463,7 +6347,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6532,146 +6416,8 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -7046,6 +6792,144 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
                 }
             ]
         },
@@ -7055,7 +6939,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_b9Nqc0prQVFMjIhm",
+        "path": "/api/v2/client-grants/cgr_NUKidZC54pI9CYZV",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7192,8 +7076,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_b9Nqc0prQVFMjIhm",
-            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "id": "cgr_NUKidZC54pI9CYZV",
+            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7335,7 +7219,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_kaiA3umN6yp9IOm9",
+        "path": "/api/v2/client-grants/cgr_pzLmQ5o4eKIoCQXe",
         "body": {
             "scope": [
                 "read:client_grants",
@@ -7472,8 +7356,8 @@
         },
         "status": 200,
         "response": {
-            "id": "cgr_kaiA3umN6yp9IOm9",
-            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "id": "cgr_pzLmQ5o4eKIoCQXe",
+            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7621,25 +7505,25 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_MzpnnGz6d68mbldY",
+                    "id": "rol_suBuW3gIaoRKQ2YI",
                     "name": "Admin",
                     "description": "Can read and write things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_bUvFAw4rOYJNAocU",
+                    "id": "rol_ULMlbmvvd3mzoPwt",
                     "name": "Reader",
                     "description": "Can only read things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_Ix7SQbb6p2t6dQRg",
+                    "id": "rol_lkZCKwORLWaTSWuv",
                     "name": "read_only",
                     "description": "Read Only",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_C6IFQdUiqeNqfYe3",
+                    "id": "rol_sQEZiIEgfOQdKTLk",
                     "name": "read_osnly",
                     "description": "Readz Only",
                     "type": "tenant"
@@ -7655,7 +7539,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7670,7 +7554,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7685,7 +7569,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7700,7 +7584,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -7715,14 +7599,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI",
         "body": {
             "name": "Admin",
             "description": "Can read and write things"
         },
         "status": 200,
         "response": {
-            "id": "rol_MzpnnGz6d68mbldY",
+            "id": "rol_suBuW3gIaoRKQ2YI",
             "name": "Admin",
             "description": "Can read and write things",
             "type": "tenant"
@@ -7733,14 +7617,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_bUvFAw4rOYJNAocU",
+            "id": "rol_ULMlbmvvd3mzoPwt",
             "name": "Reader",
             "description": "Can only read things",
             "type": "tenant"
@@ -7751,14 +7635,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv",
         "body": {
             "name": "read_only",
             "description": "Read Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_Ix7SQbb6p2t6dQRg",
+            "id": "rol_lkZCKwORLWaTSWuv",
             "name": "read_only",
             "description": "Read Only",
             "type": "tenant"
@@ -7769,14 +7653,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_C6IFQdUiqeNqfYe3",
+            "id": "rol_sQEZiIEgfOQdKTLk",
             "name": "read_osnly",
             "description": "Readz Only",
             "type": "tenant"
@@ -7813,7 +7697,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-08-05T18:57:08.272Z",
+                    "updated_at": "2026-08-10T13:55:18.245Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7889,12 +7773,40 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-08-05T18:58:51.655Z",
+            "updated_at": "2026-08-10T13:59:07.048Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/welcome_email",
+        "body": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "enabled": false,
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600
+        },
+        "status": 200,
+        "response": {
+            "template": "welcome_email",
+            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
+            "from": "",
+            "resultUrl": "https://example.com/welcome",
+            "subject": "Welcome",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 3600,
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7927,28 +7839,33 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/welcome_email",
-        "body": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "enabled": false,
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600
-        },
+        "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
         "status": 200,
         "response": {
-            "template": "welcome_email",
-            "body": "<html>\n  <body>\n    <h1>Welcome!</h1>\n  </body>\n</html>\n",
-            "from": "",
-            "resultUrl": "https://example.com/welcome",
-            "subject": "Welcome",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 3600,
-            "enabled": false
+            "organizations": [
+                {
+                    "id": "org_SrEMrFYV9b6phMSo",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_heCvrp0Pkxw4ilGg",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    },
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8056,7 +7973,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8107,7 +8024,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -8120,7 +8037,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -8167,7 +8084,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8208,7 +8125,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8261,7 +8178,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8321,7 +8238,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8379,7 +8296,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8442,40 +8359,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?include_totals=true&take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": [
-                {
-                    "id": "org_U7hHFWA8LmetETGu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                },
-                {
-                    "id": "org_KvyIU8ipa4KpyL0n",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8490,7 +8374,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8505,7 +8389,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -8517,7 +8401,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8532,7 +8431,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -8547,11 +8446,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
             "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -8565,7 +8479,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8630,12 +8544,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8657,495 +8571,9 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 9,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
-                                }
-                            ]
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                    "callback_url_template": false,
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com",
-                        "mr|google-oauth2|109614534713742077035",
-                        "mr|google-oauth2|116771660953104383819",
-                        "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com",
-                        "mr|google-oauth2|113227425378005249939",
-                        "mr|google-oauth2|111201688215901175487"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "cross_origin_authentication": true,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
                 }
             ]
         },
@@ -9161,146 +8589,8 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -9675,6 +8965,630 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "total": 9,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "client_authentication_methods": {
+                        "private_key_jwt": {
+                            "credentials": [
+                                {
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                                }
+                            ]
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "callback_url_template": false,
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com",
+                        "mr|google-oauth2|109614534713742077035",
+                        "mr|google-oauth2|116771660953104383819",
+                        "mr|google-oauth2|112839029247827700155",
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "cross_origin_authentication": true,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
                 }
             ]
         },
@@ -9684,7 +9598,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg",
         "body": {
             "branding": {
                 "colors": {
@@ -9702,7 +9616,7 @@
                     "primary": "#57ddff"
                 }
             },
-            "id": "org_U7hHFWA8LmetETGu",
+            "id": "org_heCvrp0Pkxw4ilGg",
             "display_name": "Organization",
             "name": "org1",
             "third_party_client_access": "block",
@@ -9714,13 +9628,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo",
         "body": {
             "display_name": "Organization2"
         },
         "status": 200,
         "response": {
-            "id": "org_KvyIU8ipa4KpyL0n",
+            "id": "org_SrEMrFYV9b6phMSo",
             "display_name": "Organization2",
             "name": "org2",
             "third_party_client_access": "block",
@@ -9737,7 +9651,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000030152",
+                "id": "lst_0000000000030347",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -9748,14 +9662,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000030153",
+                "id": "lst_0000000000030348",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
                 },
                 "filters": [
                     {
@@ -9804,7 +9718,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000030152",
+        "path": "/api/v2/log-streams/lst_0000000000030347",
         "body": {
             "name": "Suspended DD Log Stream",
             "sink": {
@@ -9814,7 +9728,7 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000030152",
+            "id": "lst_0000000000030347",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -9830,7 +9744,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000030153",
+        "path": "/api/v2/log-streams/lst_0000000000030348",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -9875,14 +9789,14 @@
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000030153",
+            "id": "lst_0000000000030348",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
             },
             "filters": [
                 {
@@ -10030,7 +9944,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10081,7 +9995,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -10094,7 +10008,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -10141,7 +10055,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10182,7 +10096,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10235,7 +10149,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10295,7 +10209,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10353,7 +10267,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10377,18 +10291,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d7qeana2JAao683Q2XUikK",
+                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-08-05T18:57:12.277Z",
-                "updated_at": "2026-08-05T18:57:12.277Z"
+                "created_at": "2026-08-10T13:55:22.110Z",
+                "updated_at": "2026-08-10T13:55:22.110Z"
             }
         ],
         "rawHeaders": [],
@@ -10397,13 +10311,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d7qeana2JAao683Q2XUikK"
+                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                         }
                     ]
                 }
@@ -10446,7 +10360,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d7qeana2JAao683Q2XUikK"
+                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                         }
                     ]
                 }
@@ -10459,7 +10373,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -10489,7 +10403,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10497,34 +10411,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:58:41.315788603Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:58:58.256171458Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-08-05T18:58:42.074685776Z",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z"
+                        "build_time": "2026-08-10T13:58:58.918670443Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-08-05T18:58:42.074685776Z",
+                        "built_at": "2026-08-10T13:58:58.918670443Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -10563,7 +10477,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-08-05T18:57:13.648Z",
+                    "updated_at": "2026-08-10T13:55:23.310Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -10619,7 +10533,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-08-05T18:58:58.445Z",
+            "updated_at": "2026-08-10T13:59:13.605Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -10665,7 +10579,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-08-05T18:57:17.452Z"
+                    "updated_at": "2026-08-10T13:55:26.891Z"
                 }
             ]
         },
@@ -10751,7 +10665,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-05T18:57:17.452Z"
+            "updated_at": "2026-08-10T13:55:26.891Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10891,7 +10805,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-05T18:59:02.351Z"
+            "updated_at": "2026-08-10T13:59:17.158Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -11133,7 +11047,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11184,7 +11098,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -11197,7 +11111,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11244,7 +11158,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11285,7 +11199,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11338,7 +11252,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11398,7 +11312,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11456,7 +11370,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12749,7 +12663,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12800,7 +12714,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -12813,7 +12727,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12860,7 +12774,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12901,7 +12815,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12954,7 +12868,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13014,7 +12928,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13072,7 +12986,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13096,18 +13010,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d7qeana2JAao683Q2XUikK",
+                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-08-05T18:57:12.277Z",
-                "updated_at": "2026-08-05T18:57:12.277Z"
+                "created_at": "2026-08-10T13:55:22.110Z",
+                "updated_at": "2026-08-10T13:55:22.110Z"
             }
         ],
         "rawHeaders": [],
@@ -13116,7 +13030,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
         "body": "",
         "status": 204,
         "response": "",
@@ -13126,7 +13040,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
         "body": "",
         "status": 204,
         "response": "",
@@ -13136,7 +13050,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
         "body": "",
         "status": 204,
         "response": "",
@@ -13146,7 +13060,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
         "body": "",
         "status": 204,
         "response": "",
@@ -13156,7 +13070,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
         "body": "",
         "status": 204,
         "response": "",
@@ -13166,7 +13080,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
         "body": "",
         "status": 204,
         "response": "",
@@ -13176,7 +13090,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
         "body": "",
         "status": 204,
         "response": "",
@@ -13247,7 +13161,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+            "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -13269,7 +13183,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -13283,7 +13197,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -13325,7 +13239,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -13367,7 +13281,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -13544,7 +13458,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -13552,34 +13466,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:58:41.315788603Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:58:58.256171458Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 2,
-                        "build_time": "2026-08-05T18:58:42.074685776Z",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z"
+                        "build_time": "2026-08-10T13:58:58.918670443Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "41a29e33-0bb2-4b22-8498-de3d86eabbd7",
+                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
                         "deployed": true,
                         "number": 2,
-                        "built_at": "2026-08-05T18:58:42.074685776Z",
+                        "built_at": "2026-08-10T13:58:58.918670443Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:58:41.994374412Z",
-                        "updated_at": "2026-08-05T18:58:42.076111094Z",
+                        "created_at": "2026-08-10T13:58:58.846471999Z",
+                        "updated_at": "2026-08-10T13:58:58.919104626Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -13600,7 +13514,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d?force=true",
+        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118?force=true",
         "body": "",
         "status": 204,
         "response": "",
@@ -13616,6 +13530,99 @@
         "response": {
             "actions": [],
             "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [],
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_u6eDOnzfycy2sDLb",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": []
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13713,7 +13720,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13795,7 +13802,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13869,100 +13876,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [],
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_3a5w9rUEBfXfZnSs",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": []
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13974,11 +13888,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-08-05T18:59:15.687Z"
+            "deleted_at": "2026-08-10T13:59:29.479Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -14007,7 +13921,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_tWXLXEcrqENnFdJ2",
+            "id": "con_aLhZ4KAMwSo6RqKA",
             "options": {
                 "mfa": {
                     "active": true,
@@ -14091,7 +14005,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14171,14 +14085,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_tWXLXEcrqENnFdJ2/clients",
+        "path": "/api/v2/connections/con_aLhZ4KAMwSo6RqKA/clients",
         "body": [
             {
                 "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                 "status": true
             },
             {
-                "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                 "status": true
             }
         ],
@@ -14280,7 +14194,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14349,7 +14263,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14373,7 +14287,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14445,7 +14359,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                     ]
                 }
             ]
@@ -14477,7 +14391,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14501,7 +14415,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14573,7 +14487,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                     ]
                 }
             ]
@@ -14584,7 +14498,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -14596,11 +14510,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-08-05T18:59:21.264Z"
+            "deleted_at": "2026-08-10T13:59:34.671Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -14732,7 +14646,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15054,25 +14968,25 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_MzpnnGz6d68mbldY",
+                    "id": "rol_suBuW3gIaoRKQ2YI",
                     "name": "Admin",
                     "description": "Can read and write things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_bUvFAw4rOYJNAocU",
+                    "id": "rol_ULMlbmvvd3mzoPwt",
                     "name": "Reader",
                     "description": "Can only read things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_Ix7SQbb6p2t6dQRg",
+                    "id": "rol_lkZCKwORLWaTSWuv",
                     "name": "read_only",
                     "description": "Read Only",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_C6IFQdUiqeNqfYe3",
+                    "id": "rol_sQEZiIEgfOQdKTLk",
                     "name": "read_osnly",
                     "description": "Readz Only",
                     "type": "tenant"
@@ -15088,7 +15002,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15103,7 +15017,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15118,7 +15032,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15133,7 +15047,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15148,7 +15062,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI",
         "body": "",
         "status": 200,
         "response": {},
@@ -15158,7 +15072,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt",
         "body": "",
         "status": 200,
         "response": {},
@@ -15168,7 +15082,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk",
         "body": "",
         "status": 200,
         "response": {},
@@ -15178,10 +15092,43 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv",
         "body": "",
         "status": 200,
         "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": [
+                {
+                    "id": "org_SrEMrFYV9b6phMSo",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_heCvrp0Pkxw4ilGg",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    },
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -15278,7 +15225,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15341,40 +15288,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?include_totals=true&take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": [
-                {
-                    "id": "org_U7hHFWA8LmetETGu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                },
-                {
-                    "id": "org_KvyIU8ipa4KpyL0n",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15389,7 +15303,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15404,7 +15318,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15416,7 +15330,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15431,7 +15360,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15446,11 +15375,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
             "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -15464,7 +15408,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15536,7 +15480,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                     ]
                 }
             ]
@@ -15890,7 +15834,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15953,7 +15897,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg",
         "body": "",
         "status": 204,
         "response": "",
@@ -15963,7 +15907,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo",
         "body": "",
         "status": 204,
         "response": "",
@@ -15978,7 +15922,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000030152",
+                "id": "lst_0000000000030347",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -15989,14 +15933,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000030153",
+                "id": "lst_0000000000030348",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
                 },
                 "filters": [
                     {
@@ -16045,7 +15989,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000030152",
+        "path": "/api/v2/log-streams/lst_0000000000030347",
         "body": "",
         "status": 204,
         "response": "",
@@ -16055,7 +15999,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000030153",
+        "path": "/api/v2/log-streams/lst_0000000000030348",
         "body": "",
         "status": 204,
         "response": "",
@@ -17546,7 +17490,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17576,7 +17520,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17648,7 +17592,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                     ]
                 }
             ]
@@ -17672,16 +17616,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_tWXLXEcrqENnFdJ2/clients?take=100",
+        "path": "/api/v2/connections/con_aLhZ4KAMwSo6RqKA/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                 },
                 {
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 }
             ]
         },
@@ -17712,7 +17656,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_tWXLXEcrqENnFdJ2",
+                    "id": "con_aLhZ4KAMwSo6RqKA",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17784,7 +17728,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "W733pUyDPi9D97vDw314YH0juUeF9Lhi"
+                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
                     ]
                 }
             ]
@@ -17883,6 +17827,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -17901,22 +17860,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/mfa_oob_code",
         "body": "",
         "status": 404,
         "response": {
@@ -17932,6 +17876,21 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/email-templates/enrollment_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email_by_code",
         "body": "",
         "status": 404,
         "response": {
@@ -17965,22 +17924,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
+        "path": "/api/v2/email-templates/blocked_account",
         "body": "",
         "status": 404,
         "response": {
@@ -18010,7 +17954,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
+        "path": "/api/v2/email-templates/stolen_credentials",
         "body": "",
         "status": 404,
         "response": {
@@ -18025,7 +17969,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
+        "path": "/api/v2/email-templates/reset_email",
         "body": "",
         "status": 404,
         "response": {
@@ -18055,7 +17999,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/mfa_oob_code",
+        "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
         "response": {
@@ -18070,7 +18014,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
+        "path": "/api/v2/email-templates/user_invitation",
         "body": "",
         "status": 404,
         "response": {
@@ -18389,7 +18333,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/sms/providers/twilio",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
         "body": "",
         "status": 200,
         "response": {},
@@ -18399,7 +18343,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
         "response": {},
@@ -18517,7 +18461,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-17T06:13:20.998Z"
+                    "updated_at": "2026-08-07T09:04:29.688Z"
                 }
             ]
         },
@@ -18533,33 +18477,33 @@
         "response": {
             "templates": [
                 {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-17T06:13:22.584Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-17T06:13:22.508Z",
+                    "updated_at": "2026-08-07T09:04:31.611Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-08-07T09:04:31.494Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
@@ -18571,7 +18515,7 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-17T06:13:22.506Z",
+                    "updated_at": "2026-08-07T09:04:31.621Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18587,7 +18531,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-17T06:13:22.815Z",
+                    "updated_at": "2026-08-07T09:04:31.802Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18701,7 +18645,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
+        "path": "/api/v2/prompts/login-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18711,7 +18655,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/custom-text/en",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18771,7 +18715,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18791,7 +18735,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18861,6 +18805,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
@@ -18881,16 +18835,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa-sms/custom-text/en",
         "body": "",
         "status": 200,
@@ -18901,7 +18845,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18931,7 +18875,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
+        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18941,7 +18885,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18961,7 +18905,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18971,7 +18915,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -19011,7 +18955,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -19021,7 +18965,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "path": "/api/v2/prompts/captcha/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -19042,6 +18986,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19081,17 +19035,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-password/partials",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/signup-password/partials",
+        "path": "/api/v2/prompts/signup-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19111,7 +19055,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/partials",
+        "path": "/api/v2/prompts/signup-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19188,6 +19132,17 @@
                 },
                 {
                     "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
                     "version": "v2",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -19199,28 +19154,6 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "credentials-exchange",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
                     "id": "credentials-exchange",
                     "version": "v2",
                     "status": "CURRENT",
@@ -19229,6 +19162,17 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "credentials-exchange",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19257,6 +19201,17 @@
                 },
                 {
                     "id": "post-user-registration",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-user-registration",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -19264,17 +19219,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19684,7 +19628,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "W733pUyDPi9D97vDw314YH0juUeF9Lhi",
+                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19747,25 +19691,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": "",
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/attack-protection/breached-password-detection",
         "body": "",
         "status": 200,
@@ -19782,6 +19707,25 @@
                     "shields": []
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": "",
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19872,11 +19816,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19884,11 +19828,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "remember_for": 30
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19959,7 +19903,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-08-05T18:59:02.351Z"
+                    "updated_at": "2026-08-10T13:59:17.158Z"
                 }
             ]
         },
@@ -20030,22 +19974,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-05T18:59:02.351Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows/vault/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 50,
-            "start": 0,
-            "total": 0,
-            "connections": []
+            "updated_at": "2026-08-10T13:59:17.158Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -20061,6 +19990,21 @@
             "start": 0,
             "total": 0,
             "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows/vault/connections?page=0&per_page=50&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 50,
+            "start": 0,
+            "total": 0,
+            "connections": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -20109,7 +20053,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-08-05T18:58:51.655Z",
+                    "updated_at": "2026-08-10T13:59:07.048Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -20161,7 +20105,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-08-05T18:58:39.345Z",
+                    "updated_at": "2026-08-10T13:58:56.622Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -20312,7 +20256,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-08-05T18:58:58.445Z",
+                    "updated_at": "2026-08-10T13:59:13.605Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {

--- a/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
+++ b/test/e2e/recordings/should-deploy-without-deleting-resources-if-AUTH0_ALLOW_DELETE-is-false.json
@@ -187,7 +187,7 @@
         "status": 200,
         "response": {
             "allowed_logout_urls": [
-                "https://travel0.com/logoutCallback"
+                "https://mycompany.org/logoutCallback"
             ],
             "change_password": {
                 "enabled": true,
@@ -223,7 +223,7 @@
                 "disable_clickjack_protection_headers": false,
                 "enable_pipeline2": false
             },
-            "friendly_name": "This tenant name should be preserved",
+            "friendly_name": "My Test Tenant",
             "guardian_mfa_page": {
                 "enabled": true,
                 "html": "<html>MFA</html>\n"
@@ -232,8 +232,8 @@
             "picture_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Grandmas_marathon_finishers.png",
             "sandbox_version": "12",
             "session_lifetime": 3.0166666666666666,
-            "support_email": "support@travel0.com",
-            "support_url": "https://travel0.com/support",
+            "support_email": "support@mycompany.org",
+            "support_url": "https://mycompany.org/support",
             "universal_login": {
                 "colors": {
                     "primary": "#F8F8F2",
@@ -1386,7 +1386,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 3,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -1472,7 +1472,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -1484,59 +1484,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -1630,7 +1577,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1740,7 +1687,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1829,7 +1776,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+            "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -1908,7 +1855,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2014,7 +1961,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+            "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2134,7 +2081,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+            "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2242,7 +2189,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+            "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2257,6 +2204,20 @@
                 "client_credentials"
             ],
             "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/duo",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2292,41 +2253,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
         "body": {
             "enabled": false
         },
         "status": 200,
         "response": {
             "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": true
-        },
-        "status": 200,
-        "response": {
-            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2362,7 +2295,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": true
+        },
+        "status": 200,
+        "response": {
+            "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -2548,7 +2495,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-07-17T06:13:14.009Z",
+                    "updated_at": "2026-08-07T09:04:14.288Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -2593,7 +2540,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-08-05T18:56:55.136Z",
+            "updated_at": "2026-08-10T13:55:03.319Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -2789,7 +2736,7 @@
         },
         "status": 201,
         "response": {
-            "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+            "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -2797,8 +2744,8 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-08-05T18:56:56.983801987Z",
-            "updated_at": "2026-08-05T18:56:56.991550383Z",
+            "created_at": "2026-08-10T13:55:04.937881440Z",
+            "updated_at": "2026-08-10T13:55:04.948366503Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
@@ -2818,7 +2765,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -2826,8 +2773,8 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
@@ -2845,19 +2792,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/actions/actions/89ce1b5c-aa57-4b24-afba-5ff0aff09a5d/deploy",
+        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118/deploy",
         "body": "",
         "status": 200,
         "response": {
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
-            "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+            "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
             "deployed": false,
             "number": 1,
             "secrets": [],
             "status": "built",
-            "created_at": "2026-08-05T18:56:57.654938301Z",
-            "updated_at": "2026-08-05T18:56:57.654938301Z",
+            "created_at": "2026-08-10T13:55:05.534632268Z",
+            "updated_at": "2026-08-10T13:55:05.534632268Z",
             "runtime": "node18",
             "supported_triggers": [
                 {
@@ -2866,7 +2813,7 @@
                 }
             ],
             "action": {
-                "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                 "name": "My Custom Action",
                 "supported_triggers": [
                     {
@@ -2874,67 +2821,10 @@
                         "version": "v2"
                     }
                 ],
-                "created_at": "2026-08-05T18:56:56.983801987Z",
-                "updated_at": "2026-08-05T18:56:56.983801987Z",
+                "created_at": "2026-08-10T13:55:04.937881440Z",
+                "updated_at": "2026-08-10T13:55:04.937881440Z",
                 "all_changes_deployed": false
             }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                }
-            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -2948,7 +2838,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -2956,34 +2846,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3008,7 +2898,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -3094,7 +2984,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3106,59 +2996,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -3200,7 +3037,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3255,7 +3092,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3303,7 +3140,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3344,7 +3181,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3397,7 +3234,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3457,7 +3294,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3515,7 +3352,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -3578,85 +3415,54 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -3686,7 +3492,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -3697,13 +3503,163 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
+                    ]
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -3763,7 +3719,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_3a5w9rUEBfXfZnSs",
+            "id": "con_u6eDOnzfycy2sDLb",
             "options": {
                 "mfa": {
                     "active": true,
@@ -3873,7 +3829,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -3979,14 +3935,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients",
         "body": [
             {
-                "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                 "status": true
             },
             {
-                "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                 "status": true
             }
         ],
@@ -4002,7 +3958,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -4088,7 +4044,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4100,59 +4056,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -4194,7 +4097,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4249,7 +4152,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4297,7 +4200,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4338,7 +4241,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4391,7 +4294,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4451,7 +4354,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4509,7 +4412,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4578,7 +4481,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4675,49 +4578,53 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                },
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -4747,7 +4654,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -4779,7 +4686,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4876,49 +4783,53 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                },
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -4948,7 +4859,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -4958,28 +4869,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                },
-                {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1",
+        "method": "POST",
+        "path": "/api/v2/connections",
         "body": {
+            "name": "google-oauth2",
+            "strategy": "google-oauth2",
             "is_domain_connection": false,
             "options": {
                 "email": true,
@@ -4990,9 +4884,9 @@
                 "profile": true
             }
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "con_wXkTr1DrHw8CrHg1",
+            "id": "con_Dyc8vFGQ4ncArPi0",
             "options": {
                 "email": true,
                 "scope": [
@@ -5010,10 +4904,7 @@
             "connected_accounts": {
                 "active": false
             },
-            "enabled_clients": [
-                "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-            ],
+            "enabled_clients": [],
             "realms": [
                 "google-oauth2"
             ]
@@ -5023,24 +4914,53 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=google-oauth2&include_fields=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_Dyc8vFGQ4ncArPi0",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": []
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients",
         "body": [
             {
-                "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                 "status": true
             },
             {
-                "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                 "status": true
-            },
-            {
-                "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-                "status": false
-            },
-            {
-                "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "status": false
             }
         ],
         "status": 204,
@@ -5092,7 +5012,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -5178,7 +5098,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5190,59 +5110,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -5284,7 +5151,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5339,7 +5206,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5387,7 +5254,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5428,7 +5295,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5481,7 +5348,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5541,7 +5408,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5599,7 +5466,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5917,7 +5784,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6054,8 +5921,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_kaiA3umN6yp9IOm9",
-            "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+            "id": "cgr_NUKidZC54pI9CYZV",
+            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6199,7 +6066,7 @@
         "method": "POST",
         "path": "/api/v2/client-grants",
         "body": {
-            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6336,8 +6203,8 @@
         },
         "status": 201,
         "response": {
-            "id": "cgr_b9Nqc0prQVFMjIhm",
-            "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+            "id": "cgr_pzLmQ5o4eKIoCQXe",
+            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -6501,7 +6368,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_bUvFAw4rOYJNAocU",
+            "id": "rol_ULMlbmvvd3mzoPwt",
             "name": "Reader",
             "description": "Can only read things",
             "type": "tenant"
@@ -6519,7 +6386,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_MzpnnGz6d68mbldY",
+            "id": "rol_suBuW3gIaoRKQ2YI",
             "name": "Admin",
             "description": "Can read and write things",
             "type": "tenant"
@@ -6537,7 +6404,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_Ix7SQbb6p2t6dQRg",
+            "id": "rol_lkZCKwORLWaTSWuv",
             "name": "read_only",
             "description": "Read Only",
             "type": "tenant"
@@ -6555,7 +6422,7 @@
         },
         "status": 200,
         "response": {
-            "id": "rol_C6IFQdUiqeNqfYe3",
+            "id": "rol_sQEZiIEgfOQdKTLk",
             "name": "read_osnly",
             "description": "Readz Only",
             "type": "tenant"
@@ -6592,7 +6459,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-07-17T06:13:21.914Z",
+                    "updated_at": "2026-08-07T09:04:30.894Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -6668,7 +6535,7 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-08-05T18:57:08.272Z",
+            "updated_at": "2026-08-10T13:55:18.245Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
@@ -6735,11 +6602,23 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -6825,7 +6704,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6837,59 +6716,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -6931,7 +6757,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6986,7 +6812,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7034,7 +6860,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7075,7 +6901,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7128,7 +6954,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7188,7 +7014,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7246,7 +7072,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -7309,25 +7135,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?include_totals=true&take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -7424,12 +7238,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -7451,22 +7265,53 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -7496,7 +7341,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -7513,146 +7358,8 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -8027,6 +7734,144 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
                 }
             ]
         },
@@ -8037,771 +7882,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 11,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": true,
-                    "callbacks": [],
-                    "is_first_party": true,
-                    "name": "All Applications",
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "owners": [
-                        "mr|samlp|okta|will.vedder@auth0.com",
-                        "mr|google-oauth2|102002633619863830825",
-                        "mr|samlp|okta|frederik.prijck@auth0.com",
-                        "mr|google-oauth2|109614534713742077035",
-                        "mr|google-oauth2|116771660953104383819",
-                        "mr|google-oauth2|112839029247827700155",
-                        "mr|samlp|okta|ewan.harris@auth0.com",
-                        "mr|google-oauth2|113227425378005249939",
-                        "mr|google-oauth2|111201688215901175487"
-                    ],
-                    "custom_login_page": "<html>TEST123</html>\n",
-                    "cross_origin_authentication": true,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
-                    "client_secret": "[REDACTED]",
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
-        "body": {
-            "name": "org1",
-            "branding": {
-                "colors": {
-                    "page_background": "#fff5f5",
-                    "primary": "#57ddff"
-                }
-            },
-            "display_name": "Organization"
-        },
-        "status": 201,
-        "response": {
-            "id": "org_U7hHFWA8LmetETGu",
-            "display_name": "Organization",
-            "name": "org1",
-            "branding": {
-                "colors": {
-                    "page_background": "#fff5f5",
-                    "primary": "#57ddff"
-                }
-            },
-            "third_party_client_access": "block",
-            "is_app_entitlement_active": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/organizations",
-        "body": {
-            "name": "org2",
-            "display_name": "Organization2"
-        },
-        "status": 201,
-        "response": {
-            "id": "org_KvyIU8ipa4KpyL0n",
-            "display_name": "Organization2",
-            "name": "org2",
-            "third_party_client_access": "block",
-            "is_app_entitlement_active": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/log-streams",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/log-streams",
-        "body": {
-            "name": "Suspended DD Log Stream",
-            "sink": {
-                "datadogApiKey": "some-sensitive-api-key",
-                "datadogRegion": "us"
-            },
-            "type": "datadog"
-        },
-        "status": 200,
-        "response": {
-            "id": "lst_0000000000030152",
-            "name": "Suspended DD Log Stream",
-            "type": "datadog",
-            "status": "active",
-            "sink": {
-                "datadogApiKey": "some-sensitive-api-key",
-                "datadogRegion": "us"
-            },
-            "isPriority": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/log-streams",
-        "body": {
-            "name": "Amazon EventBridge",
-            "filters": [
-                {
-                    "type": "category",
-                    "name": "auth.login.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.login.notification"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.login.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.signup.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.logout.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.logout.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.silent_auth.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.silent_auth.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.token_exchange.fail"
-                }
-            ],
-            "sink": {
-                "awsAccountId": "123456789012",
-                "awsRegion": "us-east-2"
-            },
-            "type": "eventbridge"
-        },
-        "status": 200,
-        "response": {
-            "id": "lst_0000000000030153",
-            "name": "Amazon EventBridge",
-            "type": "eventbridge",
-            "status": "active",
-            "sink": {
-                "awsAccountId": "123456789012",
-                "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
-            },
-            "filters": [
-                {
-                    "type": "category",
-                    "name": "auth.login.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.login.notification"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.login.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.signup.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.logout.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.logout.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.silent_auth.fail"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.silent_auth.success"
-                },
-                {
-                    "type": "category",
-                    "name": "auth.token_exchange.fail"
-                }
-            ],
-            "isPriority": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true&is_global=false",
         "body": "",
         "status": 200,
         "response": {
@@ -8891,7 +7971,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8903,59 +7983,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -8997,7 +8024,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9052,7 +8079,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9100,7 +8127,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9141,7 +8168,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9194,7 +8221,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9254,7 +8281,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9312,7 +8339,719 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": true,
+                    "callbacks": [],
+                    "is_first_party": true,
+                    "name": "All Applications",
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "owners": [
+                        "mr|samlp|okta|will.vedder@auth0.com",
+                        "mr|google-oauth2|102002633619863830825",
+                        "mr|samlp|okta|frederik.prijck@auth0.com",
+                        "mr|google-oauth2|109614534713742077035",
+                        "mr|google-oauth2|116771660953104383819",
+                        "mr|google-oauth2|112839029247827700155",
+                        "mr|samlp|okta|ewan.harris@auth0.com",
+                        "mr|google-oauth2|113227425378005249939",
+                        "mr|google-oauth2|111201688215901175487"
+                    ],
+                    "custom_login_page": "<html>TEST123</html>\n",
+                    "cross_origin_authentication": true,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Isi93ibGHIGwmdYjsLwTOn7Gu7nwxU3V",
+                    "client_secret": "[REDACTED]",
+                    "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/organizations",
+        "body": {
+            "name": "org2",
+            "display_name": "Organization2"
+        },
+        "status": 201,
+        "response": {
+            "id": "org_SrEMrFYV9b6phMSo",
+            "display_name": "Organization2",
+            "name": "org2",
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/organizations",
+        "body": {
+            "name": "org1",
+            "branding": {
+                "colors": {
+                    "page_background": "#fff5f5",
+                    "primary": "#57ddff"
+                }
+            },
+            "display_name": "Organization"
+        },
+        "status": 201,
+        "response": {
+            "id": "org_heCvrp0Pkxw4ilGg",
+            "display_name": "Organization",
+            "name": "org1",
+            "branding": {
+                "colors": {
+                    "page_background": "#fff5f5",
+                    "primary": "#57ddff"
+                }
+            },
+            "third_party_client_access": "block",
+            "is_app_entitlement_active": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/log-streams",
+        "body": "",
+        "status": 200,
+        "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
+        "body": {
+            "name": "Suspended DD Log Stream",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            },
+            "type": "datadog"
+        },
+        "status": 200,
+        "response": {
+            "id": "lst_0000000000030347",
+            "name": "Suspended DD Log Stream",
+            "type": "datadog",
+            "status": "active",
+            "sink": {
+                "datadogApiKey": "some-sensitive-api-key",
+                "datadogRegion": "us"
+            },
+            "isPriority": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
+        "body": {
+            "name": "Amazon EventBridge",
+            "filters": [
+                {
+                    "type": "category",
+                    "name": "auth.login.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.login.notification"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.login.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.signup.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.logout.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.logout.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.silent_auth.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.silent_auth.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.token_exchange.fail"
+                }
+            ],
+            "sink": {
+                "awsAccountId": "123456789012",
+                "awsRegion": "us-east-2"
+            },
+            "type": "eventbridge"
+        },
+        "status": 200,
+        "response": {
+            "id": "lst_0000000000030348",
+            "name": "Amazon EventBridge",
+            "type": "eventbridge",
+            "status": "active",
+            "sink": {
+                "awsAccountId": "123456789012",
+                "awsRegion": "us-east-2",
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
+            },
+            "filters": [
+                {
+                    "type": "category",
+                    "name": "auth.login.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.login.notification"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.login.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.signup.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.logout.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.logout.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.silent_auth.fail"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.silent_auth.success"
+                },
+                {
+                    "type": "category",
+                    "name": "auth.token_exchange.fail"
+                }
+            ],
+            "isPriority": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true&is_global=false",
+        "body": "",
+        "status": 200,
+        "response": {
+            "total": 9,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9336,7 +9075,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": "",
         "status": 200,
         "response": [],
@@ -9346,7 +9085,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "POST",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": {
             "name": "e2e-test-key",
             "pem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs8/9RN2qV8HZMunRt8mx\nihqnIX726YqxGwF+7x1A0gpk4TWRpMUWnaaL2D3Nt/Kd5obKM0THZPCuE+Xwncf4\nQloizZEn4jM3PNldweL9qwG160o2wXif2R5zLVQat9/188+Ko/sU/LorHgh23DMp\nznSwIN30AdLG1WRPxqP5s9abVT0WgBt1VuQobw4TS6QltFUnMSEMBsNtMSPK+NPJ\npz9s3ozqkNMLNSLZMTwgODQWchUr2YJeZa5RbM0u5Xt9oF0HtXH8db3L6Rp3TdIA\nuISnZ+mC7zRiCzWljkJZSBrqgtx6Su5wSve9cYGPS23zu3yeSapJWP7pki3G/GBz\nJQIDAQAB\n-----END PUBLIC KEY-----\n",
@@ -9354,13 +9093,13 @@
         },
         "status": 201,
         "response": {
-            "id": "cred_d7qeana2JAao683Q2XUikK",
+            "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
             "credential_type": "public_key",
             "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
             "alg": "RS256",
             "name": "e2e-test-key",
-            "created_at": "2026-08-05T18:57:12.277Z",
-            "updated_at": "2026-08-05T18:57:12.277Z"
+            "created_at": "2026-08-10T13:55:22.110Z",
+            "updated_at": "2026-08-10T13:55:22.110Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9368,13 +9107,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d7qeana2JAao683Q2XUikK"
+                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                         }
                     ]
                 }
@@ -9417,7 +9156,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_d7qeana2JAao683Q2XUikK"
+                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                         }
                     ]
                 }
@@ -9430,7 +9169,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -9460,7 +9199,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -9468,34 +9207,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -9534,7 +9273,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-07-17T06:13:27.176Z",
+                    "updated_at": "2026-08-07T09:04:43.820Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -9590,7 +9329,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-08-05T18:57:13.648Z",
+            "updated_at": "2026-08-10T13:55:23.310Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -9636,7 +9375,7 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-07-30T13:01:57.535Z"
+                    "updated_at": "2026-08-10T12:58:47.473Z"
                 }
             ]
         },
@@ -9722,7 +9461,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-07-30T13:01:57.535Z"
+            "updated_at": "2026-08-10T12:58:47.473Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -9862,7 +9601,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-05T18:57:17.452Z"
+            "updated_at": "2026-08-10T13:55:26.891Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -11167,6 +10906,1241 @@
         "body": "",
         "status": 200,
         "response": {
+            "total": 9,
+            "start": 0,
+            "limit": 100,
+            "clients": [
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Deploy CLI",
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "cross_origin_authentication": false,
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials",
+                        "implicit",
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Default App",
+                    "callbacks": [],
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "API Explorer Application",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Node App",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "client_authentication_methods": {
+                        "private_key_jwt": {
+                            "credentials": [
+                                {
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                                }
+                            ]
+                        }
+                    },
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "allowed_origins": [],
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "callback_url_template": false,
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "app_type": "regular_web",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "web_origins": [],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Quickstarts API (Test Application)",
+                    "client_metadata": {
+                        "foo": "bar"
+                    },
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Terraform Provider",
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "The Default App",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": false,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso": false,
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token",
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "Test SPA",
+                    "allowed_clients": [],
+                    "allowed_logout_urls": [
+                        "http://localhost:3000"
+                    ],
+                    "callbacks": [
+                        "http://localhost:3000"
+                    ],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "expiring",
+                        "leeway": 0,
+                        "token_lifetime": 2592000,
+                        "idle_token_lifetime": 1296000,
+                        "infinite_token_lifetime": false,
+                        "infinite_idle_token_lifetime": false,
+                        "rotation_type": "rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "none",
+                    "app_type": "spa",
+                    "grant_types": [
+                        "authorization_code",
+                        "implicit",
+                        "refresh_token"
+                    ],
+                    "web_origins": [
+                        "http://localhost:3000"
+                    ],
+                    "custom_login_page_on": true
+                },
+                {
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "global": false,
+                    "is_token_endpoint_ip_header_trusted": false,
+                    "name": "auth0-deploy-cli-extension",
+                    "allowed_clients": [],
+                    "callbacks": [],
+                    "client_metadata": {},
+                    "cross_origin_authentication": false,
+                    "is_first_party": true,
+                    "native_social_login": {
+                        "apple": {
+                            "enabled": false
+                        },
+                        "facebook": {
+                            "enabled": false
+                        }
+                    },
+                    "oidc_conformant": true,
+                    "refresh_token": {
+                        "expiration_type": "non-expiring",
+                        "leeway": 0,
+                        "infinite_token_lifetime": true,
+                        "infinite_idle_token_lifetime": true,
+                        "token_lifetime": 31557600,
+                        "idle_token_lifetime": 2592000,
+                        "rotation_type": "non-rotating"
+                    },
+                    "sso_disabled": false,
+                    "cross_origin_auth": false,
+                    "signing_keys": [
+                        {
+                            "cert": "[REDACTED]",
+                            "pkcs7": "[REDACTED]",
+                            "subject": "deprecated"
+                        }
+                    ],
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
+                    "jwt_configuration": {
+                        "alg": "RS256",
+                        "lifetime_in_seconds": 36000,
+                        "secret_encoded": false
+                    },
+                    "client_aliases": [],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "app_type": "non_interactive",
+                    "grant_types": [
+                        "client_credentials"
+                    ],
+                    "custom_login_page_on": true
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
+        "body": "",
+        "status": 200,
+        "response": [
+            {
+                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
+                "credential_type": "public_key",
+                "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
+                "alg": "RS256",
+                "name": "e2e-test-key",
+                "created_at": "2026-08-10T13:55:22.110Z",
+                "updated_at": "2026-08-10T13:55:22.110Z"
+            }
+        ],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/clients/4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+        "body": {
+            "name": "Default App",
+            "callbacks": [],
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false
+        },
+        "status": 200,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Default App",
+            "callbacks": [],
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/duo",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/sms",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/otp",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/email",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/recovery-code",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/webauthn-roaming",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/push-notification",
+        "body": {
+            "enabled": false
+        },
+        "status": 200,
+        "response": {
+            "enabled": false
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/policies",
+        "body": [],
+        "status": 200,
+        "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/phone/selected-provider",
+        "body": {
+            "provider": "auth0"
+        },
+        "status": 200,
+        "response": {
+            "provider": "auth0"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PUT",
+        "path": "/api/v2/guardian/factors/phone/message-types",
+        "body": {
+            "message_types": []
+        },
+        "status": 200,
+        "response": {
+            "message_types": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/brute-force-protection",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "block",
+                "user_notification"
+            ],
+            "mode": "count_per_identifier_and_ip",
+            "allowlist": [],
+            "max_attempts": 10
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
+        "body": {
+            "enabled": true,
+            "shields": [
+                "admin_notification",
+                "block"
+            ],
+            "allowlist": [],
+            "stage": {
+                "pre-login": {
+                    "max_attempts": 100,
+                    "rate": 864000
+                },
+                "pre-user-registration": {
+                    "max_attempts": 50,
+                    "rate": 1200
+                }
+            }
+        },
+        "status": 200,
+        "response": {
+            "enabled": true,
+            "shields": [
+                "admin_notification",
+                "block"
+            ],
+            "allowlist": [],
+            "stage": {
+                "pre-login": {
+                    "max_attempts": 100,
+                    "rate": 864000
+                },
+                "pre-user-registration": {
+                    "max_attempts": 50,
+                    "rate": 1200
+                },
+                "pre-custom-token-exchange": {
+                    "max_attempts": 10,
+                    "rate": 600000
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/modules?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "modules": [],
+            "total": 0,
+            "page": 0,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_u6eDOnzfycy2sDLb",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "boo-baz-db-connection-test"
+                    ],
+                    "enabled_clients": [
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                    ]
+                },
+                {
+                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
+                    ]
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
             "total": 10,
             "start": 0,
             "limit": 100,
@@ -11253,7 +12227,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11265,59 +12239,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -11359,7 +12280,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11410,7 +12331,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -11423,7 +12344,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11470,7 +12391,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11511,7 +12432,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11564,7 +12485,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11624,7 +12545,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11682,1264 +12603,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
-        "body": "",
-        "status": 200,
-        "response": [
-            {
-                "id": "cred_d7qeana2JAao683Q2XUikK",
-                "credential_type": "public_key",
-                "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
-                "alg": "RS256",
-                "name": "e2e-test-key",
-                "created_at": "2026-08-05T18:57:12.277Z",
-                "updated_at": "2026-08-05T18:57:12.277Z"
-            }
-        ],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-        "body": {
-            "name": "Default App",
-            "callbacks": [],
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Default App",
-            "callbacks": [],
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/otp",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-roaming",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
-        "body": {
-            "enabled": false
-        },
-        "status": 200,
-        "response": {
-            "enabled": false
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/policies",
-        "body": [],
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/phone/selected-provider",
-        "body": {
-            "provider": "auth0"
-        },
-        "status": 200,
-        "response": {
-            "provider": "auth0"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PUT",
-        "path": "/api/v2/guardian/factors/phone/message-types",
-        "body": {
-            "message_types": []
-        },
-        "status": 200,
-        "response": {
-            "message_types": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/suspicious-ip-throttling",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "admin_notification",
-                "block"
-            ],
-            "allowlist": [],
-            "stage": {
-                "pre-login": {
-                    "max_attempts": 100,
-                    "rate": 864000
-                },
-                "pre-user-registration": {
-                    "max_attempts": 50,
-                    "rate": 1200
-                }
-            }
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "admin_notification",
-                "block"
-            ],
-            "allowlist": [],
-            "stage": {
-                "pre-login": {
-                    "max_attempts": 100,
-                    "rate": 864000
-                },
-                "pre-user-registration": {
-                    "max_attempts": 50,
-                    "rate": 1200
-                },
-                "pre-custom-token-exchange": {
-                    "max_attempts": 10,
-                    "rate": 600000
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/brute-force-protection",
-        "body": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "status": 200,
-        "response": {
-            "enabled": true,
-            "shields": [
-                "block",
-                "user_notification"
-            ],
-            "mode": "count_per_identifier_and_ip",
-            "allowlist": [],
-            "max_attempts": 10
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/modules?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "modules": [],
-            "total": 0,
-            "page": 0,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_3a5w9rUEBfXfZnSs",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
-                    ]
-                },
-                {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "total": 11,
-            "start": 0,
-            "limit": 100,
-            "clients": [
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Deploy CLI",
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "cross_origin_authentication": false,
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials",
-                        "implicit",
-                        "authorization_code",
-                        "refresh_token"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Default App",
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
-                                }
-                            ]
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                    "callback_url_template": false,
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13002,13 +12666,75 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "current_version": {
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "runtime": "node18",
+                        "status": "BUILT",
+                        "number": 1,
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                    },
+                    "deployed_version": {
+                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                        "dependencies": [],
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "deployed": true,
+                        "number": 1,
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "secrets": [],
+                        "status": "built",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "runtime": "node18",
+                        "supported_triggers": [
+                            {
+                                "id": "post-login",
+                                "version": "v2"
+                            }
+                        ]
+                    },
+                    "all_changes_deployed": true
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13105,22 +12831,53 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
                             "return_enroll_settings": true
                         },
-                        "passwordPolicy": "good",
                         "passkey_options": {
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
+                        },
+                        "password_options": {
+                            "history": {
+                                "size": 3,
+                                "active": false
+                            },
+                            "complexity": {
+                                "min_length": 15,
+                                "character_types": [],
+                                "character_type_rule": "all",
+                                "max_length_exceeded": "error",
+                                "identical_characters": "allow",
+                                "sequential_characters": "allow"
+                            },
+                            "dictionary": {
+                                "active": false,
+                                "custom": [],
+                                "default": "en_100k"
+                            },
+                            "profile_data": {
+                                "active": false,
+                                "blocked_fields": [
+                                    "name",
+                                    "username",
+                                    "nickname",
+                                    "email",
+                                    "phone_number",
+                                    "user_metadata.name",
+                                    "user_metadata.first",
+                                    "user_metadata.last"
+                                ]
+                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -13150,7 +12907,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -13161,94 +12918,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "actions": [
-                {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
-            "per_page": 100
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
-                },
-                {
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -13261,21 +12937,71 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
-            "id": "con_GCIw7tDhSMeiCyeZ",
+            "clients": [
+                {
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                },
+                {
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw"
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
+        "body": "",
+        "status": 200,
+        "response": {
+            "id": "con_zXAdAJ7zaBMcTUlE",
             "options": {
                 "mfa": {
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "good",
                 "passkey_options": {
                     "challenge_ui": "both",
                     "local_enrollment_enabled": true,
                     "progressive_enrollment_enabled": true
+                },
+                "password_options": {
+                    "history": {
+                        "size": 3,
+                        "active": false
+                    },
+                    "complexity": {
+                        "min_length": 15,
+                        "character_types": [],
+                        "character_type_rule": "all",
+                        "max_length_exceeded": "error",
+                        "identical_characters": "allow",
+                        "sequential_characters": "allow"
+                    },
+                    "dictionary": {
+                        "active": false,
+                        "custom": [],
+                        "default": "en_100k"
+                    },
+                    "profile_data": {
+                        "active": false,
+                        "blocked_fields": [
+                            "name",
+                            "username",
+                            "nickname",
+                            "email",
+                            "phone_number",
+                            "user_metadata.name",
+                            "user_metadata.first",
+                            "user_metadata.last"
+                        ]
+                    }
                 },
                 "strategy_version": 2,
                 "authentication_methods": {
@@ -13302,7 +13028,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -13314,7 +13040,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
         "body": {
             "is_domain_connection": false,
             "realms": [
@@ -13325,7 +13051,6 @@
                     "active": true,
                     "return_enroll_settings": true
                 },
-                "passwordPolicy": "good",
                 "passkey_options": {
                     "challenge_ui": "both",
                     "local_enrollment_enabled": true,
@@ -13343,12 +13068,13 @@
                     }
                 },
                 "brute_force_protection": true,
-                "disable_self_service_change_password": false
+                "disable_self_service_change_password": false,
+                "passwordPolicy": "good"
             }
         },
         "status": 200,
         "response": {
-            "id": "con_GCIw7tDhSMeiCyeZ",
+            "id": "con_zXAdAJ7zaBMcTUlE",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13385,7 +13111,7 @@
             },
             "enabled_clients": [
                 "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
             ],
             "realms": [
                 "Username-Password-Authentication"
@@ -13401,7 +13127,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -13487,7 +13213,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13499,59 +13225,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -13593,7 +13266,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13644,7 +13317,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -13657,7 +13330,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -13704,7 +13377,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13745,7 +13418,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13798,7 +13471,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13858,7 +13531,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13916,7 +13589,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13985,7 +13658,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14082,12 +13755,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14109,12 +13782,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14154,7 +13827,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -14186,7 +13859,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14283,12 +13956,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14310,12 +13983,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14355,7 +14028,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -14366,16 +14039,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i"
                 },
                 {
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                 }
             ]
         },
@@ -14404,7 +14077,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -14490,7 +14163,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14502,59 +14175,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -14596,7 +14216,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14647,7 +14267,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -14660,7 +14280,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -14707,7 +14327,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14748,7 +14368,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14801,7 +14421,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14861,7 +14481,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14919,7 +14539,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14988,146 +14608,8 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -15502,6 +14984,144 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
                 }
             ]
         },
@@ -15517,25 +15137,25 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_MzpnnGz6d68mbldY",
+                    "id": "rol_suBuW3gIaoRKQ2YI",
                     "name": "Admin",
                     "description": "Can read and write things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_bUvFAw4rOYJNAocU",
+                    "id": "rol_ULMlbmvvd3mzoPwt",
                     "name": "Reader",
                     "description": "Can only read things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_Ix7SQbb6p2t6dQRg",
+                    "id": "rol_lkZCKwORLWaTSWuv",
                     "name": "read_only",
                     "description": "Read Only",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_C6IFQdUiqeNqfYe3",
+                    "id": "rol_sQEZiIEgfOQdKTLk",
                     "name": "read_osnly",
                     "description": "Readz Only",
                     "type": "tenant"
@@ -15551,7 +15171,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15566,7 +15186,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15581,7 +15201,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15596,7 +15216,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15604,6 +15224,39 @@
             "start": 0,
             "limit": 100,
             "total": 0
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "organizations": [
+                {
+                    "id": "org_SrEMrFYV9b6phMSo",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_heCvrp0Pkxw4ilGg",
+                    "name": "org1",
+                    "display_name": "Organization",
+                    "branding": {
+                        "colors": {
+                            "page_background": "#fff5f5",
+                            "primary": "#57ddff"
+                        }
+                    },
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                }
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -15615,7 +15268,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -15701,7 +15354,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15713,59 +15366,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -15807,7 +15407,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15858,7 +15458,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -15871,7 +15471,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -15918,7 +15518,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15959,7 +15559,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16012,7 +15612,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16072,7 +15672,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16130,7 +15730,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -16193,40 +15793,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations?include_totals=true&take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "organizations": [
-                {
-                    "id": "org_U7hHFWA8LmetETGu",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                },
-                {
-                    "id": "org_KvyIU8ipa4KpyL0n",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -16241,7 +15808,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -16256,7 +15823,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -16268,7 +15835,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -16283,7 +15865,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -16298,11 +15880,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
             "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -16316,7 +15913,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -16413,12 +16010,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -16440,12 +16037,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -16485,7 +16082,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -16502,146 +16099,8 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -17016,6 +16475,144 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
                 }
             ]
         },
@@ -17029,7 +16626,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -17115,7 +16712,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17127,59 +16724,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -17221,7 +16765,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17272,7 +16816,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -17285,7 +16829,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -17332,7 +16876,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17373,7 +16917,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17426,7 +16970,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17486,7 +17030,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17544,7 +17088,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17612,7 +17156,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000030152",
+                "id": "lst_0000000000030347",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -17623,14 +17167,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000030153",
+                "id": "lst_0000000000030348",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
                 },
                 "filters": [
                     {
@@ -19074,7 +18618,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 10,
+            "total": 9,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -19160,7 +18704,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19172,59 +18716,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -19266,7 +18757,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19317,7 +18808,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -19330,7 +18821,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -19377,7 +18868,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19418,7 +18909,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19471,7 +18962,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19531,7 +19022,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19589,7 +19080,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19613,18 +19104,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx/credentials",
+        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_d7qeana2JAao683Q2XUikK",
+                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-08-05T18:57:12.277Z",
-                "updated_at": "2026-08-05T18:57:12.277Z"
+                "created_at": "2026-08-10T13:55:22.110Z",
+                "updated_at": "2026-08-10T13:55:22.110Z"
             }
         ],
         "rawHeaders": [],
@@ -19639,7 +19130,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19736,12 +19227,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -19781,7 +19272,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -19798,7 +19289,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -19806,34 +19297,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -19854,13 +19345,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_GCIw7tDhSMeiCyeZ/clients?take=100",
+        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -19873,16 +19364,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_3a5w9rUEBfXfZnSs/clients?take=100",
+        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                 },
                 {
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx"
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw"
                 }
             ]
         },
@@ -19913,7 +19404,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_3a5w9rUEBfXfZnSs",
+                    "id": "con_u6eDOnzfycy2sDLb",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -20010,12 +19501,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_wXkTr1DrHw8CrHg1",
+                    "id": "con_Dyc8vFGQ4ncArPi0",
                     "options": {
                         "email": true,
                         "scope": [
@@ -20037,12 +19528,12 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
-                        "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                     ]
                 },
                 {
-                    "id": "con_GCIw7tDhSMeiCyeZ",
+                    "id": "con_zXAdAJ7zaBMcTUlE",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -20082,7 +19573,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld"
+                        "4KWdBigdmxBionUsdewvtlj7npUfWHTA"
                     ]
                 }
             ]
@@ -20093,16 +19584,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_wXkTr1DrHw8CrHg1/clients?take=100",
+        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE"
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i"
                 },
                 {
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL"
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
                 }
             ]
         },
@@ -20200,21 +19691,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email_by_code",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/verify_email",
         "body": "",
         "status": 200,
@@ -20226,6 +19702,21 @@
             "syntax": "liquid",
             "urlLifetimeInSeconds": 432000,
             "enabled": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/verify_email_by_code",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -20267,111 +19758,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/password_reset",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/stolen_credentials",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/async_approval",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
@@ -20402,152 +19788,119 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/email-templates/stolen_credentials",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/change_password",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/async_approval",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/password_reset",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/client-grants?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_b9Nqc0prQVFMjIhm",
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
-                {
-                    "id": "cgr_kaiA3umN6yp9IOm9",
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "id": "cgr_NUKidZC54pI9CYZV",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -20922,6 +20275,144 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
+                },
+                {
+                    "id": "cgr_pzLmQ5o4eKIoCQXe",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
                 }
             ]
         },
@@ -21055,25 +20546,25 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_MzpnnGz6d68mbldY",
+                    "id": "rol_suBuW3gIaoRKQ2YI",
                     "name": "Admin",
                     "description": "Can read and write things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_bUvFAw4rOYJNAocU",
+                    "id": "rol_ULMlbmvvd3mzoPwt",
                     "name": "Reader",
                     "description": "Can only read things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_Ix7SQbb6p2t6dQRg",
+                    "id": "rol_lkZCKwORLWaTSWuv",
                     "name": "read_only",
                     "description": "Read Only",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_C6IFQdUiqeNqfYe3",
+                    "id": "rol_sQEZiIEgfOQdKTLk",
                     "name": "read_osnly",
                     "description": "Readz Only",
                     "type": "tenant"
@@ -21089,7 +20580,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_MzpnnGz6d68mbldY/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -21104,7 +20595,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_bUvFAw4rOYJNAocU/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -21119,7 +20610,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_Ix7SQbb6p2t6dQRg/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -21134,7 +20625,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_C6IFQdUiqeNqfYe3/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -21195,7 +20686,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-07-17T06:13:20.998Z"
+                    "updated_at": "2026-08-07T09:04:29.688Z"
                 }
             ]
         },
@@ -21211,33 +20702,33 @@
         "response": {
             "templates": [
                 {
-                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "channel": "phone",
-                    "type": "otp_verify",
-                    "disabled": false,
-                    "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-07-17T06:13:22.584Z",
-                    "content": {
-                        "syntax": "liquid",
-                        "body": {
-                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
-                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
-                        }
-                    }
-                },
-                {
                     "id": "tem_qarYST5TTE5pbMNB5NHZAj",
                     "tenant": "auth0-deploy-cli-e2e",
                     "channel": "phone",
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-07-17T06:13:22.508Z",
+                    "updated_at": "2026-08-07T09:04:31.611Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
                             "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}. Please enter this code to verify your enrollment.",
+                            "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
+                        }
+                    }
+                },
+                {
+                    "id": "tem_o4LBTt4NQyX8K4vC9dPafR",
+                    "tenant": "auth0-deploy-cli-e2e",
+                    "channel": "phone",
+                    "type": "otp_verify",
+                    "disabled": false,
+                    "created_at": "2025-12-09T12:26:30.547Z",
+                    "updated_at": "2026-08-07T09:04:31.494Z",
+                    "content": {
+                        "syntax": "liquid",
+                        "body": {
+                            "text": "{{ code | escape }} is your verification code for {{ friendly_name | escape }}",
                             "voice": "Hello. Your verification code for {{ friendly_name | escape }} is {{ pause }} {{ code | escape }}. I repeat, your verification code is {{ pause }} {{ code | escape }}"
                         }
                     }
@@ -21249,7 +20740,7 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-07-17T06:13:22.506Z",
+                    "updated_at": "2026-08-07T09:04:31.621Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -21265,7 +20756,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-07-17T06:13:22.815Z",
+                    "updated_at": "2026-08-07T09:04:31.802Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -21369,16 +20860,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/login-id/custom-text/en",
         "body": "",
         "status": 200,
@@ -21389,17 +20870,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "path": "/api/v2/prompts/login/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21419,7 +20890,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/custom-text/en",
+        "path": "/api/v2/prompts/login-passwordless/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21439,6 +20920,16 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/prompts/signup-id/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/prompts/signup-password/custom-text/en",
         "body": "",
         "status": 200,
@@ -21449,7 +20940,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21469,7 +20960,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-identifier-challenge/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/reset-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21509,7 +21010,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/reset-password/custom-text/en",
+        "path": "/api/v2/prompts/logout/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21539,16 +21040,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/logout/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
@@ -21559,7 +21050,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21569,7 +21060,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-phone/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21609,16 +21100,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
@@ -21629,7 +21110,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-verification/custom-text/en",
+        "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21649,7 +21130,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "path": "/api/v2/prompts/email-verification/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21659,7 +21140,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/invitation/custom-text/en",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21679,7 +21160,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/captcha/custom-text/en",
+        "path": "/api/v2/prompts/invitation/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21690,6 +21171,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/common/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/captcha/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -21719,7 +21210,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-id/partials",
+        "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21729,7 +21220,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/partials",
+        "path": "/api/v2/prompts/login-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21759,7 +21250,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/partials",
+        "path": "/api/v2/prompts/login-passwordless/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21769,7 +21260,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-passwordless/partials",
+        "path": "/api/v2/prompts/signup-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -21820,7 +21311,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -21828,34 +21319,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -21898,29 +21389,6 @@
             "triggers": [
                 {
                     "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
-                    "version": "v2",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node18",
-                        "node22"
-                    ],
-                    "default_runtime": "node16",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v3",
                     "status": "CURRENT",
                     "runtimes": [
@@ -21937,6 +21405,29 @@
                     ]
                 },
                 {
+                    "id": "post-login",
+                    "version": "v2",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node18",
+                        "node22"
+                    ],
+                    "default_runtime": "node16",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
                     "id": "credentials-exchange",
                     "version": "v1",
                     "status": "DEPRECATED",
@@ -21961,29 +21452,18 @@
                 },
                 {
                     "id": "pre-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
+                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
                 {
                     "id": "pre-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
-                    "runtimes": [
-                        "node18-actions",
-                        "node22"
-                    ],
-                    "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-user-registration",
                     "version": "v1",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -22006,14 +21486,13 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "post-change-password",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "id": "post-user-registration",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -22025,6 +21504,18 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "post-change-password",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node18-actions",
+                        "node22"
+                    ],
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -22315,7 +21806,14 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_U7hHFWA8LmetETGu",
+                    "id": "org_SrEMrFYV9b6phMSo",
+                    "name": "org2",
+                    "display_name": "Organization2",
+                    "third_party_client_access": "block",
+                    "is_app_entitlement_active": false
+                },
+                {
+                    "id": "org_heCvrp0Pkxw4ilGg",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -22324,13 +21822,6 @@
                             "primary": "#57ddff"
                         }
                     },
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                },
-                {
-                    "id": "org_KvyIU8ipa4KpyL0n",
-                    "name": "org2",
-                    "display_name": "Organization2",
                     "third_party_client_access": "block",
                     "is_app_entitlement_active": false
                 }
@@ -22346,7 +21837,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 11,
+            "total": 10,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -22432,7 +21923,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "Ckqg6mLzKuqmHNuWgPqMdFBskW0ChIld",
+                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22444,59 +21935,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Auth0 CLI - dev",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "logo_uri": "https://dev.assets.com/photos/foo",
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "oidc_conformant": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "luhFfLpeKyP0D2ryuDCWHNP5ZVYAR9pS",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -22538,7 +21976,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "WcSJW1mH5UIG0QlmMDlhNRpd2dq6sqGn",
+                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22589,7 +22027,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_d7qeana2JAao683Q2XUikK"
+                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
                                 }
                             ]
                         }
@@ -22602,7 +22040,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "ywOJm1EzNZ77l8YehxzZBYZFcaRjjETx",
+                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -22649,7 +22087,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "to7nHehhuLZbAUE4dNryEzQnf9HuhPw4",
+                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22690,7 +22128,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "VP8T1JToBV0NClVPbwyCrH2EC51hhCy3",
+                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22743,7 +22181,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "KiAvX1xC8taBgD4gMdRPSScDTXrNGVeL",
+                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22803,7 +22241,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "msEfDfVQc5iydxNCr5aPdbVenCY1r7zs",
+                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22861,7 +22299,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "8atRm0FfOxnGo0LBdr25p5oYQA3MpvHE",
+                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -22924,7 +22362,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22939,7 +22377,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22954,7 +22392,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_U7hHFWA8LmetETGu/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -22966,7 +22404,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22981,7 +22434,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -22996,11 +22449,26 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_KvyIU8ipa4KpyL0n/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
             "domains": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
+        "body": "",
+        "status": 403,
+        "response": {
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Insufficient scope, expected any of: read:organization_clients",
+            "errorCode": "insufficient_scope"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -23133,18 +22601,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
-        "body": "",
-        "status": 200,
-        "response": {
-            "remember_for": 30
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
@@ -23157,12 +22613,24 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/risk-assessments/settings/new-device",
+        "body": "",
+        "status": 200,
+        "response": {
+            "remember_for": 30
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000030152",
+                "id": "lst_0000000000030347",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -23173,14 +22641,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000030153",
+                "id": "lst_0000000000030348",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-c0f3a834-95ce-4ffb-99cc-037f092dbb76/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
                 },
                 "filters": [
                     {
@@ -23254,6 +22722,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -23267,24 +22750,9 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-08-05T18:57:17.452Z"
+                    "updated_at": "2026-08-10T13:55:26.891Z"
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -23353,22 +22821,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-05T18:57:17.452Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-08-10T13:55:26.891Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -23384,6 +22837,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -23432,7 +22900,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-08-05T18:57:08.272Z",
+                    "updated_at": "2026-08-10T13:55:18.245Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -23484,7 +22952,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-08-05T18:56:55.136Z",
+                    "updated_at": "2026-08-10T13:55:03.319Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -23580,7 +23048,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23588,34 +23056,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -23684,7 +23152,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-08-05T18:57:13.648Z",
+                    "updated_at": "2026-08-10T13:55:23.310Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -23709,7 +23177,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "89ce1b5c-aa57-4b24-afba-5ff0aff09a5d",
+                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -23717,34 +23185,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-05T18:56:56.983801987Z",
-                    "updated_at": "2026-08-05T18:56:56.991550383Z",
+                    "created_at": "2026-08-10T13:55:04.937881440Z",
+                    "updated_at": "2026-08-10T13:55:04.948366503Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-05T18:56:57.736560561Z",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z"
+                        "build_time": "2026-08-10T13:55:05.631088679Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "7dd8e09b-833a-47c7-a828-29cbaf5c1aa2",
+                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-05T18:56:57.736560561Z",
+                        "built_at": "2026-08-10T13:55:05.631088679Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-05T18:56:57.654938301Z",
-                        "updated_at": "2026-08-05T18:56:57.737733915Z",
+                        "created_at": "2026-08-10T13:55:05.534632268Z",
+                        "updated_at": "2026-08-10T13:55:05.632719953Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -1633,6 +1633,74 @@ describe('#organizations handler', () => {
       expect(removedClientIds).to.deep.equal(['abc_123']);
     });
 
+    it('should not remove org-client associations when AUTH0_ALLOW_DELETE is false', async () => {
+      const configNoDelete = function (key) {
+        return configNoDelete.data && configNoDelete.data[key];
+      };
+      configNoDelete.data = { AUTH0_ALLOW_DELETE: false };
+
+      const existingOrgClientFromApi = {
+        client_id: 'abc_123',
+        use_for_member_access: true,
+        client: {
+          name: 'test client',
+          app_type: 'regular_web',
+          is_first_party: true,
+          grant_types: [],
+          organization_usage: 'allow',
+        },
+      };
+
+      const auth0 = {
+        organizations: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [sampleOrg])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            list: () => ({ data: [existingOrgClientFromApi], hasNextPage: () => false }),
+            delete: () => {
+              throw new Error(
+                'deleteOrganizationClients should not be called when AUTH0_ALLOW_DELETE is false'
+              );
+            },
+          },
+        },
+        connections: {
+          list: (params) => mockPagedData(params, 'connections', []),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({
+        client: pageClient(auth0),
+        config: configNoDelete,
+      });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      // Should not throw — delete is skipped and a warning is emitted instead
+      await stageFn.apply(handler, [
+        {
+          organizations: [{ id: '123', name: 'acme', display_name: 'Acme Inc', clients: [] }],
+        },
+      ]);
+    });
+
     it('should gracefully handle when org-clients feature is not enabled (403)', async () => {
       const freshOrg = {
         id: '999',

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -289,6 +289,9 @@ describe('#organizations handler', () => {
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         connections: {
           list: (params) => mockPagedData(params, 'connections', []),
@@ -335,6 +338,9 @@ describe('#organizations handler', () => {
             discoveryDomains: {
               list: () => mockPagedData({}, 'discovery_domains', []),
             },
+            clients: {
+              list: () => ({ data: [], hasNextPage: () => false }),
+            },
           },
           connections: {
             list: (params) => mockPagedData(params, 'connections', []),
@@ -367,6 +373,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', [sampleDiscoveryDomain]),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         clients: {
@@ -413,6 +422,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         clients: {
@@ -461,6 +473,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         clients: {
@@ -578,6 +593,9 @@ describe('#organizations handler', () => {
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         clients: {
           list: (params) => mockPagedData(params, 'clients', sampleClients),
@@ -655,6 +673,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         connections: {
@@ -746,6 +767,9 @@ describe('#organizations handler', () => {
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         connections: {
           list: (params) =>
@@ -831,6 +855,9 @@ describe('#organizations handler', () => {
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         connections: {
           list: (params) =>
@@ -893,6 +920,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         connections: {
@@ -957,6 +987,9 @@ describe('#organizations handler', () => {
           },
           discoveryDomains: {
             list: () => mockPagedData({}, 'discovery_domains', []),
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         connections: {
@@ -1079,6 +1112,9 @@ describe('#organizations handler', () => {
               return Promise.resolve({ data: {} });
             },
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         connections: {
           list: (params) => mockPagedData(params, 'connections', []),
@@ -1161,6 +1197,9 @@ describe('#organizations handler', () => {
               return Promise.resolve({ data: {} });
             },
           },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
         },
         connections: {
           list: (params) => mockPagedData(params, 'connections', []),
@@ -1239,6 +1278,9 @@ describe('#organizations handler', () => {
             delete: () => {
               throw new Error('deleteDiscoveryDomain should not be called when delete is disabled');
             },
+          },
+          clients: {
+            list: () => ({ data: [], hasNextPage: () => false }),
           },
         },
         connections: {
@@ -1336,6 +1378,301 @@ describe('#organizations handler', () => {
       ]);
 
       expect(createdDomains).to.have.lengthOf(3);
+    });
+
+    it('should export org-client associations with client name instead of ID', async () => {
+      const sampleOrgClientFromApi = {
+        client_id: 'abc_123',
+        use_for_member_access: true,
+        client: {
+          name: 'test client',
+          app_type: 'regular_web',
+          is_first_party: true,
+          grant_types: [],
+          organization_usage: 'allow',
+        },
+      };
+
+      const auth0 = {
+        organizations: {
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [sampleOrg])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            list: () => ({ data: [sampleOrgClientFromApi], hasNextPage: () => false }),
+          },
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const data = await handler.getType();
+
+      expect(data[0].clients).to.deep.equal([
+        { client_id: 'test client', use_for_member_access: true },
+      ]);
+    });
+
+    it('should create organization with org-client associations', async () => {
+      let createdClients = null;
+
+      const auth0 = {
+        organizations: {
+          create: (data) => {
+            data.id = 'fake';
+            return Promise.resolve(data);
+          },
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            create: (orgId, body) => {
+              expect(orgId).to.equal('fake');
+              createdClients = body.clients;
+              return Promise.resolve(body.clients);
+            },
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+        },
+        connections: {
+          list: (params) => mockPagedData(params, 'connections', []),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              name: 'acme',
+              display_name: 'Acme',
+              clients: [{ client_id: 'test client', use_for_member_access: true }],
+            },
+          ],
+        },
+      ]);
+
+      expect(createdClients).to.deep.equal([{ client_id: 'abc_123', use_for_member_access: true }]);
+    });
+
+    it('should add, update, and remove org-client associations on update', async () => {
+      const existingOrgClient = { client_id: 'deploy client', use_for_member_access: false };
+      const existingOrgClientFromApi = {
+        client_id: 'xyz_123',
+        use_for_member_access: false,
+        client: {
+          name: 'deploy client',
+          app_type: 'regular_web',
+          is_first_party: true,
+          grant_types: [],
+          organization_usage: 'allow',
+        },
+      };
+
+      let addedClients = null;
+      let removedClientIds = null;
+      let updatedClientId = null;
+      let updatedBody = null;
+
+      const auth0 = {
+        organizations: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [sampleOrg])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            list: () => ({ data: [existingOrgClientFromApi], hasNextPage: () => false }),
+            create: (orgId, body) => {
+              addedClients = body.clients;
+              return Promise.resolve(body.clients);
+            },
+            delete: (orgId, body) => {
+              removedClientIds = body.clients;
+              return Promise.resolve();
+            },
+            update: (orgId, clientId, body) => {
+              updatedClientId = clientId;
+              updatedBody = body;
+              return Promise.resolve({});
+            },
+          },
+        },
+        connections: {
+          list: (params) => mockPagedData(params, 'connections', []),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: '123',
+              name: 'acme',
+              display_name: 'Acme Inc',
+              // remove 'deploy client', add 'test client', update deploy client's use_for_member_access
+              clients: [
+                { client_id: 'test client', use_for_member_access: true },
+                { client_id: 'deploy client', use_for_member_access: true },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      // 'test client' is new → added
+      expect(addedClients).to.deep.equal([{ client_id: 'abc_123', use_for_member_access: true }]);
+      // 'deploy client' use_for_member_access changed false → true → updated
+      expect(updatedClientId).to.equal('xyz_123');
+      expect(updatedBody).to.deep.equal({ use_for_member_access: true });
+      // nothing removed
+      expect(removedClientIds).to.be.null;
+    });
+
+    it('should remove org-client associations when not in config', async () => {
+      const existingOrgClientFromApi = {
+        client_id: 'abc_123',
+        use_for_member_access: true,
+        client: {
+          name: 'test client',
+          app_type: 'regular_web',
+          is_first_party: true,
+          grant_types: [],
+          organization_usage: 'allow',
+        },
+      };
+
+      let removedClientIds = null;
+
+      const auth0 = {
+        organizations: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [sampleOrg])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            list: () => ({ data: [existingOrgClientFromApi], hasNextPage: () => false }),
+            delete: (orgId, body) => {
+              removedClientIds = body.clients;
+              return Promise.resolve();
+            },
+          },
+        },
+        connections: {
+          list: (params) => mockPagedData(params, 'connections', []),
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [{ id: '123', name: 'acme', display_name: 'Acme Inc', clients: [] }],
+        },
+      ]);
+
+      expect(removedClientIds).to.deep.equal(['abc_123']);
+    });
+
+    it('should gracefully handle when org-clients feature is not enabled (403)', async () => {
+      const freshOrg = {
+        id: '999',
+        name: 'fresh-org',
+        display_name: 'Fresh Org',
+        client_grants: [],
+      };
+      const auth0 = {
+        organizations: {
+          list: (params) => Promise.resolve(mockPagedData(params, 'organizations', [freshOrg])),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clientGrants: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          discoveryDomains: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+          },
+          clients: {
+            list: () => {
+              const err = new Error('feature_not_enabled');
+              err.statusCode = 403;
+              err.errorCode = 'feature_not_enabled';
+              throw err;
+            },
+          },
+        },
+        clients: {
+          list: (params) => mockPagedData(params, 'clients', sampleClients),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const data = await handler.getType();
+
+      // clients property should not be set when feature is unavailable
+      expect(data[0].clients).to.be.undefined;
     });
   });
 });

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -1481,7 +1481,6 @@ describe('#organizations handler', () => {
     });
 
     it('should add, update, and remove org-client associations on update', async () => {
-      const existingOrgClient = { client_id: 'deploy client', use_for_member_access: false };
       const existingOrgClientFromApi = {
         client_id: 'xyz_123',
         use_for_member_access: false,


### PR DESCRIPTION
### 🔧 Changes

Add `is_app_entitlement_active` and org-client associations (clients) support for organizations (Org-to-App Entitlement EA).                                                       
                                                                                                                                                                                   
What changed:                          
  - `is_app_entitlement_active` boolean is now exported/deployed on all organizations when the `org_to_app_entitlement_enabled` feature flag is enabled on the tenant                  
  - New `clients` sub-resource on organizations: manages which client applications org members are entitled to use for login via `use_for_member_access  `                             
  - On export, `client_id` values are resolved to client names for portability across environments; on deploy, names are resolved back to IDs                                        
  - Create/delete operations are batched in chunks of 10 per API limits
  - Gracefully handles tenants without the feature flag enabled (403 → skips silently)
  - Requires `read:organization_clients`, `create:organization_clients`, `update:organization_clients`, `delete:organization_clients` scopes on the M2M application

### 📚 References


### 🔬 Testing

- Unit tests added for: export with client name resolution, create with org-clients, update (add/remove/update), remove all org-clients, and graceful 403 handling
  - Tested end-to-end against a real tenant with the `org_to_app_entitlement_enabled` FF enabled: export → modify org → deploy → re-export confirmed the association was applied correctly

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
