### PR TITLE
8.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.43.0] - 2026-08-12
 ### Added
-
 - Add org-to-app entitlement (EA) support for organizations. [#1454]
 - Support full group metadata for Google Workspace directory sync (GA). [#1456]
 
 ### Fixed
-
 - Create phone templates on import instead of skipping when they have no ID. [#1457]
 - Address path traversal vulnerability and false warnings in config file handlers. [#1449]
 - Exclude org-scoped roles from tenant export by filtering `type='tenant'`. [#1453]
 - Strip read-only field from roles to fix export/import round-trip. [#1445]
 
 ## [8.42.0] - 2026-07-30
-
 ### Added
-
 - Add UL identifier input support for themes and tenant settings. [#1433]
 - Add `token_vault_privileged_access` support for clients. [#1430]
 - Add `auth0_managed` field support for network ACLs (Curated Blocklists - EA). [#1435]
@@ -30,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `cross_app_access_requesting_app` support for connections (EA). [#1422]
 
 ### Fixed
-
 - Prevent dry-run crash on `clientAuthCredentials` handler. [#1438]
 - Resolve spurious dry-run diffs for rules, themes, and hooks. [#1437]
 - Strip unresolved placeholders on deploy instead of throwing. [#1436]
@@ -39,107 +35,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `use_scope_descriptions_for_consent` to allowed tenant flags. [#1428]
 
 ## [8.41.0] - 2026-07-16
-
 ### Added
-
 - Add `third_party_client_access` support for organizations. [#1421]
 
 ## [8.40.0] - 2026-07-09
-
 ### Added
-
 - Add client credential lifecycle management for Private Key JWT and mTLS authentication methods. [#1417]
 - Add Rate Limit Policies (EA) support. [#1395]
 
 ### Fixed
-
 - Preserve `false` value for `default_head_tags_disabled` in screen renderer update. [#1416]
 - Skip destination update for action event streams as the destination type cannot be changed after creation. [#1425]
 
 ## [8.39.0] - 2026-06-30
-
 ### Added
-
 - Add `eventStreams` support. [#1412]
 - Add `id_token_session_expiry_supported` validation for enterprise connections. [#1411]
 
 ## [8.38.0] - 2026-06-25
-
 ### Added
-
 - Add `session_transfer` delegation config support for CTE impersonation on the Client entity. [#1406]
 - Add `fedcm_login` support for Google One Tap / FedCM in Universal Login on the Client entity. [#1407]
 - Add `login-post-identifier` and `signup-post-identifier` as supported action triggers. [#1409]
 - Add `allow_online_access` and `allow_online_access_with_ephemeral_sessions` fields to resource server. [#1398]
 
 ### Fixed
-
 - Fix keyword placeholder validation to allow lowercase Auth0 template variables (e.g. `@@password@@`). [#1408]
 - Re-apply prompt settings after branding update to prevent Authentication Profile reset. [#1404]
 
 ## [8.37.0] - 2026-06-17
-
 ### Added
-
 - Add `invitation_landing_client_id` support to `my_organization_configuration` on the Client entity, with client ID-to-name resolution on export and name-to-ID resolution on import. [#1400]
 
 ### Fixed
-
 - Remove `enable_custom_domain_in_emails` from managed tenant flags to prevent import failures on tenants without a ready custom domain. [#1401]
 - Remove incorrect `maximum: 10` constraint on Network ACL `priority` field in schema validation. [#1403]
 
 ## [8.36.0] - 2026-06-05
-
 ### Added
-
 - Add optional flag to skip secret masking during export. [#1396]
 
 ### Fixed
-
 - Remove stale connection files from directory export when connections are deleted. [#1389]
 
 ## [8.35.0] - 2026-05-22
-
 ### Added
-
 - Add `AUTH0_IGNORE_DRY_RUN_FIELDS` config option to exclude specified fields from `--dry-run` diff output per handler type. [#1385]
 - Add hostnames and CIDR fields to network ACL match schema. [#1386]
 - Add `ES384` and `ES512` as valid `dpop_signing_alg` values for OIDC and Okta enterprise connections (GA). [#1391]
 
 ### Deprecated
-
 - Deprecate absolute and external file path references in config handlers; a warning is emitted when detected. Support will be removed in a future major version. [#1392]
 
 ### Fixed
-
 - Fix keyword markers in themes not being preserved during default export configuration. [#1387]
 
 ## [8.34.0] - 2026-05-11
-
 ### Added
-
 - Add support for `authorization_policy` on the Auth0 My Account API resource server, enabling ACR (Authentication Context Class Reference) policy configuration via Deploy CLI. [#1381]
 - Add Google Workspace inbound group sync support to directory provisioning configuration. [#1380]
 
 ### Fixed
-
 - Fix keyword replacement mappings (e.g. `##ENV##`) not being applied to `theme.json` during import. [#1379]
 
 ## [8.33.0] - 2026-05-05
-
 ### Added
-
 - Add support for Third Party Apps CORE EA Release 1 properties, including updated `clientGrants` matching and `clients` schema handling. [#1372]
 - Add support for additional signing algorithms (`token_endpoint_auth_signing_alg`, `id_token_signed_response_algs`) in OIDC and Okta enterprise connections. [#1375]
 
 ### Fixed
-
 - Fix Deploy CLI hanging indefinitely when importing 3 or more actions that reference action modules, caused by a deadlock in the shared rate-limiting pool. [#1374]
 
 ## [8.32.0] - 2026-04-23
-
 ### Added
-
 - Add support for CIMD client registration via `external_client_id`, allowing clients to be registered from an OAuth 2.0 Client ID Metadata Document. [#1369]
 - Add `on_behalf_of_token_exchange` to supported `token_exchange.allow_any_profile_of_type` values for clients. [#1366]
 - Add Flexible Password Policy support for database connections. [#1362]
@@ -147,86 +115,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dry-run mode (GA) with `--dry-run`, `--dry-run --interactive`, and `--dry-run --apply` flags. [#1336]
 
 ### Fixed
-
 - Fix silent process exit when deploying 3+ organizations with discovery domains. [#1354]
 - Fix organization creation response handling and add ID validation. [#1365]
 - Fix undefined `enabled_clients` handling in `getEnabledClients`. [#1364]
 - Fix unresolved keyword placeholders being sent in API payloads before deploy. [#1360]
 
 ## [8.31.0] - 2026-04-10
-
 ### Added
-
 - Add support for `is_default` on `customDomains`. [#1330]
 - Add `AUTH0_EXPORT_ORDERED` config property and `--export_ordered` flag for stable exports. [#1335]
 
 ### Fixed
-
 - Fix `clientGrants` matching when multiple grants share the same `client_id` and `audience`. [#1341]
 
 ## [8.30.0] - 2026-04-02
-
 ### Added
-
 - Add support for passkey enrollment in `prompts` partials. [#1328]
 - Add support for `dpop_signing_alg` validation in OIDC and Okta `connections`. [#1343]
 
 ### Fixed
-
 - Fix action module fetching logic to resolve correct module IDs. [#1340]
 - Fix `AUTH0_EXCLUDED_*` options not respected during export. [#1342]
 
 ## [8.29.3] - 2026-03-25
-
 ### Fixed
-
 - Fix Universal Login Authentication Profile reverting to Identifier+Password after import when branding is included. [#1333]
 - Fix efficiency and reliability of fetching `enabled_clients` for `connections`. [#1334]
 
 ## [8.29.2] - 2026-03-17
-
 ### Fixed
-
 - Fix false-positive deprecation warning for `cross_origin_auth` when `cross_origin_authentication` is correctly used in config. [#1322]
 
 ## [8.29.1] - 2026-03-12
-
 ### Fixed
-
 - Fix bad request error when no `emailProvider` is configured. [#1321]
 - Fix `enabled_clients` pagination for `connections`. [#1320]
 
 ## [8.29.0] - 2026-03-03
-
 ### Added
-
 - Add DPoP support for proof-of-possession mechanism in `resourceServers` (GA) [#1311]
 - Add `supplemental signals` configuration for Akamai integration.(EA) [#1310]
 
 ## [8.28.0] - 2026-02-20
-
 ### Added
-
 - Add support for managing `action-modules`.(EA) [#1302]
 - Add support for managing `modules` in `actions`.(EA) [#1302]
 
 ## [8.27.0] - 2026-02-13
-
 ### Added
-
 - Add support for `custom_password_hash.action_id` in `databases` (Universal Custom Password Hash EA). [#1288]
 - Add support for `allowed_strategies` in `selfServiceProfiles`. [#1298]
 
 ### Fixed
-
 - Fix validation handling for `authentication_methods.password.enabled` and `disable_self_service_change_password` in `databases`. [#1297]
 - Fix stripping deprecated `enabled_clients` for `connections` with enhanced client management. [#1294]
 - Fix exclude third-party `clientGrants` when `AUTH0_EXCLUDE_THIRD_PARTY_CLIENTS` is enabled. [#1289]
 
 ## [8.26.0] - 2026-01-30
-
 ### Added
-
 - Add support for `use_for_organization_discovery` in organizations `discovery-domains`. [#1283]
 - Add support for passwordless authentication methods (`email_otp` and `phone_otp`) in `databases`. [#1282]
 - Add support for `relying_party_identifier` in `customDomains`. [#1280]
@@ -234,361 +180,264 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add OIDC logout configuration support with session metadata in `clients`. [#1263]
 
 ### Changed
-
 - Optimize directory provisioning configuration fetching for `connections`. [#1284]
 
 ### Fixed
-
 - Fix exclude read-only `is_default` from `customDomains`. [#1279]
 - Fix pagination skipping last page. [#1277]
 
 ## [8.25.0] - 2026-01-08
-
 ### Added
-
 - `AUTH0_INCLUDED_CONNECTIONS` config property to include only selected `connection`. [#1242]
 
 ### Fixed
-
 - Fix `tokenExchangeProfiles` profiles handling. [#1253]
 - Fix `idle_ephemeral_session_lifetime` and `ephemeral_session_lifetime` handling while importing [#1261]
 
 ## [8.24.0] - 2025-12-22
-
 ### Added
-
 - Add support for managing `riskAssessment` settings. [#1217]
 - Add directory provisioning support for `google-apps` connections. [#1246]
 
 ## [8.23.2] - 2025-12-18
-
 ### Fixed
-
 - Fix `customDomains` handler 409 for listing domains. [#1244]
 
 ## [8.23.1] - 2025-12-18
-
 ### Fixed
-
 - Fix resolve race conditions in processChanges for handlers. [#1240]
 - Fix client grants pagination to use checkpoint. [#1239]
 
 ## [8.23.0] - 2025-12-16
-
 ### Added
-
 - Add support for `brute-force-protection` in prompts custom-text. [#1221]
 - Add support for `phoneTemplates`. [#1224]
 - Add support for `tokenExchangeProfiles`. [#1232]
 
 ### Changed
-
 - Upgrading `node-auth0` from v4 to v5. [#1207]
 
 ### Fixed
-
 - Fix `improved_signup_bot_detection_in_classic` is added in allowed `tenant` flags. [#1231]
 
 ## [8.22.0] - 2025-12-10
-
 ### Added
-
 - Add `AUTH0_EXCLUDE_THIRD_PARTY_CLIENTS` config property to exclude third-party `clients`. [#1212]
 
 ### Fixed
-
 - Fix managing `Auth0 My Account API` in `resourceServers`. [#1229]
 - Fix `cross_origin_auth` is deprecated and migrated to `cross_origin_authentication` in `clients`. [#1223]
 
 ## [8.21.0] - 2025-11-21
-
 ### Added
-
 - Add support for Connection Profiles and Express Configuration on Clients. [#1204]
 - Add support for ACUL GA. [#1209]
 - Add support for `session_transfer` schema in `clients`. [#1211]
 
 ### Fixed
-
 - Fix handle responses when paginating custom domains. [#1214]
 
 ## [8.20.4-beta.0] - 2025-12-02
-
 ### Changed
-
 - Upgrading node-auth0 from v4 to v5 [beta]. [#1207]
 
 ## [8.20.3] - 2025-11-14
-
 ### Fixed
-
 - Fix pagination error when API returns empty array. [#1203]
 
 ## [8.20.2] - 2025-11-13
-
 ### Changed
-
 - Support enhanced custom domains in `customDomains` [#1193]
 
 ## [8.20.1] - 2025-11-10
-
 ### Fixed
-
 - Fix bot detection and captcha files optional loading & CIDR validation for `attackProtection`. [#1200]
 
 ## [8.20.0] - 2025-11-06
-
 ### Added
-
 - Add support for bot-detection and captcha configurations in `attackProtection`. [#1189]
 - Add support for `async_approval_notification_channels` for CIBA on `clients`. [#1194]
 
 ### Fixed
-
 - Fix `AUTH0_EXPORT_IDENTIFIERS` configuration to export action IDs in exports. [#1196]
 - Fix `EXCLUDED_PROPS` configuration exporting `emailProvider` in directory format. [#1195]
 
 ## [8.19.0] - 2025-10-31
-
 ### Added
-
 - Add support for organization discovery domains in `organizations`. [#1187]
 - Add support for `email.unique` attribute property in `databases`. [`#1190]
 - Add support for custom-URI-schemes in `clients` and `tenant`. [#1182]
 
 ### Fixed
-
 - Fix docs for env vars usage with keyword replacement. [#1188]
 - Fix read_only_background property schema for `themes`. [#1184]
 - Fix `userAttributeProfiles` handle if feature is not enabled. [#1181]
 
 ## [8.18.0] - 2025-10-13
-
 ### Added
-
 - Add support for connection purpose configuration options in `connections`. [#1162]
 
 ### Fixed
-
 - Fix execution order for `logStreams`. [#1175]
 - Fix keyword replacement handling for special characters. [#1174]
 
 ## [8.17.0] - 2025-09-30
-
 ### Added
-
 - Add support for user attribute profiles EA [#1166]
 - Add support for `user_attribute_profile_id` in `selfServiceProfiles` [#1166]
 - Add support for new language codes [#1159]
 
 ## [8.16.0] - 2025-09-16
-
 ### Added
-
 - Add support for token vault in `clients` and `resourceServers`. [#1158]
 - Add support for `async_approval` template in `emailTemplates`. [#1146]
 - Add support for `passkeys` in `prompts`. [#1161]
 
 ### Fixed
-
 - Fix example directory name for `phoneProviders`. [#1155]
 
 ## [8.15.0] - 2025-09-02
-
 ### Added
-
 - Add application access permissions support in `clientGrants` and `resourceServers`. [#1144]
 
 ### Fixed
-
 - Fix create or update custom domains for `customDomains`. [#1142]
 
 ## [8.13.0] - 2025-08-04
-
 ### Added
-
 - Add support for native to web SSO in `clients`. [#1139]
 - Add support for PII config in `logStreams`. [#1130]
 
 ## [8.12.0] - 2025-07-30
-
 ### Added
-
 - Add DPoP support for proof-of-possession mechanism in `resourceServers` [#1132]
 
 ### Fixed
-
 - Fix update enabled clients pagination for `connections` and `databases`. [#1127]
 - Fix request throttling for `forms` and `flows`. [#1133]
 - Fix logging and scope validation for `connections` and `databases`. [#1134]
 
 ## [8.11.0] - 2025-07-15
-
 ### Added
-
 - Add support for multiple custom domains in `customDomains`. [#1113]
 
 ## [8.10.0] - 2025-07-01
-
 ### Added
-
 - Add support new schema fields in `prompt` screens for rendering. [#1124]
 
 ### Changed
-
 - Update endpoints for enabled_clients in `connections` and `databases`. [#1123]
 - Update CONTRIBUTING.md with detailed setup and workflow instructions. [#1115]
 
 ### Fixed
-
 - Fix process execution order for `forms`,`flows`,`flowVaultConnections`. [#1121]
 - Fix keyword replacement markers in `databases` enabled_clients. [#1116]
 
 ## [8.9.0] - 2025-06-04
-
 ### Added
-
 - Add support for limit M2M usage - EA [#1093]
 - Add support to fetch list `prompt` screen's settings [#1104]
 
 ### Fixed
-
 - Fix secret masking for `connections`, `emailProvider` and `logStreams` [#1103]
 - Fix supported resource types in READMEs. [#1109]
 
 ## [8.8.3] - 2025-05-27
-
 ### Added
-
 - Add support new screens for rendering `prompt` screen's settings [#1096]
 
 ### Fixed
-
 - Fix export `databases` options and customScripts [#1095]
 
 ## [8.8.2] - 2025-05-08
-
 ### Added
-
 - Add support for refresh token policies configuration for `clients` - EA [#1085]
 
 ### Changed
-
 - Remove `AUTH0_EXPERIMENTAL_EA` flag check for screens rendering `prompt` screen's settings `import` command [#1084]
 
 ### Fixed
-
 - Fix tenant network ACL management not enabled [#1079]
 - Fix error handling `guardianFactorProviders`, `guardianFactorTemplates`, `guardianFactors`, `guardianPhoneFactorMessageTypes`, `guardianPhoneFactorSelectedProvider` for forbidden depreated feature [#1086]
 
 ## [8.8.1] - 2025-04-28
-
 ### Added
-
 - Add support new screens for rendering `prompt` screen's settings [#1071]
 
 ### Fixed
-
 - Fix AUTH0_EXCLUDED_CLIENTS support for `clients` YAML format [#1072]
 
 ## [8.8.0] - 2025-04-10
-
 ### Added
-
 - Add support for tenant ACL EA support [#1063]
 - Add support for new prompts in custom-text [#1064]
 
 ### Fixed
-
 - Fix remove unsupported ACUL screens for rendering `prompt` screen's settings [#1061]
 - Fix update node version requirement to 20(v20.18.1) [#1062]
 
 ## [8.7.1] - 2025-03-27
-
 ### Added
-
 - Add support new screens for rendering `prompt` screen's settings [#1053]
 
 ### Fixed
-
 - Fix get all `customDomains` types [#1054]
 
 ### Security
-
 - Security fixes from dependencies [#1054]
 
 ## [8.7.0] - 2025-03-13
-
 ### Added
-
 - Add support for extensibility as custom phone provider `phoneProviders` [#1038]
 - Add support for checkpoint pagination for GET `connections` [#1041]
 
 ### Fixed
-
 - Removed survey link from import/export command [#1039]
 - Fix dumping JSON files with keyword preserve markers in client grants [#1040]
 - Fix warn log insufficient scope for branding templates export [#1047]
 
 ### Security
-
 - Security fixes from dependencies [#1046]
 - Node 20(v20.18.3) LTS and newer LTS releases are supported [#1046]
 
 ## [8.6.2] - 2025-02-21
-
 ### Added
-
 - Add support new screens for rendering `prompt` screen's settings [#1035]
 
 ## [8.6.1] - 2025-02-20
-
 ### Fixed
-
 - Fix docs for support of `forms`,`flows`,`flowVaultConnections` [#1030]
 - Fix keyword preservation for `clientGrants` [#1032]
 - Fix google credential support for `clients` [#1031]
 
 ## [8.6.0] - 2025-02-06
-
 ### Added
-
 - Add support new screens for rendering `prompt` screen's settings [#1028]
 - Add support for new `--experimental_ea` command flag [#1027]
 
 ### Fixed
-
 - Fix keyword for the repository [#1026]
 
 ## [8.5.0] - 2025-01-29
-
 ### Added
-
 - Add support for reset_email_by_code template for `emailTemplates` [#1014]
 
 ### Fixed
-
 - Fix proxy support [#1022]
 - Fix schema for phone,email,username as flexible identifiers for `databases` [#1023]
 - Fix docs for support of `selfServiceProfiles` [#1021]
 
 ## [8.4.4] - 2025-01-20
-
 ### Fixed
-
 - Fix `emailProvider` support for Azure and MS365 [#1016]
 - Fix npmignore to exclude additional files and directories [#1017]
 
 ## [8.4.3] - 2025-01-08
-
 ### Fixed
-
 - Fix release CI version bump
 
 ## [8.4.2] - 2025-01-08
-
 ### Fixed
-
 - Fix Twilio SMS factor provider update for `guardianFactorProviders` [#1007]
 - Fix exporting SAML `connections` certificate [#1008]
 - Fix `action` code paths for directory format exports [#1009]
@@ -596,720 +445,510 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix dependency update proxy agent [#1010]
 
 ## [8.4.1] - 2024-12-16
-
 ### Fixed
-
 - Fix importing forms, flows and flow vault connections dependencies[#1001]
 - Fix docs for support of rendering `prompt` screen's settings [#1002]
 
 ## [8.4.0] - 2024-12-09
-
 ### Added
-
 - Add support for rendering `prompt` screen's settings [#998]
 
 ## [8.3.0] - 2024-11-28
-
 ### Added
-
 - Management support for `selfServiceProfiles` [#989]
 
 ### Fixed
-
 - Fix checkpoint pagination to get all organizations [#984]
 - Fix error handling for trigger bindings [#991]
 
 ## [8.2.0] - 2024-11-18
-
 ### Added
-
 - Management support for `forms`, `flows` and `flowVaultConnections` [#982]
 
 ### Fixed
-
 - Fix docs to support free tier usage [#978]
 
 ## [8.1.0] - 2024-11-08
-
 ### Added
-
 - Client Credentials (M2M) support in `organizations` and `clientGrants` [#975]
 
 ## [8.0.0] - 2024-10-21
-
 ### Changed
-
 - Auth0 [v4.X](https://github.com/auth0/node-auth0/releases/tag/v4.10.0) migration
 - The `delete` operation on the `emailProvider` resource will disable the email provider instead of deleting it.
 
 ### Deprecated
-
 - Migration resource operation
 
 ### Security
-
 - Security fixes from dependencies
 - Node 18 LTS and newer LTS releases are supported.
-
+  
   Doc: [v8 Migartion](./docs/v8_MIGRATION_GUIDE.md)
 
 ## [7.24.3] - 2024-10-15
-
 ### Fixed
-
 - Fix keyword replacement for `actions secrets` using the directory format [#954]
 - Fix keyword replacement for `custom prompts` using the directory format [#963]
 
 ## [7.24.2] - 2024-08-28
-
 ### Added
-
 - Add support for `login-passwordless` prompt on `partials` in prompts handler [#946]
 
 ### Fixed
-
 - Fix `branding` template `path` on export/import [#943]
 - Fix docs for support `exclusions of individual resource` [#944]
 
 ## [7.24.1] - 2024-08-09
-
 ### Fixed
-
 - Fix `branding` template `path` on export/import as Yaml [#939]
 - Fix `databases` handler to handle `options` property correctly for flexible identifiers [#937]
 
 ## [7.24.0] - 2024-08-02
-
 ### Added
-
 - Management support for `partials` in `prompts` handler [#930]
 
 ### Changed
-
 - Reduced latency while performing `SCIM` CRUD operations [#933]
 
 ## [7.23.1] - 2024-07-19
-
 ### Fixed
-
 - Fix `429`(`too_many_requests`) and `403`(`insufficient_scope`) errors in the SCIM handler [#925]
 
 ## [7.23.0] - 2024-07-16
-
 ### Added
-
 - Management support for `scim_configuration` in connections handler [#921]
 
 ## [7.22.1] - 2024-06-24
-
 ### Fixed
-
 - Made `captcha_widget_theme` an optional field in the `colors` property within the `themes` schema [#911]
 
 ## [7.22.0] - 2024-06-21
-
 ### Added
-
 - Management support for `is_signup_enabled` in organization connections [#905]
 - Management support for `captcha_widget_theme` in theme colors [#906]
 
 ## [7.21.0] - 2024-02-08
-
 ### Added
-
 - `show_as_button` management support for organization connections [#889]
 
 ### Fixed
-
 - Strip `sink.azurePartnerTopic` field from payload when creating log stream [#876]
 
 ## [7.20.0] - 2023-11-29
-
 ### Added
-
 - Relative path import support for actions directory handler [#866]
 
 ### Fixed
-
 - Keyword preservation for wider array of resources [#864]
 - Fetching clients if not defined when managing client grants in YAML format [#865]
 
 ## [7.19.0] - 2023-08-11
-
 ### Added
-
 - Support for Private Key JWT authentication for authenticating with private key instead of client secret [#817]
 
 ### Fixed
-
 - Process branding changes after theme changes to prevent delay in dashboard preview [#836]
 - Handling eventual hooks and rules deprecation [#838]
 - Overwrites occurring when preserving keywords within multiple client grants [#837]
 
 ## [7.18.0] - 2023-07-14
-
 ### Added
-
 - Support for `password-reset-post-challenge` action trigger [#818]
 
 ### Fixed
-
 - Runtime error when attempting to preserve keyword on null remote assets [#822]
 - Respect email template `body` filepath definition [#820]
 
 ## [7.17.7] - 2023-07-07
-
 ### Fixed
-
 - Delay processing of action triggers until deployed actions register [#809]
 - Process custom domains prior to branding settings [#811]
 
 ## [7.17.6] - 2023-06-23
-
 ### Changed
-
 - Improve handling of custom text prompts, reducing high-volume errors and timeouts by leveraging connection pooling for controlled execution [#804]
 
 ## [7.17.5] - 2023-06-08
-
 ### Fixed
-
 - Obfuscating sensitive log streams keys [#800]
 - Prevent exporting of disallowed tenant flags [#799]
 
 ## [7.17.4] - 2023-06-06
-
 ### Fixed
-
 - Prevent tenant flag "Additional properties not allowed" error by only updating publicly-available feature flags [#797]
 
 ## [7.17.3] - 2023-05-24
-
 ### Fixed
-
 - Keyword preservation for client grant `audience` field [#793]
 
 ## [7.17.2] - 2023-04-19
-
 ### Fixed
-
 - API error when no tenant flags defined [#780]
 - Keyword preservation in a resource's identifier fields [#784]
 
 ## [7.17.1] - 2023-03-31
-
 ### Fixed
-
 - Tenant-agnostic filenames for client grants if more than fifty clients and fifty resource servers [#764]
 - Unintentional exclusion of clients when injecting access token via `AUTH0_ACCESS_TOKEN` [#775]
 
 ## [7.17.0] - 2023-03-03
-
 ### Added
-
 - Keyword preservation on export to prevent overwriting of keyword markers in most instances. Enabled through the `AUTH0_PRESERVE_KEYWORDS` boolean configuration property. See also: [Preserving Keywords on Export](./docs/keyword-replacement.md#preserving-keywords-on-export) [#738],[#740],[#741],[#744],[#745],[#751],[#754],[#757],[#758],[#760]
 
 ### Fixed
-
 - Enabled wrapping of `@@ARRAY_REPLACE@@` keyword markers with single quotes in YAML resource configuration files [#760]
 
 ## [7.16.1] - 2023-02-07
-
 ### Fixed
-
 - Exporting of multiple client grants for a single client when using directory format [#729]
 - Tenant-agnostic client grant files when exporting using directory format [#729]
 
 ## [7.16.0] - 2023-02-01
-
 ### Added
-
 - `AUTH0_INCLUDED_ONLY` configuration property to express sole management of certain resource types [#726]
 - Suspended log stream management support [#725]
 - More descriptive errors when actions service is unavailable [#724]
 
 ### Fixed
-
 - Remove configurable tenant `sandbox_version` property from readonly list [#683]
 - Handling of undefined tenant `enabled_locales` property [#727]
 
 ## [7.15.2] - 2023-01-03
-
 ### Fixed
-
 - Deletion of email provider when setting as empty object [#673]
 
 ### Security
-
 - Upgraded `node-auth0` which addresses [vulnerability reported](https://github.com/advisories/GHSA-hjrf-2m68-5959) for `jsonwebtoken` package
 
 ## [7.15.1] - 2022-10-19
-
 ### Added
-
 - Warning about future fix that enables deletion of email provider; no significant changes to functionality [#672]
 
 ### Fixed
-
 - Returning all branding setting when using YAML [#666]
 - Preventing empty `logo_url` from update tenant payload [#667]
 - Loading actions between different operating systems [#668]
 - Prevent writing undefined page templates files [#671]
 
 ## [7.15.0] - 2022-10-11
-
 ### Added
-
 - Ignoring management of marketplace actions because they are unsupported by the Management API [#660]
 
 ### Fixed
-
 - Allowing partial attack protection configurations [#638]
 
 ## [7.14.3] - 2022-08-24
-
 ### Fixed
-
 - Reclassify select production dependencies as dev dependencies [#626]
 - Allowing certain page templates configuration to be modified even when absent of HTML [#629],[#630]
 
 ## [7.14.2] - 2022-08-01
-
 ### Fixed
-
 - Allowing updating of branding themes when used in conjunction with `--export_ids` flag [#603]
 - Halting deploy process if passwordless email template does not exist [#617]
 
 ## [7.14.1] - 2022-06-29
-
 ### Fixed
-
 - Reverting unreplaced keyword mapping detection that would trigger some false-positives [#597]
 
 ## [7.14.0] - 2022-06-27
-
 ### Added
-
 - Validation to detect unreplaced keyword mappings during import [#591]
 
 ### Fixed
-
 - Detect and prevent `You are not allowed to set flag '<SOME_FLAG>' for this tenant.` errors when erroneously setting non-configurable migration flag [#590]
 - Crash when attempting to create page templates from undefined value [#592]
 
 ## [7.13.1] - 2022-06-13
-
 ### Fixed
-
 - Removing single usage of `flatMap` array method to prevent crashes with Node v10 [#577]
 
 ## [7.13.0] - 2022-06-06
-
 ### Added
-
 - Themes support (if supported by tenant) [#554]
 
 ### Fixed
-
 - Omit `enabled_clients` from connection payload if not defined in resource configuration files [#563]
 
 ## [7.12.3] - 2022-05-24
-
 ### Fixed
-
 - Resource exclusion respected during import even if resource configuration exists [#545]
 - Environment variables ingested by default [#553]
 
 ## [7.12.2] - 2022-05-17
-
 ### Fixed
-
 - Properly handle all screen types within a prompt grouping [#541]
 - Gracefully ignoring custom domains if not supported by tenant [#542]
 
 ## [7.12.1] - 2022-05-11
-
 ### Fixed
-
 - Unable to deploy without branding settings feature [#532]
 
 ## [7.12.0] - 2022-05-10
-
 ### Added
-
 - Prompts support (both prompts settings and custom text for prompts) [#530]
 - Custom domains support [#527]
 
 ## [7.11.1] - 2022-05-04
-
 ### Fixed
-
 - Deployment of newly-created actions always failing due to "A draft must be in the 'built' state" error [#524]
 - Undefined `updateRule` Auth0 SDK alias replaced with operational `rules.update` [#526]
 
 ## [7.11.0] - 2022-04-28
-
 ### Added
-
 - Intelligent scope detection, will skip resources when insufficient scope provided to designated application [#517]
 
 ### Fixed
-
 - Inconsistencies between resource handlers with respect to empty, null and undefined values [#512]
 
 ## [7.10.0] - 2022-04-26
-
 ### Added
-
 - Branding support for directory format [#505]
 
 ### Fixed
-
 - More comprehensive support for deletions through `AUTH0_ALLOW_DELETE` [#509]
 
 ## [7.9.0] - 2022-04-19
-
 ### Added
-
 - Log streams support [#495]
 
 ### Fixed
-
 - `##` String keyword replacements now work when nested inside `@@` array replacements [#504]
 
 ## [7.8.0] - 2022-04-14
-
 ### Added
-
 - Type declarations for more seamless integration into Typescript projects when used as a module [#485]
 
 ### Security
-
 - Updated Winston from 2.3.x to 3.3.0 which applies fix for theoretical prototype pollution vulnerability [#497]
 
 ## [7.7.1] - 2022-04-07
-
 ### Added
-
 - Deprecation warnings for now deprecated asset-specific exclusion configuration properties: `AUTH0_EXCLUDED_RULES`, `AUTH0_EXCLUDED_CLIENTS`, `AUTH0_EXCLUDED_DATABASES`, `AUTH0_EXCLUDED_CONNECTIONS`, `AUTH0_EXCLUDED_RESOURCE_SERVERS`, `AUTH0_EXCLUDED_DEFAULTS`. See [Resource Exclusion Proposal](https://github.com/auth0/auth0-deploy-cli/issues/451#user-content-deprecated-exclusion-props) for details. [#481]
 
 ### Fixed
-
 - Rules configs failing to update after regression prevented asset-specific overrides of Node Auth0 SDK methods [#482]
 - Attack protection not replacing keywords [#478]
 
 ## [7.7.0] - 2022-04-06
-
 ### Added
-
 - Exclusion of entire resource types via the `AUTH0_EXCLUDED` configuration parameter. See [Resource Exclusion Proposal](https://github.com/auth0/auth0-deploy-cli/issues/451) for details. [#468]
 
 ### Fixed
-
 - `idle_session_lifetime` and `session_lifetime` values properly ignored on update if inheriting default tenant values.[#471]
 
 ## [7.6.0] - 2022-03-25
-
 ### Added
-
 - New branding template feature support [#438]
 
 ### Fixed
-
 - Colliding `e` parameter alias between `export_ids` and `env` [#453]
 
 ## [7.5.2] - 2022-03-15
-
 ### Fixed
-
 - Resetting this version to be latest on NPM
 
 ## [7.5.1] - 2022-03-11
-
 ### Fixed
-
 - Updating dead link in logging output [#436]
 - Fixing `--env` flag to properly dictate environment variable inheritance [#432]
 
 ## [7.5.0] - 2022-03-08
-
 ### Added
-
 - Support for attack protection configuration management [#428]
 
 ### Fixed
-
 - Excluded connection properties from getting deleted upon update [#430]
 - Organizations in YAML format are skipped when not defined [#388]
 
 ## [7.4.0] - 2022-02-24
-
 ### Added
-
 - Allowing @@ array variable replacement to work when wrapped in quotes [#421]
 
 ### Fixed
-
 - Eliminated benign `client_metadata` warnings on import [#416]
 - Fixing request abstraction from losing function scope, enabling Auth0 Node SDK updates [#412]
 
 ### Security
-
 - Updating Auth0 Node SDK to 2.40.0 which fixes minor dependency vulnerability
 
 ## [7.3.7] - 2022-02-03
-
 ### Fixed
-
 - Expose errors that may be silently missed in Actions [#408]
 
 ## [7.3.6] - 2022-02-02
-
 ### Fixed
-
 - Fix errors caused by incompatibilities introduced by new versions of Auth0 SDK [#406]
 
 ## [7.3.5] - 2022-01-27
-
 ### Fixed
-
 - Fix an error with the function context [#403]
 
 ## [7.3.4] - 2022-01-26
-
 ### Fixed
-
 - Fix pagination [#401]
 
 ## [7.3.3] - 2022-01-26
-
 ### Fixed
-
 - Fix pagination [#400]
 
 ### Security
-
 - Security fixes from dependencies
 
 ## [7.3.2] - 2021-12-14
-
 ### Security
-
 - Fixes dependency security issues
 
 ## [7.3.1] - 2021-09-21
-
 ### Fixed
-
 - Error when authenticating with AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET with Node.js prior to v14
 
 ## [7.3.0] - 2021-09-20
-
 ### Added
-
 - Allow set of AUTH0_AUDIENCE for custom domain [#379] (credit @AliBazzi)
 
 ### Fixed
-
 - Load file configured in customScripts for DB Connections [#367] (credit @skukx)
 
 ### Security
-
 - Security fixes from dependencies
 
 ## [7.2.1] - 2021-08-23
-
 ### Fixed
-
 - [IDS-3074] Updated structure when dumping orgs (#369)
-
+  
   Fixes an issue when exporting organizations as a directory, connections are not structured in the right way, causing the import to remove any connection on the organizations.
-
 - [DXEX-1721] Fix client metadata property deletion
-
+  
   Fixes an inconsistency between how we calculate changes on deep metadata-like objects and with how APIv2 expects such changes to be expressed when a property is deleted.
-
 - Bump js-yaml from 3.x to 4.x and move to kacl (#371)
-
+  
   This PR bumps js-yaml from 3.x to 4.x in accordance with its migration guide. This bump means that we're able to use the default safe behaviour for both exports and imports.
-
+  
   Notably, this means that we won't end up with values like !<tag:yaml.org,2002:js/undefined> '' that are not at all human friendly and were problematic when we used the .safeLoad functionality.
 
 ## [7.2.0] - 2021-07-14
-
 ### Added
-
 - Add runtime property for actions [#364]
 
 ## [7.1.1] - 2021-06-23
-
 ### Added
-
 - Export tools module
 
 ### Fixed
-
 - Fix exception when actions is undefined [#361]
 - yargs should not be called when required as a module
 
 ## [7.1.0] - 2021-06-23
-
 ### Changed
-
 - Actions refactoring and fixes [#356]
 - Bump auth0@2.35.1
 
 ## [7.0.0] - 2021-06-11
-
 ### Added
-
 - MFA-1174 Support Recovery Codes
 - Support for organizations
 - Prompt link to Auth0 Docs upon insufficient scope
 
 ### Changed
-
 - Removed dependency on `auth0-source-control-extension-tools`, the package is not part of `auth0-deploy-cli`
 - Removed dependency on `auth-extension-tools`
 
 ### Deprecated
-
 - Dropped Node.js 8 support
 
 ### Fixed
-
 - Upstream node registry
 
 ### Security
-
 - Security fixes from dependencies
 
 ## [6.0.0] - 2020-12-28
-
 ### Deprecated
-
 - This release has been withdrawn
 
 ## [5.5.7] - 2021-05-19
-
 ### Added
-
 - Add Support Recovery Codes by bumping auth0-source-control-extension-tools@4.7.2
 
 ## [5.5.6] - 2021-04-21
-
 ### Fixed
-
 - Fix EXCLUDE_PROPS behaviour for connections and databases.
 
 ## [5.5.5] - 2021-03-26
-
 ### Fixed
-
 - Broken dependencies on 4.5.x range of source-countrol-extension-tools because of organizations.
 
 ## [5.5.4] - 2021-03-12
-
 ### Fixed
-
 - Remove limit on permissions in roles
 
 ## [5.5.3] - 2021-03-10
-
 ### Added
-
 - Add webauthn platform as a supported factor
 
 ## [5.5.2] - 2021-03-10
-
 ### Fixed
-
 - Fix pagination when computing changes
 
 ## [5.5.1] - 2021-03-03
-
 ### Fixed
-
 - Fix issues with retrieving more than 50 roles
 
 ## [5.5.0] - 2021-01-28
-
 ### Added
-
 - Add support for `verify_email_by_code` email template [#309]
 
 ## [5.3.2] - 2020-12-17
-
 ### Fixed
-
 - Fix keyword mapping in client page templates [ESD-10528] [#291]
 
 ## [5.3.1] - 2020-11-16
-
 ### Fixed
-
 - Fix report error exporting hooks by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 - Add MFA factor webauthn-roaming support by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 
 ## [5.3.0] - 2020-11-05
-
 ### Changed
-
 - Return database `enabled_clients` in deterministic order [#281]
 
 ### Fixed
-
 - Fix the structure of the example policies.json, and correct the guardianPolicies test to use `all-applications` instead of `all-application` [#278]
 - Fix pagination for specific API calls by bumping auth0-source-control-extension-tools@4.1.9 [#287]
 
 ## [5.2.1] - 2020-09-23
-
 ### Fixed
-
 - Issue with client grants deleted when using AUTH0_EXCLUDED_CLIENTS
 
 ## [5.2.0] - 2020-09-17
-
 ### Fixed
-
 - Always sort custom database scripts alphabetically
 
 ## [5.1.6] - 2020-09-15
-
 ### Fixed
-
 - Add new line support to JSON files generated in directory dumps
 - Move write file method to common util
 - Update `auth0-source-control-extension-tools`
 
 ## [5.1.5] - 2020-08-13
-
 ### Fixed
-
 - The --proxy_url option should work properly now. (Although only on Node >= 10).
 
 ## [5.1.4] - 2020-08-12
-
 ### Fixed
-
 - Connections disabled when the client is added AUTH0_EXCLUDED_CLIENTS list.
 
 ## [5.1.3] - 2020-08-04
-
 ### Fixed
-
 - Many entities were not being fetched via the Paging API properly.
 
 ## [5.1.3] - 2020-08-04
-
 ### Fixed
-
 - Many entities were not being fetched via the Paging API properly.
 
 ## [5.1.0] - 2020-07-09
-
 ### Added
-
 - Add support for three guardian/MFA-related features:
   - Guardian Policies
   - Guardian Phone factor selected provider
@@ -1317,31 +956,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for Migrations
 
 ## [5.0.0] - 2020-06-04
-
 ### Added
-
 - Allow excluding default values for emailProvider with `AUTH0_EXCLUDED_DEFAULTS` [#236]
 
 ### Changed
-
 - [**Breaking**] Updated dependencies and deprecated support for Node versions earlier than 8 via babel@7 and dot-prop@5 [#242]
 
 ### Fixed
-
 - pages: fix error when dumping error_page without html property [#247]
 
 ## [4.3.1] - 2020-05-20
-
 ### Fixed
-
 - Fixed broken mkdirp package dependency
 
 ## [4.3.0] - 2020-05-18
-
 ### Removed
-
 - Removed several unused dependencies:
-
+  
   - ajv
   - e6-template-strings
   - node-storage
@@ -1349,250 +980,174 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - xregexp
 
 ## [4.2.2] - 2020-05-04
-
 ### Added
-
 - Support for phone message hook added.
 - Configurable connections directory with `AUTH0_CONNECTIONS_DIRECTORY`.
 
 ### Removed
-
 - Remove data from verify email example to prevent copy and paste misuse.
 
 ## [4.2.1] - 2020-04-06
-
 ### Fixed
-
 - Fixed rules' reorder to avoid order collisions by updating `auth0-source-control-extension-tools`
 
 ## [4.2.0] - 2020-03-28
-
 ### Fixed
-
 - When importing SAML database connections, support client name in the `options.idpinitiated.client_id` property.
 - When exporting SAML database connections, convert client ID to client name.
 
 ## [4.1.0] - 2020-03-28
-
 ### Fixed
-
 - When exporting a mailgun email provider, a placholder api key will be included in the export..
 
 ## [4.0.3] - 2020-03-18
-
 ### Fixed
-
 - Programmatic usage will not complain about args. [#215]
 
 ## [4.0.2] - 2020-02-28
-
 ### Added
-
 - Included Deploy CLI version number in User-Agent header.
 - If no command line arguments are passed, the usage statement will be printed.
 
 ## [4.0.1] - 2020-02-05
-
 ### Changed
-
 - Update `auth0-source-control-extension-tools`
 
 ### Fixed
-
 - Fixed import and export errors when roles and hooks are not available
 
 ## [4.0.0] - 2020-01-29
-
 ### Added
-
 - Add support for Hooks and Hook Secrets
 - Update `auth0`, `auth0-extension-tools`, `auth0-source-control-extension-tools`, and `js-yaml`
 
 ## [3.6.7] - 2020-01-08
-
 ### Fixed
-
 - Fixed a crash when no roles are present in a tenant during an export
 
 ## [3.6.5] - 2019-12-19
-
 ### Added
-
 - Add readonly flag `remove_stale_idp_attributes`
 
 ## [3.6.4] - 2019-12-04
-
 ### Changed
-
 - Update `https-proxy-agent` and `js-yaml`
 
 ## [3.6.3] - 2019-11-04
-
 ### Added
-
 - Add `AUTH0_API_MAX_RETRIES` support
 
 ## [3.6.2] - 2019-10-18
-
 ### Fixed
-
 - Fix mapping for passwordless email connection template
 
 ## [3.6.1] - 2019-09-27
-
 ### Removed
-
 - Removed `--verbose` option
 
 ## [3.6.0] - 2019-08-26
-
 ### Changed
-
 - Update `auth0-extension-tools`
 
 ### Fixed
-
 - Clear empty descriptions on roles
 
 ## [3.5.0] - 2019-08-14
-
 ### Added
-
 - Ability to exclude connections and databases (AUTH0_EXCLUDED_CONNECTIONS & AUTH0_EXCLUDED_DATABASES)
 
 ### Fixed
-
 - Excludes for yaml import
 
 ## [3.4.0] - 2019-07-15
-
 ### Added
-
 - Load email template for passwordless email connection from external html file [#124]
 - Load custom_login_page template for client from external html file [#138]
 
 ## [3.3.2] - 2019-07-11
-
 ### Changed
-
 - pin minor version of source-control-tools@~3.4.1
 
 ## [3.3.1] - 2019-06-13
-
 ### Fixed
-
 - `allowed_clients`, `allowed_logout_urls`, `allowed_origins` and `callbacks` properties of the `client` can no longer be exported as `null`
 
 ## [3.3.0] - 2019-04-22
-
 ### Added
-
 - Support for roles and permissions export and import
 
 ## [3.2.0] - 2019-04-12
-
 ### Changed
-
 - Secrets (`rules configs` and databases `options.configuration`) can no longer be exported
 
 ## [3.1.3] - 2019-04-03
-
 ### Added
-
 - Clearing empty tenant flags on `import`
 
 ## [3.1.2] - 2019-03-22
-
 ### Added
-
 - Consistent property sorting for yaml dump [#108] [#61] [#82]
 
 ## [3.1.1] - 2019-03-15
-
 ### Fixed
-
 - Exit status code on error [#107]
 
 ## [3.1.0] - 2019-03-14
-
 ### Added
-
 - `AUTH0_EXCLUDED_CLIENTS` option has been added to the config. Works similar to `AUTH0_EXCLUDED_RULES` and `AUTH0_EXCLUDED_RESOURCE_SERVERS`. [#102]
 
 ## [3.0.2] - 2019-03-12
-
 ### Fixed
-
 - Remove empty `flags` property from tenant settings [#104]
 
 ## [3.0.1] - 2019-03-04
-
 ### Fixed
-
 - fix readonly `flags.enable_sso`
 
 ## [3.0.0] - 2019-03-04
-
 ### Added
-
 - Options added to the config:
   - `INCLUDED_PROPS` - enables export of properties that are excluded by default (e.g. `client_secret`)
   - `EXCLUDED_PROPS` - provides ability to exclude any unwanted properties from exported objects
 
 ### Changed
-
 - `--strip` option has been removed from `export` command. Now **IDs will be stripped by default**. `AUTH0_EXPORT_IDENTIFIERS: true` or `--export_ids` can be used to override.
 
 ## [2.3.3] - 2019-03-04
-
 ### Fixed
-
 - backport readonly `flags.enable_sso`
 
 ## [2.3.2] - 2019-03-02
-
 ### Changed
-
 - set `enable_sso` and `sandbox_version` as readonly properties
 - alias `export = dump` and `import = deploy` for programmatic usage
 
 ## [2.3.1] - 2019-02-27
-
 ### Changed
-
 - convert non-integer `session_lifetime` to minutes [#95]
 - update `auth0-source-control-extension-tools`
   - Fix email provider export
   - Process empty arrays of databases
 
 ## [2.3.0] - 2019-02-21
-
 ### Changed
-
 - Empty arrays in the `tenant.yaml` (`clients: []`) will now lead to deleting all relevant records from the tenant. [#89]
 - Update environment variable explanation in READMEs. [#90]
 - Sanitize file and folder names. [#92]
 
 ## [2.2.5] - 2019-02-04
-
 ### Changed
-
 - Fix for using the wrong proxy reference. [#80]
 
 ## [2.2.4] - 2019-01-17
-
 ### Added
-
 - Added 'name' prop to pages examples [#76]
 
 ### Changed
-
 - Fix various schema validation issues. auth0-extensions/auth0-source-control-extension-tools PRs [#52] thru [#57]
 
 ## 2.2.0 - 2018-11-28
-
 ### Changed
-
 - Update package dependency which contains security vulnerabilities.
 
 [#52]: https://github.com/auth0/auth0-deploy-cli/issues/52
@@ -1925,7 +1480,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1454]: https://github.com/auth0/auth0-deploy-cli/issues/1454
 [#1456]: https://github.com/auth0/auth0-deploy-cli/issues/1456
 [#1457]: https://github.com/auth0/auth0-deploy-cli/issues/1457
-[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v8.42.0...HEAD
+
+[Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v8.43.0...HEAD
+[8.43.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.42.0...v8.43.0
 [8.42.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.41.0...v8.42.0
 [8.41.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.40.0...v8.41.0
 [8.40.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.39.0...v8.40.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [8.43.0] - 2026-08-12
+
 ### Added
+
 - Add org-to-app entitlement (EA) support for organizations. [#1454]
 - Support full group metadata for Google Workspace directory sync (GA). [#1456]
 
 ### Fixed
+
 - Create phone templates on import instead of skipping when they have no ID. [#1457]
 - Address path traversal vulnerability and false warnings in config file handlers. [#1449]
 - Exclude org-scoped roles from tenant export by filtering `type='tenant'`. [#1453]
 - Strip read-only field from roles to fix export/import round-trip. [#1445]
 
 ## [8.42.0] - 2026-07-30
+
 ### Added
+
 - Add UL identifier input support for themes and tenant settings. [#1433]
 - Add `token_vault_privileged_access` support for clients. [#1430]
 - Add `auth0_managed` field support for network ACLs (Curated Blocklists - EA). [#1435]
@@ -27,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `cross_app_access_requesting_app` support for connections (EA). [#1422]
 
 ### Fixed
+
 - Prevent dry-run crash on `clientAuthCredentials` handler. [#1438]
 - Resolve spurious dry-run diffs for rules, themes, and hooks. [#1437]
 - Strip unresolved placeholders on deploy instead of throwing. [#1436]
@@ -35,79 +41,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `use_scope_descriptions_for_consent` to allowed tenant flags. [#1428]
 
 ## [8.41.0] - 2026-07-16
+
 ### Added
+
 - Add `third_party_client_access` support for organizations. [#1421]
 
 ## [8.40.0] - 2026-07-09
+
 ### Added
+
 - Add client credential lifecycle management for Private Key JWT and mTLS authentication methods. [#1417]
 - Add Rate Limit Policies (EA) support. [#1395]
 
 ### Fixed
+
 - Preserve `false` value for `default_head_tags_disabled` in screen renderer update. [#1416]
 - Skip destination update for action event streams as the destination type cannot be changed after creation. [#1425]
 
 ## [8.39.0] - 2026-06-30
+
 ### Added
+
 - Add `eventStreams` support. [#1412]
 - Add `id_token_session_expiry_supported` validation for enterprise connections. [#1411]
 
 ## [8.38.0] - 2026-06-25
+
 ### Added
+
 - Add `session_transfer` delegation config support for CTE impersonation on the Client entity. [#1406]
 - Add `fedcm_login` support for Google One Tap / FedCM in Universal Login on the Client entity. [#1407]
 - Add `login-post-identifier` and `signup-post-identifier` as supported action triggers. [#1409]
 - Add `allow_online_access` and `allow_online_access_with_ephemeral_sessions` fields to resource server. [#1398]
 
 ### Fixed
+
 - Fix keyword placeholder validation to allow lowercase Auth0 template variables (e.g. `@@password@@`). [#1408]
 - Re-apply prompt settings after branding update to prevent Authentication Profile reset. [#1404]
 
 ## [8.37.0] - 2026-06-17
+
 ### Added
+
 - Add `invitation_landing_client_id` support to `my_organization_configuration` on the Client entity, with client ID-to-name resolution on export and name-to-ID resolution on import. [#1400]
 
 ### Fixed
+
 - Remove `enable_custom_domain_in_emails` from managed tenant flags to prevent import failures on tenants without a ready custom domain. [#1401]
 - Remove incorrect `maximum: 10` constraint on Network ACL `priority` field in schema validation. [#1403]
 
 ## [8.36.0] - 2026-06-05
+
 ### Added
+
 - Add optional flag to skip secret masking during export. [#1396]
 
 ### Fixed
+
 - Remove stale connection files from directory export when connections are deleted. [#1389]
 
 ## [8.35.0] - 2026-05-22
+
 ### Added
+
 - Add `AUTH0_IGNORE_DRY_RUN_FIELDS` config option to exclude specified fields from `--dry-run` diff output per handler type. [#1385]
 - Add hostnames and CIDR fields to network ACL match schema. [#1386]
 - Add `ES384` and `ES512` as valid `dpop_signing_alg` values for OIDC and Okta enterprise connections (GA). [#1391]
 
 ### Deprecated
+
 - Deprecate absolute and external file path references in config handlers; a warning is emitted when detected. Support will be removed in a future major version. [#1392]
 
 ### Fixed
+
 - Fix keyword markers in themes not being preserved during default export configuration. [#1387]
 
 ## [8.34.0] - 2026-05-11
+
 ### Added
+
 - Add support for `authorization_policy` on the Auth0 My Account API resource server, enabling ACR (Authentication Context Class Reference) policy configuration via Deploy CLI. [#1381]
 - Add Google Workspace inbound group sync support to directory provisioning configuration. [#1380]
 
 ### Fixed
+
 - Fix keyword replacement mappings (e.g. `##ENV##`) not being applied to `theme.json` during import. [#1379]
 
 ## [8.33.0] - 2026-05-05
+
 ### Added
+
 - Add support for Third Party Apps CORE EA Release 1 properties, including updated `clientGrants` matching and `clients` schema handling. [#1372]
 - Add support for additional signing algorithms (`token_endpoint_auth_signing_alg`, `id_token_signed_response_algs`) in OIDC and Okta enterprise connections. [#1375]
 
 ### Fixed
+
 - Fix Deploy CLI hanging indefinitely when importing 3 or more actions that reference action modules, caused by a deadlock in the shared rate-limiting pool. [#1374]
 
 ## [8.32.0] - 2026-04-23
+
 ### Added
+
 - Add support for CIMD client registration via `external_client_id`, allowing clients to be registered from an OAuth 2.0 Client ID Metadata Document. [#1369]
 - Add `on_behalf_of_token_exchange` to supported `token_exchange.allow_any_profile_of_type` values for clients. [#1366]
 - Add Flexible Password Policy support for database connections. [#1362]
@@ -115,64 +149,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dry-run mode (GA) with `--dry-run`, `--dry-run --interactive`, and `--dry-run --apply` flags. [#1336]
 
 ### Fixed
+
 - Fix silent process exit when deploying 3+ organizations with discovery domains. [#1354]
 - Fix organization creation response handling and add ID validation. [#1365]
 - Fix undefined `enabled_clients` handling in `getEnabledClients`. [#1364]
 - Fix unresolved keyword placeholders being sent in API payloads before deploy. [#1360]
 
 ## [8.31.0] - 2026-04-10
+
 ### Added
+
 - Add support for `is_default` on `customDomains`. [#1330]
 - Add `AUTH0_EXPORT_ORDERED` config property and `--export_ordered` flag for stable exports. [#1335]
 
 ### Fixed
+
 - Fix `clientGrants` matching when multiple grants share the same `client_id` and `audience`. [#1341]
 
 ## [8.30.0] - 2026-04-02
+
 ### Added
+
 - Add support for passkey enrollment in `prompts` partials. [#1328]
 - Add support for `dpop_signing_alg` validation in OIDC and Okta `connections`. [#1343]
 
 ### Fixed
+
 - Fix action module fetching logic to resolve correct module IDs. [#1340]
 - Fix `AUTH0_EXCLUDED_*` options not respected during export. [#1342]
 
 ## [8.29.3] - 2026-03-25
+
 ### Fixed
+
 - Fix Universal Login Authentication Profile reverting to Identifier+Password after import when branding is included. [#1333]
 - Fix efficiency and reliability of fetching `enabled_clients` for `connections`. [#1334]
 
 ## [8.29.2] - 2026-03-17
+
 ### Fixed
+
 - Fix false-positive deprecation warning for `cross_origin_auth` when `cross_origin_authentication` is correctly used in config. [#1322]
 
 ## [8.29.1] - 2026-03-12
+
 ### Fixed
+
 - Fix bad request error when no `emailProvider` is configured. [#1321]
 - Fix `enabled_clients` pagination for `connections`. [#1320]
 
 ## [8.29.0] - 2026-03-03
+
 ### Added
+
 - Add DPoP support for proof-of-possession mechanism in `resourceServers` (GA) [#1311]
 - Add `supplemental signals` configuration for Akamai integration.(EA) [#1310]
 
 ## [8.28.0] - 2026-02-20
+
 ### Added
+
 - Add support for managing `action-modules`.(EA) [#1302]
 - Add support for managing `modules` in `actions`.(EA) [#1302]
 
 ## [8.27.0] - 2026-02-13
+
 ### Added
+
 - Add support for `custom_password_hash.action_id` in `databases` (Universal Custom Password Hash EA). [#1288]
 - Add support for `allowed_strategies` in `selfServiceProfiles`. [#1298]
 
 ### Fixed
+
 - Fix validation handling for `authentication_methods.password.enabled` and `disable_self_service_change_password` in `databases`. [#1297]
 - Fix stripping deprecated `enabled_clients` for `connections` with enhanced client management. [#1294]
 - Fix exclude third-party `clientGrants` when `AUTH0_EXCLUDE_THIRD_PARTY_CLIENTS` is enabled. [#1289]
 
 ## [8.26.0] - 2026-01-30
+
 ### Added
+
 - Add support for `use_for_organization_discovery` in organizations `discovery-domains`. [#1283]
 - Add support for passwordless authentication methods (`email_otp` and `phone_otp`) in `databases`. [#1282]
 - Add support for `relying_party_identifier` in `customDomains`. [#1280]
@@ -180,264 +236,361 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add OIDC logout configuration support with session metadata in `clients`. [#1263]
 
 ### Changed
+
 - Optimize directory provisioning configuration fetching for `connections`. [#1284]
 
 ### Fixed
+
 - Fix exclude read-only `is_default` from `customDomains`. [#1279]
 - Fix pagination skipping last page. [#1277]
 
 ## [8.25.0] - 2026-01-08
+
 ### Added
+
 - `AUTH0_INCLUDED_CONNECTIONS` config property to include only selected `connection`. [#1242]
 
 ### Fixed
+
 - Fix `tokenExchangeProfiles` profiles handling. [#1253]
 - Fix `idle_ephemeral_session_lifetime` and `ephemeral_session_lifetime` handling while importing [#1261]
 
 ## [8.24.0] - 2025-12-22
+
 ### Added
+
 - Add support for managing `riskAssessment` settings. [#1217]
 - Add directory provisioning support for `google-apps` connections. [#1246]
 
 ## [8.23.2] - 2025-12-18
+
 ### Fixed
+
 - Fix `customDomains` handler 409 for listing domains. [#1244]
 
 ## [8.23.1] - 2025-12-18
+
 ### Fixed
+
 - Fix resolve race conditions in processChanges for handlers. [#1240]
 - Fix client grants pagination to use checkpoint. [#1239]
 
 ## [8.23.0] - 2025-12-16
+
 ### Added
+
 - Add support for `brute-force-protection` in prompts custom-text. [#1221]
 - Add support for `phoneTemplates`. [#1224]
 - Add support for `tokenExchangeProfiles`. [#1232]
 
 ### Changed
+
 - Upgrading `node-auth0` from v4 to v5. [#1207]
 
 ### Fixed
+
 - Fix `improved_signup_bot_detection_in_classic` is added in allowed `tenant` flags. [#1231]
 
 ## [8.22.0] - 2025-12-10
+
 ### Added
+
 - Add `AUTH0_EXCLUDE_THIRD_PARTY_CLIENTS` config property to exclude third-party `clients`. [#1212]
 
 ### Fixed
+
 - Fix managing `Auth0 My Account API` in `resourceServers`. [#1229]
 - Fix `cross_origin_auth` is deprecated and migrated to `cross_origin_authentication` in `clients`. [#1223]
 
 ## [8.21.0] - 2025-11-21
+
 ### Added
+
 - Add support for Connection Profiles and Express Configuration on Clients. [#1204]
 - Add support for ACUL GA. [#1209]
 - Add support for `session_transfer` schema in `clients`. [#1211]
 
 ### Fixed
+
 - Fix handle responses when paginating custom domains. [#1214]
 
 ## [8.20.4-beta.0] - 2025-12-02
+
 ### Changed
+
 - Upgrading node-auth0 from v4 to v5 [beta]. [#1207]
 
 ## [8.20.3] - 2025-11-14
+
 ### Fixed
+
 - Fix pagination error when API returns empty array. [#1203]
 
 ## [8.20.2] - 2025-11-13
+
 ### Changed
+
 - Support enhanced custom domains in `customDomains` [#1193]
 
 ## [8.20.1] - 2025-11-10
+
 ### Fixed
+
 - Fix bot detection and captcha files optional loading & CIDR validation for `attackProtection`. [#1200]
 
 ## [8.20.0] - 2025-11-06
+
 ### Added
+
 - Add support for bot-detection and captcha configurations in `attackProtection`. [#1189]
 - Add support for `async_approval_notification_channels` for CIBA on `clients`. [#1194]
 
 ### Fixed
+
 - Fix `AUTH0_EXPORT_IDENTIFIERS` configuration to export action IDs in exports. [#1196]
 - Fix `EXCLUDED_PROPS` configuration exporting `emailProvider` in directory format. [#1195]
 
 ## [8.19.0] - 2025-10-31
+
 ### Added
+
 - Add support for organization discovery domains in `organizations`. [#1187]
 - Add support for `email.unique` attribute property in `databases`. [`#1190]
 - Add support for custom-URI-schemes in `clients` and `tenant`. [#1182]
 
 ### Fixed
+
 - Fix docs for env vars usage with keyword replacement. [#1188]
 - Fix read_only_background property schema for `themes`. [#1184]
 - Fix `userAttributeProfiles` handle if feature is not enabled. [#1181]
 
 ## [8.18.0] - 2025-10-13
+
 ### Added
+
 - Add support for connection purpose configuration options in `connections`. [#1162]
 
 ### Fixed
+
 - Fix execution order for `logStreams`. [#1175]
 - Fix keyword replacement handling for special characters. [#1174]
 
 ## [8.17.0] - 2025-09-30
+
 ### Added
+
 - Add support for user attribute profiles EA [#1166]
 - Add support for `user_attribute_profile_id` in `selfServiceProfiles` [#1166]
 - Add support for new language codes [#1159]
 
 ## [8.16.0] - 2025-09-16
+
 ### Added
+
 - Add support for token vault in `clients` and `resourceServers`. [#1158]
 - Add support for `async_approval` template in `emailTemplates`. [#1146]
 - Add support for `passkeys` in `prompts`. [#1161]
 
 ### Fixed
+
 - Fix example directory name for `phoneProviders`. [#1155]
 
 ## [8.15.0] - 2025-09-02
+
 ### Added
+
 - Add application access permissions support in `clientGrants` and `resourceServers`. [#1144]
 
 ### Fixed
+
 - Fix create or update custom domains for `customDomains`. [#1142]
 
 ## [8.13.0] - 2025-08-04
+
 ### Added
+
 - Add support for native to web SSO in `clients`. [#1139]
 - Add support for PII config in `logStreams`. [#1130]
 
 ## [8.12.0] - 2025-07-30
+
 ### Added
+
 - Add DPoP support for proof-of-possession mechanism in `resourceServers` [#1132]
 
 ### Fixed
+
 - Fix update enabled clients pagination for `connections` and `databases`. [#1127]
 - Fix request throttling for `forms` and `flows`. [#1133]
 - Fix logging and scope validation for `connections` and `databases`. [#1134]
 
 ## [8.11.0] - 2025-07-15
+
 ### Added
+
 - Add support for multiple custom domains in `customDomains`. [#1113]
 
 ## [8.10.0] - 2025-07-01
+
 ### Added
+
 - Add support new schema fields in `prompt` screens for rendering. [#1124]
 
 ### Changed
+
 - Update endpoints for enabled_clients in `connections` and `databases`. [#1123]
 - Update CONTRIBUTING.md with detailed setup and workflow instructions. [#1115]
 
 ### Fixed
+
 - Fix process execution order for `forms`,`flows`,`flowVaultConnections`. [#1121]
 - Fix keyword replacement markers in `databases` enabled_clients. [#1116]
 
 ## [8.9.0] - 2025-06-04
+
 ### Added
+
 - Add support for limit M2M usage - EA [#1093]
 - Add support to fetch list `prompt` screen's settings [#1104]
 
 ### Fixed
+
 - Fix secret masking for `connections`, `emailProvider` and `logStreams` [#1103]
 - Fix supported resource types in READMEs. [#1109]
 
 ## [8.8.3] - 2025-05-27
+
 ### Added
+
 - Add support new screens for rendering `prompt` screen's settings [#1096]
 
 ### Fixed
+
 - Fix export `databases` options and customScripts [#1095]
 
 ## [8.8.2] - 2025-05-08
+
 ### Added
+
 - Add support for refresh token policies configuration for `clients` - EA [#1085]
 
 ### Changed
+
 - Remove `AUTH0_EXPERIMENTAL_EA` flag check for screens rendering `prompt` screen's settings `import` command [#1084]
 
 ### Fixed
+
 - Fix tenant network ACL management not enabled [#1079]
 - Fix error handling `guardianFactorProviders`, `guardianFactorTemplates`, `guardianFactors`, `guardianPhoneFactorMessageTypes`, `guardianPhoneFactorSelectedProvider` for forbidden depreated feature [#1086]
 
 ## [8.8.1] - 2025-04-28
+
 ### Added
+
 - Add support new screens for rendering `prompt` screen's settings [#1071]
 
 ### Fixed
+
 - Fix AUTH0_EXCLUDED_CLIENTS support for `clients` YAML format [#1072]
 
 ## [8.8.0] - 2025-04-10
+
 ### Added
+
 - Add support for tenant ACL EA support [#1063]
 - Add support for new prompts in custom-text [#1064]
 
 ### Fixed
+
 - Fix remove unsupported ACUL screens for rendering `prompt` screen's settings [#1061]
 - Fix update node version requirement to 20(v20.18.1) [#1062]
 
 ## [8.7.1] - 2025-03-27
+
 ### Added
+
 - Add support new screens for rendering `prompt` screen's settings [#1053]
 
 ### Fixed
+
 - Fix get all `customDomains` types [#1054]
 
 ### Security
+
 - Security fixes from dependencies [#1054]
 
 ## [8.7.0] - 2025-03-13
+
 ### Added
+
 - Add support for extensibility as custom phone provider `phoneProviders` [#1038]
 - Add support for checkpoint pagination for GET `connections` [#1041]
 
 ### Fixed
+
 - Removed survey link from import/export command [#1039]
 - Fix dumping JSON files with keyword preserve markers in client grants [#1040]
 - Fix warn log insufficient scope for branding templates export [#1047]
 
 ### Security
+
 - Security fixes from dependencies [#1046]
 - Node 20(v20.18.3) LTS and newer LTS releases are supported [#1046]
 
 ## [8.6.2] - 2025-02-21
+
 ### Added
+
 - Add support new screens for rendering `prompt` screen's settings [#1035]
 
 ## [8.6.1] - 2025-02-20
+
 ### Fixed
+
 - Fix docs for support of `forms`,`flows`,`flowVaultConnections` [#1030]
 - Fix keyword preservation for `clientGrants` [#1032]
 - Fix google credential support for `clients` [#1031]
 
 ## [8.6.0] - 2025-02-06
+
 ### Added
+
 - Add support new screens for rendering `prompt` screen's settings [#1028]
 - Add support for new `--experimental_ea` command flag [#1027]
 
 ### Fixed
+
 - Fix keyword for the repository [#1026]
 
 ## [8.5.0] - 2025-01-29
+
 ### Added
+
 - Add support for reset_email_by_code template for `emailTemplates` [#1014]
 
 ### Fixed
+
 - Fix proxy support [#1022]
 - Fix schema for phone,email,username as flexible identifiers for `databases` [#1023]
 - Fix docs for support of `selfServiceProfiles` [#1021]
 
 ## [8.4.4] - 2025-01-20
+
 ### Fixed
+
 - Fix `emailProvider` support for Azure and MS365 [#1016]
 - Fix npmignore to exclude additional files and directories [#1017]
 
 ## [8.4.3] - 2025-01-08
+
 ### Fixed
+
 - Fix release CI version bump
 
 ## [8.4.2] - 2025-01-08
+
 ### Fixed
+
 - Fix Twilio SMS factor provider update for `guardianFactorProviders` [#1007]
 - Fix exporting SAML `connections` certificate [#1008]
 - Fix `action` code paths for directory format exports [#1009]
@@ -445,510 +598,720 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix dependency update proxy agent [#1010]
 
 ## [8.4.1] - 2024-12-16
+
 ### Fixed
+
 - Fix importing forms, flows and flow vault connections dependencies[#1001]
 - Fix docs for support of rendering `prompt` screen's settings [#1002]
 
 ## [8.4.0] - 2024-12-09
+
 ### Added
+
 - Add support for rendering `prompt` screen's settings [#998]
 
 ## [8.3.0] - 2024-11-28
+
 ### Added
+
 - Management support for `selfServiceProfiles` [#989]
 
 ### Fixed
+
 - Fix checkpoint pagination to get all organizations [#984]
 - Fix error handling for trigger bindings [#991]
 
 ## [8.2.0] - 2024-11-18
+
 ### Added
+
 - Management support for `forms`, `flows` and `flowVaultConnections` [#982]
 
 ### Fixed
+
 - Fix docs to support free tier usage [#978]
 
 ## [8.1.0] - 2024-11-08
+
 ### Added
+
 - Client Credentials (M2M) support in `organizations` and `clientGrants` [#975]
 
 ## [8.0.0] - 2024-10-21
+
 ### Changed
+
 - Auth0 [v4.X](https://github.com/auth0/node-auth0/releases/tag/v4.10.0) migration
 - The `delete` operation on the `emailProvider` resource will disable the email provider instead of deleting it.
 
 ### Deprecated
+
 - Migration resource operation
 
 ### Security
+
 - Security fixes from dependencies
 - Node 18 LTS and newer LTS releases are supported.
-  
+
   Doc: [v8 Migartion](./docs/v8_MIGRATION_GUIDE.md)
 
 ## [7.24.3] - 2024-10-15
+
 ### Fixed
+
 - Fix keyword replacement for `actions secrets` using the directory format [#954]
 - Fix keyword replacement for `custom prompts` using the directory format [#963]
 
 ## [7.24.2] - 2024-08-28
+
 ### Added
+
 - Add support for `login-passwordless` prompt on `partials` in prompts handler [#946]
 
 ### Fixed
+
 - Fix `branding` template `path` on export/import [#943]
 - Fix docs for support `exclusions of individual resource` [#944]
 
 ## [7.24.1] - 2024-08-09
+
 ### Fixed
+
 - Fix `branding` template `path` on export/import as Yaml [#939]
 - Fix `databases` handler to handle `options` property correctly for flexible identifiers [#937]
 
 ## [7.24.0] - 2024-08-02
+
 ### Added
+
 - Management support for `partials` in `prompts` handler [#930]
 
 ### Changed
+
 - Reduced latency while performing `SCIM` CRUD operations [#933]
 
 ## [7.23.1] - 2024-07-19
+
 ### Fixed
+
 - Fix `429`(`too_many_requests`) and `403`(`insufficient_scope`) errors in the SCIM handler [#925]
 
 ## [7.23.0] - 2024-07-16
+
 ### Added
+
 - Management support for `scim_configuration` in connections handler [#921]
 
 ## [7.22.1] - 2024-06-24
+
 ### Fixed
+
 - Made `captcha_widget_theme` an optional field in the `colors` property within the `themes` schema [#911]
 
 ## [7.22.0] - 2024-06-21
+
 ### Added
+
 - Management support for `is_signup_enabled` in organization connections [#905]
 - Management support for `captcha_widget_theme` in theme colors [#906]
 
 ## [7.21.0] - 2024-02-08
+
 ### Added
+
 - `show_as_button` management support for organization connections [#889]
 
 ### Fixed
+
 - Strip `sink.azurePartnerTopic` field from payload when creating log stream [#876]
 
 ## [7.20.0] - 2023-11-29
+
 ### Added
+
 - Relative path import support for actions directory handler [#866]
 
 ### Fixed
+
 - Keyword preservation for wider array of resources [#864]
 - Fetching clients if not defined when managing client grants in YAML format [#865]
 
 ## [7.19.0] - 2023-08-11
+
 ### Added
+
 - Support for Private Key JWT authentication for authenticating with private key instead of client secret [#817]
 
 ### Fixed
+
 - Process branding changes after theme changes to prevent delay in dashboard preview [#836]
 - Handling eventual hooks and rules deprecation [#838]
 - Overwrites occurring when preserving keywords within multiple client grants [#837]
 
 ## [7.18.0] - 2023-07-14
+
 ### Added
+
 - Support for `password-reset-post-challenge` action trigger [#818]
 
 ### Fixed
+
 - Runtime error when attempting to preserve keyword on null remote assets [#822]
 - Respect email template `body` filepath definition [#820]
 
 ## [7.17.7] - 2023-07-07
+
 ### Fixed
+
 - Delay processing of action triggers until deployed actions register [#809]
 - Process custom domains prior to branding settings [#811]
 
 ## [7.17.6] - 2023-06-23
+
 ### Changed
+
 - Improve handling of custom text prompts, reducing high-volume errors and timeouts by leveraging connection pooling for controlled execution [#804]
 
 ## [7.17.5] - 2023-06-08
+
 ### Fixed
+
 - Obfuscating sensitive log streams keys [#800]
 - Prevent exporting of disallowed tenant flags [#799]
 
 ## [7.17.4] - 2023-06-06
+
 ### Fixed
+
 - Prevent tenant flag "Additional properties not allowed" error by only updating publicly-available feature flags [#797]
 
 ## [7.17.3] - 2023-05-24
+
 ### Fixed
+
 - Keyword preservation for client grant `audience` field [#793]
 
 ## [7.17.2] - 2023-04-19
+
 ### Fixed
+
 - API error when no tenant flags defined [#780]
 - Keyword preservation in a resource's identifier fields [#784]
 
 ## [7.17.1] - 2023-03-31
+
 ### Fixed
+
 - Tenant-agnostic filenames for client grants if more than fifty clients and fifty resource servers [#764]
 - Unintentional exclusion of clients when injecting access token via `AUTH0_ACCESS_TOKEN` [#775]
 
 ## [7.17.0] - 2023-03-03
+
 ### Added
+
 - Keyword preservation on export to prevent overwriting of keyword markers in most instances. Enabled through the `AUTH0_PRESERVE_KEYWORDS` boolean configuration property. See also: [Preserving Keywords on Export](./docs/keyword-replacement.md#preserving-keywords-on-export) [#738],[#740],[#741],[#744],[#745],[#751],[#754],[#757],[#758],[#760]
 
 ### Fixed
+
 - Enabled wrapping of `@@ARRAY_REPLACE@@` keyword markers with single quotes in YAML resource configuration files [#760]
 
 ## [7.16.1] - 2023-02-07
+
 ### Fixed
+
 - Exporting of multiple client grants for a single client when using directory format [#729]
 - Tenant-agnostic client grant files when exporting using directory format [#729]
 
 ## [7.16.0] - 2023-02-01
+
 ### Added
+
 - `AUTH0_INCLUDED_ONLY` configuration property to express sole management of certain resource types [#726]
 - Suspended log stream management support [#725]
 - More descriptive errors when actions service is unavailable [#724]
 
 ### Fixed
+
 - Remove configurable tenant `sandbox_version` property from readonly list [#683]
 - Handling of undefined tenant `enabled_locales` property [#727]
 
 ## [7.15.2] - 2023-01-03
+
 ### Fixed
+
 - Deletion of email provider when setting as empty object [#673]
 
 ### Security
+
 - Upgraded `node-auth0` which addresses [vulnerability reported](https://github.com/advisories/GHSA-hjrf-2m68-5959) for `jsonwebtoken` package
 
 ## [7.15.1] - 2022-10-19
+
 ### Added
+
 - Warning about future fix that enables deletion of email provider; no significant changes to functionality [#672]
 
 ### Fixed
+
 - Returning all branding setting when using YAML [#666]
 - Preventing empty `logo_url` from update tenant payload [#667]
 - Loading actions between different operating systems [#668]
 - Prevent writing undefined page templates files [#671]
 
 ## [7.15.0] - 2022-10-11
+
 ### Added
+
 - Ignoring management of marketplace actions because they are unsupported by the Management API [#660]
 
 ### Fixed
+
 - Allowing partial attack protection configurations [#638]
 
 ## [7.14.3] - 2022-08-24
+
 ### Fixed
+
 - Reclassify select production dependencies as dev dependencies [#626]
 - Allowing certain page templates configuration to be modified even when absent of HTML [#629],[#630]
 
 ## [7.14.2] - 2022-08-01
+
 ### Fixed
+
 - Allowing updating of branding themes when used in conjunction with `--export_ids` flag [#603]
 - Halting deploy process if passwordless email template does not exist [#617]
 
 ## [7.14.1] - 2022-06-29
+
 ### Fixed
+
 - Reverting unreplaced keyword mapping detection that would trigger some false-positives [#597]
 
 ## [7.14.0] - 2022-06-27
+
 ### Added
+
 - Validation to detect unreplaced keyword mappings during import [#591]
 
 ### Fixed
+
 - Detect and prevent `You are not allowed to set flag '<SOME_FLAG>' for this tenant.` errors when erroneously setting non-configurable migration flag [#590]
 - Crash when attempting to create page templates from undefined value [#592]
 
 ## [7.13.1] - 2022-06-13
+
 ### Fixed
+
 - Removing single usage of `flatMap` array method to prevent crashes with Node v10 [#577]
 
 ## [7.13.0] - 2022-06-06
+
 ### Added
+
 - Themes support (if supported by tenant) [#554]
 
 ### Fixed
+
 - Omit `enabled_clients` from connection payload if not defined in resource configuration files [#563]
 
 ## [7.12.3] - 2022-05-24
+
 ### Fixed
+
 - Resource exclusion respected during import even if resource configuration exists [#545]
 - Environment variables ingested by default [#553]
 
 ## [7.12.2] - 2022-05-17
+
 ### Fixed
+
 - Properly handle all screen types within a prompt grouping [#541]
 - Gracefully ignoring custom domains if not supported by tenant [#542]
 
 ## [7.12.1] - 2022-05-11
+
 ### Fixed
+
 - Unable to deploy without branding settings feature [#532]
 
 ## [7.12.0] - 2022-05-10
+
 ### Added
+
 - Prompts support (both prompts settings and custom text for prompts) [#530]
 - Custom domains support [#527]
 
 ## [7.11.1] - 2022-05-04
+
 ### Fixed
+
 - Deployment of newly-created actions always failing due to "A draft must be in the 'built' state" error [#524]
 - Undefined `updateRule` Auth0 SDK alias replaced with operational `rules.update` [#526]
 
 ## [7.11.0] - 2022-04-28
+
 ### Added
+
 - Intelligent scope detection, will skip resources when insufficient scope provided to designated application [#517]
 
 ### Fixed
+
 - Inconsistencies between resource handlers with respect to empty, null and undefined values [#512]
 
 ## [7.10.0] - 2022-04-26
+
 ### Added
+
 - Branding support for directory format [#505]
 
 ### Fixed
+
 - More comprehensive support for deletions through `AUTH0_ALLOW_DELETE` [#509]
 
 ## [7.9.0] - 2022-04-19
+
 ### Added
+
 - Log streams support [#495]
 
 ### Fixed
+
 - `##` String keyword replacements now work when nested inside `@@` array replacements [#504]
 
 ## [7.8.0] - 2022-04-14
+
 ### Added
+
 - Type declarations for more seamless integration into Typescript projects when used as a module [#485]
 
 ### Security
+
 - Updated Winston from 2.3.x to 3.3.0 which applies fix for theoretical prototype pollution vulnerability [#497]
 
 ## [7.7.1] - 2022-04-07
+
 ### Added
+
 - Deprecation warnings for now deprecated asset-specific exclusion configuration properties: `AUTH0_EXCLUDED_RULES`, `AUTH0_EXCLUDED_CLIENTS`, `AUTH0_EXCLUDED_DATABASES`, `AUTH0_EXCLUDED_CONNECTIONS`, `AUTH0_EXCLUDED_RESOURCE_SERVERS`, `AUTH0_EXCLUDED_DEFAULTS`. See [Resource Exclusion Proposal](https://github.com/auth0/auth0-deploy-cli/issues/451#user-content-deprecated-exclusion-props) for details. [#481]
 
 ### Fixed
+
 - Rules configs failing to update after regression prevented asset-specific overrides of Node Auth0 SDK methods [#482]
 - Attack protection not replacing keywords [#478]
 
 ## [7.7.0] - 2022-04-06
+
 ### Added
+
 - Exclusion of entire resource types via the `AUTH0_EXCLUDED` configuration parameter. See [Resource Exclusion Proposal](https://github.com/auth0/auth0-deploy-cli/issues/451) for details. [#468]
 
 ### Fixed
+
 - `idle_session_lifetime` and `session_lifetime` values properly ignored on update if inheriting default tenant values.[#471]
 
 ## [7.6.0] - 2022-03-25
+
 ### Added
+
 - New branding template feature support [#438]
 
 ### Fixed
+
 - Colliding `e` parameter alias between `export_ids` and `env` [#453]
 
 ## [7.5.2] - 2022-03-15
+
 ### Fixed
+
 - Resetting this version to be latest on NPM
 
 ## [7.5.1] - 2022-03-11
+
 ### Fixed
+
 - Updating dead link in logging output [#436]
 - Fixing `--env` flag to properly dictate environment variable inheritance [#432]
 
 ## [7.5.0] - 2022-03-08
+
 ### Added
+
 - Support for attack protection configuration management [#428]
 
 ### Fixed
+
 - Excluded connection properties from getting deleted upon update [#430]
 - Organizations in YAML format are skipped when not defined [#388]
 
 ## [7.4.0] - 2022-02-24
+
 ### Added
+
 - Allowing @@ array variable replacement to work when wrapped in quotes [#421]
 
 ### Fixed
+
 - Eliminated benign `client_metadata` warnings on import [#416]
 - Fixing request abstraction from losing function scope, enabling Auth0 Node SDK updates [#412]
 
 ### Security
+
 - Updating Auth0 Node SDK to 2.40.0 which fixes minor dependency vulnerability
 
 ## [7.3.7] - 2022-02-03
+
 ### Fixed
+
 - Expose errors that may be silently missed in Actions [#408]
 
 ## [7.3.6] - 2022-02-02
+
 ### Fixed
+
 - Fix errors caused by incompatibilities introduced by new versions of Auth0 SDK [#406]
 
 ## [7.3.5] - 2022-01-27
+
 ### Fixed
+
 - Fix an error with the function context [#403]
 
 ## [7.3.4] - 2022-01-26
+
 ### Fixed
+
 - Fix pagination [#401]
 
 ## [7.3.3] - 2022-01-26
+
 ### Fixed
+
 - Fix pagination [#400]
 
 ### Security
+
 - Security fixes from dependencies
 
 ## [7.3.2] - 2021-12-14
+
 ### Security
+
 - Fixes dependency security issues
 
 ## [7.3.1] - 2021-09-21
+
 ### Fixed
+
 - Error when authenticating with AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET with Node.js prior to v14
 
 ## [7.3.0] - 2021-09-20
+
 ### Added
+
 - Allow set of AUTH0_AUDIENCE for custom domain [#379] (credit @AliBazzi)
 
 ### Fixed
+
 - Load file configured in customScripts for DB Connections [#367] (credit @skukx)
 
 ### Security
+
 - Security fixes from dependencies
 
 ## [7.2.1] - 2021-08-23
+
 ### Fixed
+
 - [IDS-3074] Updated structure when dumping orgs (#369)
-  
+
   Fixes an issue when exporting organizations as a directory, connections are not structured in the right way, causing the import to remove any connection on the organizations.
+
 - [DXEX-1721] Fix client metadata property deletion
-  
+
   Fixes an inconsistency between how we calculate changes on deep metadata-like objects and with how APIv2 expects such changes to be expressed when a property is deleted.
+
 - Bump js-yaml from 3.x to 4.x and move to kacl (#371)
-  
+
   This PR bumps js-yaml from 3.x to 4.x in accordance with its migration guide. This bump means that we're able to use the default safe behaviour for both exports and imports.
-  
+
   Notably, this means that we won't end up with values like !<tag:yaml.org,2002:js/undefined> '' that are not at all human friendly and were problematic when we used the .safeLoad functionality.
 
 ## [7.2.0] - 2021-07-14
+
 ### Added
+
 - Add runtime property for actions [#364]
 
 ## [7.1.1] - 2021-06-23
+
 ### Added
+
 - Export tools module
 
 ### Fixed
+
 - Fix exception when actions is undefined [#361]
 - yargs should not be called when required as a module
 
 ## [7.1.0] - 2021-06-23
+
 ### Changed
+
 - Actions refactoring and fixes [#356]
 - Bump auth0@2.35.1
 
 ## [7.0.0] - 2021-06-11
+
 ### Added
+
 - MFA-1174 Support Recovery Codes
 - Support for organizations
 - Prompt link to Auth0 Docs upon insufficient scope
 
 ### Changed
+
 - Removed dependency on `auth0-source-control-extension-tools`, the package is not part of `auth0-deploy-cli`
 - Removed dependency on `auth-extension-tools`
 
 ### Deprecated
+
 - Dropped Node.js 8 support
 
 ### Fixed
+
 - Upstream node registry
 
 ### Security
+
 - Security fixes from dependencies
 
 ## [6.0.0] - 2020-12-28
+
 ### Deprecated
+
 - This release has been withdrawn
 
 ## [5.5.7] - 2021-05-19
+
 ### Added
+
 - Add Support Recovery Codes by bumping auth0-source-control-extension-tools@4.7.2
 
 ## [5.5.6] - 2021-04-21
+
 ### Fixed
+
 - Fix EXCLUDE_PROPS behaviour for connections and databases.
 
 ## [5.5.5] - 2021-03-26
+
 ### Fixed
+
 - Broken dependencies on 4.5.x range of source-countrol-extension-tools because of organizations.
 
 ## [5.5.4] - 2021-03-12
+
 ### Fixed
+
 - Remove limit on permissions in roles
 
 ## [5.5.3] - 2021-03-10
+
 ### Added
+
 - Add webauthn platform as a supported factor
 
 ## [5.5.2] - 2021-03-10
+
 ### Fixed
+
 - Fix pagination when computing changes
 
 ## [5.5.1] - 2021-03-03
+
 ### Fixed
+
 - Fix issues with retrieving more than 50 roles
 
 ## [5.5.0] - 2021-01-28
+
 ### Added
+
 - Add support for `verify_email_by_code` email template [#309]
 
 ## [5.3.2] - 2020-12-17
+
 ### Fixed
+
 - Fix keyword mapping in client page templates [ESD-10528] [#291]
 
 ## [5.3.1] - 2020-11-16
+
 ### Fixed
+
 - Fix report error exporting hooks by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 - Add MFA factor webauthn-roaming support by bumping auth0-source-control-extension-tools@4.1.12 [#289]
 
 ## [5.3.0] - 2020-11-05
+
 ### Changed
+
 - Return database `enabled_clients` in deterministic order [#281]
 
 ### Fixed
+
 - Fix the structure of the example policies.json, and correct the guardianPolicies test to use `all-applications` instead of `all-application` [#278]
 - Fix pagination for specific API calls by bumping auth0-source-control-extension-tools@4.1.9 [#287]
 
 ## [5.2.1] - 2020-09-23
+
 ### Fixed
+
 - Issue with client grants deleted when using AUTH0_EXCLUDED_CLIENTS
 
 ## [5.2.0] - 2020-09-17
+
 ### Fixed
+
 - Always sort custom database scripts alphabetically
 
 ## [5.1.6] - 2020-09-15
+
 ### Fixed
+
 - Add new line support to JSON files generated in directory dumps
 - Move write file method to common util
 - Update `auth0-source-control-extension-tools`
 
 ## [5.1.5] - 2020-08-13
+
 ### Fixed
+
 - The --proxy_url option should work properly now. (Although only on Node >= 10).
 
 ## [5.1.4] - 2020-08-12
+
 ### Fixed
+
 - Connections disabled when the client is added AUTH0_EXCLUDED_CLIENTS list.
 
 ## [5.1.3] - 2020-08-04
+
 ### Fixed
+
 - Many entities were not being fetched via the Paging API properly.
 
 ## [5.1.3] - 2020-08-04
+
 ### Fixed
+
 - Many entities were not being fetched via the Paging API properly.
 
 ## [5.1.0] - 2020-07-09
+
 ### Added
+
 - Add support for three guardian/MFA-related features:
   - Guardian Policies
   - Guardian Phone factor selected provider
@@ -956,23 +1319,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for Migrations
 
 ## [5.0.0] - 2020-06-04
+
 ### Added
+
 - Allow excluding default values for emailProvider with `AUTH0_EXCLUDED_DEFAULTS` [#236]
 
 ### Changed
+
 - [**Breaking**] Updated dependencies and deprecated support for Node versions earlier than 8 via babel@7 and dot-prop@5 [#242]
 
 ### Fixed
+
 - pages: fix error when dumping error_page without html property [#247]
 
 ## [4.3.1] - 2020-05-20
+
 ### Fixed
+
 - Fixed broken mkdirp package dependency
 
 ## [4.3.0] - 2020-05-18
+
 ### Removed
+
 - Removed several unused dependencies:
-  
+
   - ajv
   - e6-template-strings
   - node-storage
@@ -980,174 +1351,250 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - xregexp
 
 ## [4.2.2] - 2020-05-04
+
 ### Added
+
 - Support for phone message hook added.
 - Configurable connections directory with `AUTH0_CONNECTIONS_DIRECTORY`.
 
 ### Removed
+
 - Remove data from verify email example to prevent copy and paste misuse.
 
 ## [4.2.1] - 2020-04-06
+
 ### Fixed
+
 - Fixed rules' reorder to avoid order collisions by updating `auth0-source-control-extension-tools`
 
 ## [4.2.0] - 2020-03-28
+
 ### Fixed
+
 - When importing SAML database connections, support client name in the `options.idpinitiated.client_id` property.
 - When exporting SAML database connections, convert client ID to client name.
 
 ## [4.1.0] - 2020-03-28
+
 ### Fixed
+
 - When exporting a mailgun email provider, a placholder api key will be included in the export..
 
 ## [4.0.3] - 2020-03-18
+
 ### Fixed
+
 - Programmatic usage will not complain about args. [#215]
 
 ## [4.0.2] - 2020-02-28
+
 ### Added
+
 - Included Deploy CLI version number in User-Agent header.
 - If no command line arguments are passed, the usage statement will be printed.
 
 ## [4.0.1] - 2020-02-05
+
 ### Changed
+
 - Update `auth0-source-control-extension-tools`
 
 ### Fixed
+
 - Fixed import and export errors when roles and hooks are not available
 
 ## [4.0.0] - 2020-01-29
+
 ### Added
+
 - Add support for Hooks and Hook Secrets
 - Update `auth0`, `auth0-extension-tools`, `auth0-source-control-extension-tools`, and `js-yaml`
 
 ## [3.6.7] - 2020-01-08
+
 ### Fixed
+
 - Fixed a crash when no roles are present in a tenant during an export
 
 ## [3.6.5] - 2019-12-19
+
 ### Added
+
 - Add readonly flag `remove_stale_idp_attributes`
 
 ## [3.6.4] - 2019-12-04
+
 ### Changed
+
 - Update `https-proxy-agent` and `js-yaml`
 
 ## [3.6.3] - 2019-11-04
+
 ### Added
+
 - Add `AUTH0_API_MAX_RETRIES` support
 
 ## [3.6.2] - 2019-10-18
+
 ### Fixed
+
 - Fix mapping for passwordless email connection template
 
 ## [3.6.1] - 2019-09-27
+
 ### Removed
+
 - Removed `--verbose` option
 
 ## [3.6.0] - 2019-08-26
+
 ### Changed
+
 - Update `auth0-extension-tools`
 
 ### Fixed
+
 - Clear empty descriptions on roles
 
 ## [3.5.0] - 2019-08-14
+
 ### Added
+
 - Ability to exclude connections and databases (AUTH0_EXCLUDED_CONNECTIONS & AUTH0_EXCLUDED_DATABASES)
 
 ### Fixed
+
 - Excludes for yaml import
 
 ## [3.4.0] - 2019-07-15
+
 ### Added
+
 - Load email template for passwordless email connection from external html file [#124]
 - Load custom_login_page template for client from external html file [#138]
 
 ## [3.3.2] - 2019-07-11
+
 ### Changed
+
 - pin minor version of source-control-tools@~3.4.1
 
 ## [3.3.1] - 2019-06-13
+
 ### Fixed
+
 - `allowed_clients`, `allowed_logout_urls`, `allowed_origins` and `callbacks` properties of the `client` can no longer be exported as `null`
 
 ## [3.3.0] - 2019-04-22
+
 ### Added
+
 - Support for roles and permissions export and import
 
 ## [3.2.0] - 2019-04-12
+
 ### Changed
+
 - Secrets (`rules configs` and databases `options.configuration`) can no longer be exported
 
 ## [3.1.3] - 2019-04-03
+
 ### Added
+
 - Clearing empty tenant flags on `import`
 
 ## [3.1.2] - 2019-03-22
+
 ### Added
+
 - Consistent property sorting for yaml dump [#108] [#61] [#82]
 
 ## [3.1.1] - 2019-03-15
+
 ### Fixed
+
 - Exit status code on error [#107]
 
 ## [3.1.0] - 2019-03-14
+
 ### Added
+
 - `AUTH0_EXCLUDED_CLIENTS` option has been added to the config. Works similar to `AUTH0_EXCLUDED_RULES` and `AUTH0_EXCLUDED_RESOURCE_SERVERS`. [#102]
 
 ## [3.0.2] - 2019-03-12
+
 ### Fixed
+
 - Remove empty `flags` property from tenant settings [#104]
 
 ## [3.0.1] - 2019-03-04
+
 ### Fixed
+
 - fix readonly `flags.enable_sso`
 
 ## [3.0.0] - 2019-03-04
+
 ### Added
+
 - Options added to the config:
   - `INCLUDED_PROPS` - enables export of properties that are excluded by default (e.g. `client_secret`)
   - `EXCLUDED_PROPS` - provides ability to exclude any unwanted properties from exported objects
 
 ### Changed
+
 - `--strip` option has been removed from `export` command. Now **IDs will be stripped by default**. `AUTH0_EXPORT_IDENTIFIERS: true` or `--export_ids` can be used to override.
 
 ## [2.3.3] - 2019-03-04
+
 ### Fixed
+
 - backport readonly `flags.enable_sso`
 
 ## [2.3.2] - 2019-03-02
+
 ### Changed
+
 - set `enable_sso` and `sandbox_version` as readonly properties
 - alias `export = dump` and `import = deploy` for programmatic usage
 
 ## [2.3.1] - 2019-02-27
+
 ### Changed
+
 - convert non-integer `session_lifetime` to minutes [#95]
 - update `auth0-source-control-extension-tools`
   - Fix email provider export
   - Process empty arrays of databases
 
 ## [2.3.0] - 2019-02-21
+
 ### Changed
+
 - Empty arrays in the `tenant.yaml` (`clients: []`) will now lead to deleting all relevant records from the tenant. [#89]
 - Update environment variable explanation in READMEs. [#90]
 - Sanitize file and folder names. [#92]
 
 ## [2.2.5] - 2019-02-04
+
 ### Changed
+
 - Fix for using the wrong proxy reference. [#80]
 
 ## [2.2.4] - 2019-01-17
+
 ### Added
+
 - Added 'name' prop to pages examples [#76]
 
 ### Changed
+
 - Fix various schema validation issues. auth0-extensions/auth0-source-control-extension-tools PRs [#52] thru [#57]
 
 ## 2.2.0 - 2018-11-28
+
 ### Changed
+
 - Update package dependency which contains security vulnerabilities.
 
 [#52]: https://github.com/auth0/auth0-deploy-cli/issues/52
@@ -1480,7 +1927,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1454]: https://github.com/auth0/auth0-deploy-cli/issues/1454
 [#1456]: https://github.com/auth0/auth0-deploy-cli/issues/1456
 [#1457]: https://github.com/auth0/auth0-deploy-cli/issues/1457
-
 [Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v8.43.0...HEAD
 [8.43.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.42.0...v8.43.0
 [8.42.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.41.0...v8.42.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add org-to-app entitlement (EA) support for organizations. [#1454]
+- Support full group metadata for Google Workspace directory sync (GA). [#1456]
+
+### Fixed
+
+- Create phone templates on import instead of skipping when they have no ID. [#1457]
+- Address path traversal vulnerability and false warnings in config file handlers. [#1449]
+- Exclude org-scoped roles from tenant export by filtering `type='tenant'`. [#1453]
+- Strip read-only field from roles to fix export/import round-trip. [#1445]
+
 ## [8.42.0] - 2026-07-30
 
 ### Added
@@ -1907,6 +1919,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1436]: https://github.com/auth0/auth0-deploy-cli/issues/1436
 [#1437]: https://github.com/auth0/auth0-deploy-cli/issues/1437
 [#1438]: https://github.com/auth0/auth0-deploy-cli/issues/1438
+[#1445]: https://github.com/auth0/auth0-deploy-cli/issues/1445
+[#1449]: https://github.com/auth0/auth0-deploy-cli/issues/1449
+[#1453]: https://github.com/auth0/auth0-deploy-cli/issues/1453
+[#1454]: https://github.com/auth0/auth0-deploy-cli/issues/1454
+[#1456]: https://github.com/auth0/auth0-deploy-cli/issues/1456
+[#1457]: https://github.com/auth0/auth0-deploy-cli/issues/1457
 [Unreleased]: https://github.com/auth0/auth0-deploy-cli/compare/v8.42.0...HEAD
 [8.42.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.41.0...v8.42.0
 [8.41.0]: https://github.com/auth0/auth0-deploy-cli/compare/v8.40.0...v8.41.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-cli",
-  "version": "8.42.0",
+  "version": "8.43.0",
   "description": "A command line tool for deploying updates to your Auth0 tenant",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
### Added

- Add org-to-app entitlement (EA) support for organizations. [#1454]
- Support full group metadata for Google Workspace directory sync (GA). [#1456]

### Fixed

- Create phone templates on import instead of skipping when they have no ID. [#1457]
- Address path traversal vulnerability and false warnings in config file handlers. [#1449]
- Exclude org-scoped roles from tenant export by filtering `type='tenant'`. [#1453]
- Strip read-only field from roles to fix export/import round-trip. [#1445]
