### PR TITLE
fix: sort attackProtection arrays on export to prevent spurious diffs (#1440)

### DIFF
--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -217,9 +217,10 @@ export function eventStreamDefaults(
 }
 
 /**
- * Recursively sorts primitive arrays (e.g. `shields`, `admin_notification_frequency`)
- * within the attackProtection subtree so repeated exports produce deterministic output.
- * These are unordered enum-like sets, so ordering is cosmetic. Object arrays are left as-is.
+ * Sorts primitive arrays (e.g. `shields`, `admin_notification_frequency`) within the
+ * attackProtection subtree in place, so repeated exports produce deterministic output.
+ * These are unordered, string-typed enum sets — ordering is cosmetic. Object arrays are
+ * left as-is.
  */
 export function sortAttackProtectionArrays(attackProtection: AttackProtection): AttackProtection {
   const sortArraysDeep = (value: unknown): void => {

--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -216,6 +216,33 @@ export function eventStreamDefaults(
   });
 }
 
+/**
+ * Recursively sorts primitive arrays (e.g. `shields`, `admin_notification_frequency`)
+ * within the attackProtection subtree so repeated exports produce deterministic output.
+ * These are unordered enum-like sets, so ordering is cosmetic. Object arrays are left as-is.
+ */
+export function sortAttackProtectionArrays(attackProtection: AttackProtection): AttackProtection {
+  const sortArraysDeep = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      const isPrimitiveArray = value.every((item) => item === null || typeof item !== 'object');
+      if (isPrimitiveArray) {
+        value.sort();
+      } else {
+        value.forEach(sortArraysDeep);
+      }
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(sortArraysDeep);
+    }
+  };
+
+  sortArraysDeep(attackProtection);
+
+  return attackProtection;
+}
+
 export function attackProtectionDefaults(
   attackProtection: AttackProtection,
   config?: Pick<Config, 'AUTH0_EXPORT_SECRETS'>

--- a/src/context/directory/handlers/attackProtection.ts
+++ b/src/context/directory/handlers/attackProtection.ts
@@ -5,7 +5,7 @@ import { dumpJSON, existsMustBeDir, isFile, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
 import { ParsedAsset } from '../../../types';
-import { attackProtectionDefaults } from '../../defaults';
+import { attackProtectionDefaults, sortAttackProtectionArrays } from '../../defaults';
 import { AttackProtection } from '../../../tools/auth0/handlers/attackProtection';
 
 type ParsedAttackProtection = ParsedAsset<'attackProtection', AttackProtection>;
@@ -85,7 +85,9 @@ async function dump(context: DirectoryContext): Promise<void> {
   const files = attackProtectionFiles(context.filePath);
   fs.ensureDirSync(files.directory);
 
-  const maskedAttackProtection = attackProtectionDefaults(attackProtection, context.config);
+  const maskedAttackProtection = sortAttackProtectionArrays(
+    attackProtectionDefaults(attackProtection, context.config)
+  );
 
   if (maskedAttackProtection.botDetection) {
     dumpJSON(files.botDetection, maskedAttackProtection.botDetection);

--- a/src/context/yaml/handlers/attackProtection.ts
+++ b/src/context/yaml/handlers/attackProtection.ts
@@ -2,7 +2,7 @@ import { YAMLHandler } from '.';
 import YAMLContext from '..';
 import { AttackProtection } from '../../../tools/auth0/handlers/attackProtection';
 import { ParsedAsset } from '../../../types';
-import { attackProtectionDefaults } from '../../defaults';
+import { attackProtectionDefaults, sortAttackProtectionArrays } from '../../defaults';
 
 type ParsedAttackProtection = ParsedAsset<'attackProtection', AttackProtection>;
 
@@ -46,7 +46,7 @@ async function dump(context: YAMLContext): Promise<ParsedAttackProtection> {
   const maskedAttackProtection = attackProtectionDefaults(attackProtectionConfig, context.config);
 
   return {
-    attackProtection: maskedAttackProtection,
+    attackProtection: sortAttackProtectionArrays(maskedAttackProtection),
   };
 }
 

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -5,6 +5,7 @@ import {
   connectionDefaults,
   logStreamDefaults,
   attackProtectionDefaults,
+  sortAttackProtectionArrays,
 } from '../../src/context/defaults';
 
 describe('#context defaults', () => {
@@ -437,6 +438,71 @@ describe('#context defaults', () => {
       const result = attackProtectionDefaults(attackProtection, { AUTH0_EXPORT_SECRETS: true });
 
       expect(result.captcha.hcaptcha.secret).to.equal('real-hcaptcha-secret');
+    });
+  });
+
+  describe('sortAttackProtectionArrays', () => {
+    it('should sort primitive arrays across the attackProtection subtree deterministically', () => {
+      const attackProtection = {
+        breachedPasswordDetection: {
+          enabled: true,
+          shields: ['user_notification', 'block', 'admin_notification'],
+          admin_notification_frequency: ['weekly', 'immediately', 'monthly', 'daily'],
+        },
+        suspiciousIpThrottling: {
+          enabled: true,
+          shields: ['admin_notification', 'block'],
+        },
+        bruteForceProtection: {
+          enabled: true,
+          shields: ['block', 'user_notification'],
+          allowlist: ['192.168.1.2', '10.0.0.1'],
+        },
+      };
+
+      const result = sortAttackProtectionArrays(attackProtection);
+
+      expect(result.breachedPasswordDetection.shields).to.deep.equal([
+        'admin_notification',
+        'block',
+        'user_notification',
+      ]);
+      expect(result.breachedPasswordDetection.admin_notification_frequency).to.deep.equal([
+        'daily',
+        'immediately',
+        'monthly',
+        'weekly',
+      ]);
+      expect(result.suspiciousIpThrottling.shields).to.deep.equal(['admin_notification', 'block']);
+      expect(result.bruteForceProtection.shields).to.deep.equal(['block', 'user_notification']);
+      expect(result.bruteForceProtection.allowlist).to.deep.equal(['10.0.0.1', '192.168.1.2']);
+    });
+
+    it('should produce identical output regardless of input array order', () => {
+      const orderA = {
+        breachedPasswordDetection: {
+          shields: ['block', 'admin_notification', 'user_notification'],
+        },
+      };
+      const orderB = {
+        breachedPasswordDetection: {
+          shields: ['user_notification', 'block', 'admin_notification'],
+        },
+      };
+
+      expect(sortAttackProtectionArrays(orderA)).to.deep.equal(sortAttackProtectionArrays(orderB));
+    });
+
+    it('should not reorder arrays that contain objects', () => {
+      const attackProtection = {
+        captcha: {
+          providers: [{ name: 'zeta' }, { name: 'alpha' }],
+        },
+      };
+
+      const result = sortAttackProtectionArrays(attackProtection);
+
+      expect(result.captcha.providers).to.deep.equal([{ name: 'zeta' }, { name: 'alpha' }]);
     });
   });
 });

--- a/test/context/directory/attackProtection.test.js
+++ b/test/context/directory/attackProtection.test.js
@@ -148,38 +148,39 @@ describe('#directory context attack-protection', () => {
     expect(context.assets.attackProtection).to.deep.equal(target);
   });
 
-  it('should dump attack-protection', async () => {
+  it('should dump attack-protection with primitive arrays sorted deterministically', async () => {
     const dir = path.join(testDataDir, 'directory', 'attackProtectionDump');
     cleanThenMkdir(dir);
     const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
 
+    // Deliberately unsorted input arrays — the dump handler must reorder them.
     context.assets.attackProtection = {
       botDetection: {
-        allowlist: ['10.0.0.1'],
+        allowlist: ['10.0.0.2', '10.0.0.1'],
         bot_detection_level: 'medium',
         monitoring_mode_enabled: false,
       },
       breachedPasswordDetection: {
-        admin_notification_frequency: [],
+        admin_notification_frequency: ['weekly', 'daily', 'immediately'],
         enabled: true,
         method: 'standard',
-        shields: [],
+        shields: ['user_notification', 'block', 'admin_notification'],
       },
       bruteForceProtection: {
         allowlist: [],
         enabled: true,
         max_attempts: 10,
         mode: 'count_per_identifier_and_ip',
-        shields: ['block', 'user_notification'],
+        shields: ['user_notification', 'block'],
       },
       captcha: {
         policy: 'always',
         selected: 'friendly_captcha',
       },
       suspiciousIpThrottling: {
-        allowlist: ['127.0.0.1'],
+        allowlist: ['127.0.0.2', '127.0.0.1'],
         enabled: true,
-        shields: ['block', 'admin_notification'],
+        shields: ['user_notification', 'admin_notification', 'block'],
         stage: {
           'pre-login': {
             max_attempts: 100,
@@ -196,20 +197,49 @@ describe('#directory context attack-protection', () => {
     await handler.dump(context);
     const attackProtectionFolder = path.join(dir, 'attack-protection');
 
-    expect(loadJSON(path.join(attackProtectionFolder, 'bot-detection.json'))).to.deep.equal(
-      context.assets.attackProtection.botDetection
-    );
+    // Concrete expected output on disk, independent of the (mutated) input reference.
+    expect(loadJSON(path.join(attackProtectionFolder, 'bot-detection.json'))).to.deep.equal({
+      allowlist: ['10.0.0.1', '10.0.0.2'],
+      bot_detection_level: 'medium',
+      monitoring_mode_enabled: false,
+    });
     expect(
       loadJSON(path.join(attackProtectionFolder, 'breached-password-detection.json'))
-    ).to.deep.equal(context.assets.attackProtection.breachedPasswordDetection);
+    ).to.deep.equal({
+      admin_notification_frequency: ['daily', 'immediately', 'weekly'],
+      enabled: true,
+      method: 'standard',
+      shields: ['admin_notification', 'block', 'user_notification'],
+    });
     expect(
       loadJSON(path.join(attackProtectionFolder, 'brute-force-protection.json'))
-    ).to.deep.equal(context.assets.attackProtection.bruteForceProtection);
-    expect(loadJSON(path.join(attackProtectionFolder, 'captcha.json'))).to.deep.equal(
-      context.assets.attackProtection.captcha
-    );
+    ).to.deep.equal({
+      allowlist: [],
+      enabled: true,
+      max_attempts: 10,
+      mode: 'count_per_identifier_and_ip',
+      shields: ['block', 'user_notification'],
+    });
+    expect(loadJSON(path.join(attackProtectionFolder, 'captcha.json'))).to.deep.equal({
+      policy: 'always',
+      selected: 'friendly_captcha',
+    });
     expect(
       loadJSON(path.join(attackProtectionFolder, 'suspicious-ip-throttling.json'))
-    ).to.deep.equal(context.assets.attackProtection.suspiciousIpThrottling);
+    ).to.deep.equal({
+      allowlist: ['127.0.0.1', '127.0.0.2'],
+      enabled: true,
+      shields: ['admin_notification', 'block', 'user_notification'],
+      stage: {
+        'pre-login': {
+          max_attempts: 100,
+          rate: 864000,
+        },
+        'pre-user-registration': {
+          max_attempts: 50,
+          rate: 1200,
+        },
+      },
+    });
   });
 });

--- a/test/context/yaml/attackProtection.test.js
+++ b/test/context/yaml/attackProtection.test.js
@@ -98,35 +98,36 @@ describe('#YAML context attack-protection', () => {
     expect(context.assets.attackProtection).to.deep.equal(target);
   });
 
-  it('should dump attack-protection', async () => {
+  it('should dump attack-protection with primitive arrays sorted deterministically', async () => {
     const context = new Context({ AUTH0_INPUT_FILE: './attack-protection.yml' }, mockMgmtClient());
-    const attackProtection = {
+    // Deliberately unsorted input arrays — the dump handler must reorder them.
+    context.assets.attackProtection = {
       botDetection: {
-        allowlist: ['10.0.0.1'],
+        allowlist: ['10.0.0.2', '10.0.0.1'],
         bot_detection_level: 'medium',
         monitoring_mode_enabled: false,
       },
       breachedPasswordDetection: {
-        admin_notification_frequency: [],
+        admin_notification_frequency: ['weekly', 'daily', 'immediately'],
         enabled: true,
         method: 'standard',
-        shields: [],
+        shields: ['user_notification', 'block', 'admin_notification'],
       },
       bruteForceProtection: {
         allowlist: [],
         enabled: true,
         max_attempts: 10,
         mode: 'count_per_identifier_and_ip',
-        shields: ['block', 'user_notification'],
+        shields: ['user_notification', 'block'],
       },
       captcha: {
         policy: 'always',
         selected: 'friendly_captcha',
       },
       suspiciousIpThrottling: {
-        allowlist: ['127.0.0.1'],
+        allowlist: ['127.0.0.2', '127.0.0.1'],
         enabled: true,
-        shields: ['block', 'admin_notification'],
+        shields: ['user_notification', 'admin_notification', 'block'],
         stage: {
           'pre-login': {
             max_attempts: 100,
@@ -139,10 +140,50 @@ describe('#YAML context attack-protection', () => {
         },
       },
     };
-    context.assets.attackProtection = attackProtection;
 
     const dumped = await handler.dump(context);
 
-    expect(dumped).to.deep.equal({ attackProtection });
+    // Concrete expected output, independent of the (mutated) input reference.
+    expect(dumped).to.deep.equal({
+      attackProtection: {
+        botDetection: {
+          allowlist: ['10.0.0.1', '10.0.0.2'],
+          bot_detection_level: 'medium',
+          monitoring_mode_enabled: false,
+        },
+        breachedPasswordDetection: {
+          admin_notification_frequency: ['daily', 'immediately', 'weekly'],
+          enabled: true,
+          method: 'standard',
+          shields: ['admin_notification', 'block', 'user_notification'],
+        },
+        bruteForceProtection: {
+          allowlist: [],
+          enabled: true,
+          max_attempts: 10,
+          mode: 'count_per_identifier_and_ip',
+          shields: ['block', 'user_notification'],
+        },
+        captcha: {
+          policy: 'always',
+          selected: 'friendly_captcha',
+        },
+        suspiciousIpThrottling: {
+          allowlist: ['127.0.0.1', '127.0.0.2'],
+          enabled: true,
+          shields: ['admin_notification', 'block', 'user_notification'],
+          stage: {
+            'pre-login': {
+              max_attempts: 100,
+              rate: 864000,
+            },
+            'pre-user-registration': {
+              max_attempts: 50,
+              rate: 1200,
+            },
+          },
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
### 🔧 Changes

Fixes non-deterministic ordering of enum-like arrays under `attackProtection` on export. Previously each export re-serialized these arrays in whatever order the Auth0 API returned, producing spurious git diffs even when nothing changed.

- Added `sortAttackProtectionArrays()` in `src/context/defaults.ts` - recursively sorts **primitive** arrays within the attackProtection subtree (e.g. `shields`, `admin_notification_frequency`, `allowlist`). Arrays of objects are left untouched.
- Wired it into both dump handlers:
  - `src/context/yaml/handlers/attackProtection.ts` (YAML export)
  - `src/context/directory/handlers/attackProtection.ts` (directory export)
- Sorting is generic/alphabetical (not a hardcoded canonical order), so new enum values added server-side sort automatically without a code change.

### Shape

The array **values** are reordered on export; keys and structure are unchanged. Applies to YAML (`tenant.yaml` → `attackProtection.*`) and directory (`attack-protection/*.json`).

YAML (`tenant.yaml`):

```yaml
# before
bruteForceProtection:
  shields:
    - user_notification
    - block
# after
bruteForceProtection:
  shields:
    - block
    - user_notification
```

Directory (`attack-protection/brute-force-protection.json`):
before:
```json
{ "shields": ["user_notification", "block"] }
```
after:
```json
{ "shields": ["block", "user_notification"] }
```

The first export after this change shows a one-time diff as arrays settle into sorted order; subsequent exports are stable. No effect on deploy/import - the API treats these arrays as order-insensitive.

### 📚 References

- Fixes #1440

### 🔬 Testing

**Unit tests** - added a `sortAttackProtectionArrays` suite in `test/context/defaults.test.js` (sorts primitive arrays across the subtree; output is identical regardless of input order; object arrays left untouched). Existing `test/context/yaml/attackProtection.test.js` and `test/context/directory/attackProtection.test.js` pass unchanged.

**Manual** - exported a real tenant twice into separate folders and diffed, for both formats:
- `export -f yaml`: two consecutive exports are byte-identical (`diff` clean); previously the arrays reordered between runs.
- `export -f directory`: `attack-protection/brute-force-protection.json` `shields` output as `["block", "user_notification"]` (sorted).

**Dry-run**: verified sorting on export does not alter dry-run behavior: the dry-run comparator (`src/tools/calculateDryRunChanges.ts`) already normalizes array order before comparing primitive arrays, so it treats these arrays as order-insensitive. Sorting the exported file cannot introduce or suppress a detected change.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A) - N/A, no user-facing docs describe attackProtection array output
