### PR TITLE
fix: skip organization PATCH when no top-level properties have changed

### DIFF
--- a/src/tools/auth0/handlers/organizations.ts
+++ b/src/tools/auth0/handlers/organizations.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { omit, isEqual, pick } from 'lodash';
 import { Management } from 'auth0';
 import DefaultHandler, { order } from './default';
 import { calculateChanges } from '../../calculateChanges';
@@ -262,12 +262,13 @@ export default class OrganizationsHandler extends DefaultHandler {
   }
 
   async updateOrganization(org, organizations) {
+    const existingOrg = organizations.find((orgToUpdate) => orgToUpdate.name === org.name);
     const {
       connections: existingConnections,
       client_grants: existingClientGrants,
       discovery_domains: existingDiscoveryDomains,
       clients: existingOrgClients = [],
-    } = await organizations.find((orgToUpdate) => orgToUpdate.name === org.name);
+    } = existingOrg;
 
     const params = { id: org.id };
     const {
@@ -284,7 +285,14 @@ export default class OrganizationsHandler extends DefaultHandler {
     delete org.discovery_domains;
     delete org.clients;
 
-    await this.client.organizations.update(params.id, org);
+    // Only PATCH if top-level properties actually differ from the existing state.
+    // Compare only the keys present in the desired config against those same keys
+    // on the remote org, so that fields the user didn't specify are not considered.
+    let changed = false;
+    if (!isEqual(org, pick(existingOrg, Object.keys(org)))) {
+      await this.client.organizations.update(params.id, org);
+      changed = true;
+    }
 
     // organization connections
     const connectionsToRemove = existingConnections.filter(
@@ -305,6 +313,14 @@ export default class OrganizationsHandler extends DefaultHandler {
             x.is_enabled !== (c.is_enabled ?? true))
       )
     );
+
+    if (
+      connectionsToUpdate.length > 0 ||
+      connectionsToAdd.length > 0 ||
+      connectionsToRemove.length > 0
+    ) {
+      changed = true;
+    }
 
     // Handle updates first
     await Promise.all(
@@ -371,6 +387,10 @@ export default class OrganizationsHandler extends DefaultHandler {
           grant_id: this.getClientGrantIDByClientName(clientGrant.client_id),
         })) || [];
 
+    if (orgClientGrantsToAdd.length > 0 || orgClientGrantsToRemove.length > 0) {
+      changed = true;
+    }
+
     // Handle updates first
     await Promise.all(
       orgClientGrantsToAdd.map((orgClientGrant) =>
@@ -419,6 +439,10 @@ export default class OrganizationsHandler extends DefaultHandler {
         })
         .filter(Boolean) || [];
 
+    if (orgDiscoveryDomainsToUpdate.length > 0 || orgDiscoveryDomainsToAdd.length > 0) {
+      changed = true;
+    }
+
     for (const { id, domain, ...updateParams } of orgDiscoveryDomainsToUpdate) {
       try {
         await this.updateOrganizationDiscoveryDomain(params.id, id, domain, updateParams);
@@ -448,6 +472,7 @@ export default class OrganizationsHandler extends DefaultHandler {
         this.config('AUTH0_ALLOW_DELETE') === 'true' ||
         this.config('AUTH0_ALLOW_DELETE') === true
       ) {
+        changed = true;
         for (const domain of orgDiscoveryDomainsToRemove) {
           try {
             await this.deleteOrganizationDiscoveryDomain(params.id, domain.domain, domain.id);
@@ -499,6 +524,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       .filter((oc) => !!oc.client_id);
 
     if (orgClientsToAdd.length > 0) {
+      changed = true;
       await this.createOrganizationClients(params.id, orgClientsToAdd).catch((err) => {
         throw new Error(`Problem adding org clients for organization ${params.id}\n${err}`);
       });
@@ -509,6 +535,7 @@ export default class OrganizationsHandler extends DefaultHandler {
         this.config('AUTH0_ALLOW_DELETE') === 'true' ||
         this.config('AUTH0_ALLOW_DELETE') === true
       ) {
+        changed = true;
         await this.deleteOrganizationClients(params.id, orgClientsToRemove).catch((err) => {
           throw new Error(`Problem removing org clients for organization ${params.id}\n${err}`);
         });
@@ -521,6 +548,9 @@ export default class OrganizationsHandler extends DefaultHandler {
       }
     }
 
+    if (orgClientsToUpdate.length > 0) {
+      changed = true;
+    }
     await Promise.all(
       orgClientsToUpdate.map((oc) =>
         this.client.organizations.clients
@@ -535,7 +565,7 @@ export default class OrganizationsHandler extends DefaultHandler {
       )
     );
 
-    return params;
+    return changed ? params : null;
   }
 
   getClientGrantIDByClientName(clientsName: string): string {
@@ -580,8 +610,10 @@ export default class OrganizationsHandler extends DefaultHandler {
         generator: (item) =>
           this.updateOrganization(item, orgs)
             .then((data) => {
-              this.didUpdate(data);
-              this.updated += 1;
+              if (data) {
+                this.didUpdate(data);
+                this.updated += 1;
+              }
             })
             .catch((err) => {
               throw new Error(`Problem updating ${this.type} ${this.objString(item)}\n${err}`);

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -1742,4 +1742,427 @@ describe('#organizations handler', () => {
       expect(data[0].clients).to.be.undefined;
     });
   });
+
+  // ─── skip-unchanged tests ──────────────────────────────────────────────────
+  // These tests verify the fix for the rate-limit bug where the CLI issued a
+  // PATCH /organizations/{id} for every org on every import, even when nothing
+  // had changed.  After the fix, organizations.update() must only be called
+  // when top-level properties (display_name, branding, metadata, …) actually
+  // differ from the remote state.  Sub-resource changes (connections, client
+  // grants, discovery domains, org clients) continue to use their own diffing
+  // and are unaffected.
+  describe('#organizations skip-unchanged updates', () => {
+    // shared minimal auth0 stub factory — callers override only what they need
+    function makeAuth0({
+      existingOrg = sampleOrg,
+      existingConnections = [],
+      onUpdate = null,
+      onConnectionUpdate = null,
+      onConnectionCreate = null,
+      onConnectionDelete = null,
+    } = {}) {
+      return {
+        organizations: {
+          create: () => Promise.resolve([]),
+          update: onUpdate || (() => Promise.resolve({})),
+          delete: () => Promise.resolve([]),
+          list: (params) => mockPagedData(params, 'organizations', [existingOrg]),
+          connections: {
+            list: () => ({ data: existingConnections, hasNextPage: () => false }),
+            update: onConnectionUpdate || (() => Promise.resolve({})),
+            create: onConnectionCreate || (() => Promise.resolve({})),
+            delete: onConnectionDelete || (() => Promise.resolve({})),
+          },
+          clientGrants: { list: () => ({ data: [], hasNextPage: () => false }) },
+          discoveryDomains: { list: () => ({ data: [], hasNextPage: () => false }) },
+          clients: { list: () => ({ data: [], hasNextPage: () => false }) },
+        },
+        connections: { list: (params) => mockPagedData(params, 'connections', []) },
+        clients: { list: (params) => mockPagedData(params, 'clients', sampleClients) },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+    }
+
+    it('should not call organizations.update when no top-level fields changed', async () => {
+      let updateCalled = false;
+
+      const auth0 = makeAuth0({
+        onUpdate: () => {
+          updateCalled = true;
+          return Promise.resolve({});
+        },
+      });
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      // Desired state exactly matches sampleOrg (id, name, display_name, client_grants)
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name,
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(updateCalled).to.equal(false);
+    });
+
+    it('should not increment handler.updated when org is unchanged', async () => {
+      const auth0 = makeAuth0();
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name,
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(handler.updated).to.equal(0);
+    });
+
+    it('should call organizations.update when display_name changes', async () => {
+      let updatedId = null;
+      let updatedBody = null;
+
+      const auth0 = makeAuth0({
+        onUpdate: (id, body) => {
+          updatedId = id;
+          updatedBody = body;
+          return Promise.resolve({});
+        },
+      });
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: 'Acme Updated', // changed
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(updatedId).to.equal(sampleOrg.id);
+      expect(updatedBody.display_name).to.equal('Acme Updated');
+    });
+
+    it('should increment handler.updated when display_name changes', async () => {
+      const auth0 = makeAuth0({
+        onUpdate: () => Promise.resolve({}),
+      });
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: 'Acme Updated',
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(handler.updated).to.equal(1);
+    });
+
+    it('should call organizations.update when a nested branding field changes', async () => {
+      let updatedId = null;
+
+      const existingOrgWithBranding = {
+        ...sampleOrg,
+        branding: { colors: { primary: '#ffffff', page_background: '#000000' } },
+      };
+
+      const auth0 = makeAuth0({
+        existingOrg: existingOrgWithBranding,
+        onUpdate: (id) => {
+          updatedId = id;
+          return Promise.resolve({});
+        },
+      });
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name,
+              branding: { colors: { primary: '#ff0000', page_background: '#000000' } }, // primary changed
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(updatedId).to.equal(sampleOrg.id);
+    });
+
+    it('should not call organizations.update when branding is identical', async () => {
+      let updateCalled = false;
+
+      const existingOrgWithBranding = {
+        ...sampleOrg,
+        branding: { colors: { primary: '#ffffff', page_background: '#000000' } },
+      };
+
+      const auth0 = makeAuth0({
+        existingOrg: existingOrgWithBranding,
+        onUpdate: () => {
+          updateCalled = true;
+          return Promise.resolve({});
+        },
+      });
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name,
+              branding: { colors: { primary: '#ffffff', page_background: '#000000' } }, // identical
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(updateCalled).to.equal(false);
+    });
+
+    it('should only update the changed org when multiple orgs exist and one changes', async () => {
+      const org2 = { id: '456', name: 'contoso', display_name: 'Contoso', client_grants: [] };
+      const updatedIds = [];
+
+      const auth0 = {
+        organizations: {
+          create: () => Promise.resolve([]),
+          update: (id) => {
+            updatedIds.push(id);
+            return Promise.resolve({});
+          },
+          delete: () => Promise.resolve([]),
+          list: (params) => mockPagedData(params, 'organizations', [sampleOrg, org2]),
+          connections: {
+            list: () => ({ data: [], hasNextPage: () => false }),
+            update: () => Promise.resolve({}),
+            create: () => Promise.resolve({}),
+            delete: () => Promise.resolve({}),
+          },
+          clientGrants: { list: () => ({ data: [], hasNextPage: () => false }) },
+          discoveryDomains: { list: () => ({ data: [], hasNextPage: () => false }) },
+          clients: { list: () => ({ data: [], hasNextPage: () => false }) },
+        },
+        connections: { list: (params) => mockPagedData(params, 'connections', []) },
+        clients: { list: (params) => mockPagedData(params, 'clients', sampleClients) },
+        clientGrants: {
+          list: (params) => mockPagedData(params, 'client_grants', [sampleClientGrant]),
+        },
+        pool,
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            // acme: display_name changed
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: 'Acme Updated',
+              connections: [],
+              client_grants: [],
+            },
+            // contoso: unchanged
+            {
+              id: org2.id,
+              name: org2.name,
+              display_name: org2.display_name,
+              connections: [],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(updatedIds).to.deep.equal([sampleOrg.id]);
+      expect(handler.updated).to.equal(1);
+    });
+
+    it('should not call organizations.update when only a connection setting changes, but should update the connection', async () => {
+      let orgUpdateCalled = false;
+      let connectionUpdateCalled = false;
+
+      const existingConnection = {
+        connection_id: 'con_123',
+        assign_membership_on_login: false,
+        show_as_button: false,
+        is_signup_enabled: false,
+        is_enabled: true,
+        organization_access_level: 'none',
+        connection: { name: 'Username-Password-Login', strategy: 'auth0' },
+      };
+
+      const auth0 = makeAuth0({
+        existingConnections: [existingConnection],
+        onUpdate: () => {
+          orgUpdateCalled = true;
+          return Promise.resolve({});
+        },
+        onConnectionUpdate: (orgId, connectionId, data) => {
+          connectionUpdateCalled = true;
+          return Promise.resolve({});
+        },
+      });
+
+      // Override connections.list on the outer client to resolve connection name → id
+      auth0.connections = {
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            { id: 'con_123', name: 'Username-Password-Login', options: {} },
+          ]),
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name, // unchanged
+              connections: [
+                {
+                  name: 'Username-Password-Login',
+                  assign_membership_on_login: true, // changed
+                  show_as_button: false,
+                  is_signup_enabled: false,
+                },
+              ],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(orgUpdateCalled).to.equal(false);
+      expect(connectionUpdateCalled).to.equal(true);
+      expect(handler.updated).to.equal(1);
+    });
+
+    it('should not call any API when org and all sub-resources are identical', async () => {
+      const apiCalls = [];
+
+      const existingConnection = {
+        connection_id: 'con_123',
+        assign_membership_on_login: false,
+        show_as_button: false,
+        is_signup_enabled: false,
+        is_enabled: true,
+        organization_access_level: 'none',
+        connection: { name: 'Username-Password-Login', strategy: 'auth0' },
+      };
+
+      const auth0 = makeAuth0({
+        existingConnections: [existingConnection],
+        onUpdate: () => {
+          apiCalls.push('org.update');
+          return Promise.resolve({});
+        },
+        onConnectionUpdate: () => {
+          apiCalls.push('conn.update');
+          return Promise.resolve({});
+        },
+        onConnectionCreate: () => {
+          apiCalls.push('conn.create');
+          return Promise.resolve({});
+        },
+        onConnectionDelete: () => {
+          apiCalls.push('conn.delete');
+          return Promise.resolve({});
+        },
+      });
+
+      auth0.connections = {
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            { id: 'con_123', name: 'Username-Password-Login', options: {} },
+          ]),
+      };
+
+      const handler = new organizations.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          organizations: [
+            {
+              id: sampleOrg.id,
+              name: sampleOrg.name,
+              display_name: sampleOrg.display_name,
+              connections: [
+                {
+                  name: 'Username-Password-Login',
+                  assign_membership_on_login: false, // same
+                  show_as_button: false, // same
+                  is_signup_enabled: false, // same
+                  is_enabled: true, // same
+                  organization_access_level: 'none', // same — must be explicit to avoid false diff
+                },
+              ],
+              client_grants: [],
+            },
+          ],
+        },
+      ]);
+
+      expect(apiCalls).to.deep.equal([]);
+      expect(handler.updated).to.equal(0);
+    });
+  });
 });

--- a/test/tools/auth0/handlers/organizations.tests.js
+++ b/test/tools/auth0/handlers/organizations.tests.js
@@ -2052,7 +2052,7 @@ describe('#organizations handler', () => {
           orgUpdateCalled = true;
           return Promise.resolve({});
         },
-        onConnectionUpdate: (orgId, connectionId, data) => {
+        onConnectionUpdate: (_orgId, _connectionId, _data) => {
           connectionUpdateCalled = true;
           return Promise.resolve({});
         },


### PR DESCRIPTION
### 🔧 Changes

The deploy CLI was issuing a `PATCH /api/v2/organizations/{id}` for every organization on every import run, regardless of whether anything had changed. On tenants with many organizations this caused unnecessary API load and rate limit errors.                                                                                                                                                      
                                                                                                                                                                                   
**Root cause:** `calculateChanges` categorises any org present in both the local config and the remote tenant as an update by identifier match alone, no field comparison is performed. `updateOrganization` then unconditionally called `organizations.update()` for every org in that bucket.

**Fix:** Before calling `organizations.update()`, the desired top-level fields are now compared against the remote state using deep equality (`isEqual` + `pick`). The PATCH is only issued when a field has actually changed. A `changed` flag tracks whether any API call was made (main PATCH or any sub-resource mutation); `didUpdate` and the updated counter are gated on that flag so the CLI output only reflects real changes.

**Scope:** This eliminates redundant org PATCHes on the write side. The read side is unchanged, `getType()` still fetches all orgs and their sub-resources (~4 list calls per org) on every run regardless of what changed, since a remote read is required to diff against. That is a separate concern not addressed here.

Sub-resource diffing (connections, client grants, discovery domains, org-client associations) is unaffected, those paths already only make API calls when changes are detected.

### 📚 References

 - Fixes: deploy CLI issuing redundant PATCHes for all orgs on every import

### 🔬 Testing
 **Unit tests** (`test/tools/auth0/handlers/organizations.tests.js` - `#organizations skip-unchanged updates`):
  - No-op import → `organizations.update` not called, `handler.updated === 0`
  - Changed `display_name` → PATCH fires for that org only, counter increments
  - Changed nested `branding` object → deep equality catches it, PATCH fires
  - Identical `branding` → PATCH skipped
  - 2 orgs, 1 changed → only the changed org is PATCHed, counter is 1
  - Connection-only change → org PATCH skipped, connection update fires
  - Fully identical org + all connections → zero API calls end-to-end

  **Manual (31-org tenant):**
  - Export all orgs → re-import unchanged → **0 PATCHes** (previously 31)
  - Export → change `display_name` on one org → import → **1 PATCH** for that org only

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
