### PR TITLE
fix: resolve dry-run reporting bugs across multiple asset types

### DIFF
--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -923,7 +923,12 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
       };
     });
 
-    const proposedChanges = await super.dryRunChanges({ ...assets, connections: formatted });
+    let proposedChanges = await super.dryRunChanges({ ...assets, connections: formatted });
+
+    const includedConnections = (assets.include && assets.include.connections) || [];
+    const excludedConnections = (assets.exclude && assets.exclude.connections) || [];
+    proposedChanges = filterExcluded(proposedChanges, excludedConnections);
+    proposedChanges = filterIncluded(proposedChanges, includedConnections);
 
     return addExcludedConnectionPropertiesToChanges({
       proposedChanges,

--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -627,7 +627,7 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       assets: formatted,
       existing: existingDatabasesConnections,
       identifiers: this.identifiers,
-      ignoreDryRunFields: this.ignoreDryRunFields,
+      ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
     });
   }
 

--- a/src/tools/auth0/handlers/default.ts
+++ b/src/tools/auth0/handlers/default.ts
@@ -310,7 +310,6 @@ export default class APIHandler {
       return calculateDryRunChanges({
         type: this.type,
         assets: typeAssets,
-        // @ts-ignore TODO: investigate what happens when `existing` is null
         existing,
         identifiers: this.identifiers,
         ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
@@ -348,7 +347,6 @@ export default class APIHandler {
     return calculateDryRunChanges({
       type: this.type,
       assets: typeAssets,
-      // @ts-ignore TODO: investigate what happens when `existing` is null
       existing,
       identifiers: this.identifiers,
       ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),

--- a/src/tools/calculateDryRunChanges.ts
+++ b/src/tools/calculateDryRunChanges.ts
@@ -133,6 +133,10 @@ export const exportDiffLog = async (fileName: string, resourceTypeName?: string)
   }
 };
 
+function formatDiffValue(value: unknown): string {
+  return typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value);
+}
+
 /**
  * Compares two objects and returns an array of human-readable difference strings.
  * Only considers keys present in `localObj` — extra keys in `remoteObj` are ignored.
@@ -232,7 +236,9 @@ export function getObjectDifferences(
             );
             differences.push(...nestedDifferences);
           } else if (item !== normalizedRemoteValue[index]) {
-            const message = `Array item difference at [${currentPath}[${index}]]: local:${item} vs remote:${normalizedRemoteValue[index]}`;
+            const message = `Array item difference at [${currentPath}[${index}]]: local:${formatDiffValue(
+              item
+            )} vs remote:${formatDiffValue(normalizedRemoteValue[index])}`;
             differences.push(message);
           }
         });
@@ -273,13 +279,10 @@ export function getObjectDifferences(
       return;
     }
 
-    // Compare primitive values — omit array indices from path to reduce log noise
+    // Compare primitive values
     if (localValue !== remoteValue) {
-      let arrayPathRegex = new RegExp(/\[\d+\]/g);
-      if (!arrayPathRegex.test(currentPath)) {
-        const message = `Value difference for [${currentPath}]: local:${localValue} vs remote:${remoteValue}`;
-        differences.push(message);
-      }
+      const message = `Value difference for [${currentPath}]: local:${localValue} vs remote:${remoteValue}`;
+      differences.push(message);
     }
   });
 
@@ -341,9 +344,9 @@ export function calculateDryRunChanges({
   const localAssets: Asset[] = (Array.isArray(assets) ? [...assets] : [assets]).map((asset) =>
     type === 'tenant' ? normalizeTenantForDryRun(asset) : asset
   );
-  const remoteAssets: Asset[] = (Array.isArray(existing) ? [...existing] : [existing]).map(
-    (asset) => (type === 'tenant' ? normalizeTenantForDryRun(asset) : asset)
-  );
+  const remoteAssets: Asset[] = (
+    Array.isArray(existing) ? [...existing] : existing ? [existing] : []
+  ).map((asset) => (type === 'tenant' ? normalizeTenantForDryRun(asset) : asset));
 
   // Helper: returns true if a local and remote asset share at least one identifier value
   const assetsMatch = (localAsset: Asset, remoteAsset: Asset) =>

--- a/src/tools/calculateDryRunChanges.ts
+++ b/src/tools/calculateDryRunChanges.ts
@@ -121,6 +121,14 @@ function normalizeArrayValues(values: any[]): any[] {
 }
 
 /**
+ * Serializes a value to a human-readable string for use in diff messages.
+ * Objects and arrays are JSON-stringified to avoid "[object Object]" output.
+ */
+function formatDiffValue(value: unknown): string {
+  return typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value);
+}
+
+/**
  * Writes the accumulated diff log to a JSON file on disk.
  * Useful for CI pipelines that want a machine-readable dry-run report.
  */
@@ -132,10 +140,6 @@ export const exportDiffLog = async (fileName: string, resourceTypeName?: string)
     log.error(`Failed to export diff log: ${String(error)}`);
   }
 };
-
-function formatDiffValue(value: unknown): string {
-  return typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value);
-}
 
 /**
  * Compares two objects and returns an array of human-readable difference strings.

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -2836,3 +2836,67 @@ describe('#addExcludedConnectionPropertiesToChanges', () => {
     }); // Expect no change
   });
 });
+
+describe('#connections dryRunChanges', () => {
+  // Regression tests for INCLUDED_CONNECTIONS dry-run bug:
+  // dryRunChanges was not applying filterIncluded, causing phantom DELETEs for
+  // connections outside AUTH0_INCLUDED_CONNECTIONS.
+
+  const config = (key) => ({ AUTH0_CLIENT_ID: 'client_id' }[key]);
+
+  it('should not report phantom deletes for connections outside AUTH0_INCLUDED_CONNECTIONS', async () => {
+    const auth0 = {
+      connections: {
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            { id: 'con_google', name: 'google-oauth2', strategy: 'google-oauth2' },
+            { id: 'con_email', name: 'email', strategy: 'email' },
+          ]),
+      },
+      clients: {
+        list: (params) => mockPagedData(params, 'clients', []),
+      },
+    };
+
+    const handler = new connections.default({ client: pageClient(auth0), config });
+
+    // Local config only manages google-oauth2; include list restricts to it
+    const assets = {
+      connections: [{ name: 'google-oauth2', strategy: 'google-oauth2' }],
+      include: { connections: ['google-oauth2'] },
+    };
+
+    const changes = await handler.dryRunChanges(assets);
+
+    // 'email' exists on the tenant but is outside the include list —
+    // it must not appear as a DELETE in dry-run
+    expect(changes.del).to.have.length(0);
+  });
+
+  it('should report deletes normally when no include list is configured', async () => {
+    const auth0 = {
+      connections: {
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            { id: 'con_google', name: 'google-oauth2', strategy: 'google-oauth2' },
+            { id: 'con_email', name: 'email', strategy: 'email' },
+          ]),
+      },
+      clients: {
+        list: (params) => mockPagedData(params, 'clients', []),
+      },
+    };
+
+    const handler = new connections.default({ client: pageClient(auth0), config });
+
+    // No include filter — all connections are in scope
+    const assets = {
+      connections: [{ name: 'google-oauth2', strategy: 'google-oauth2' }],
+    };
+
+    const changes = await handler.dryRunChanges(assets);
+
+    // 'email' is in scope and not in local config — should appear as DELETE
+    expect(changes.del.some((c) => c.name === 'email')).to.be.true;
+  });
+});

--- a/test/tools/auth0/handlers/databases.tests.js
+++ b/test/tools/auth0/handlers/databases.tests.js
@@ -3022,3 +3022,113 @@ describe('#databases handler with enabled clients integration', () => {
     });
   });
 });
+
+describe('#databases dryRunChanges', () => {
+  // Regression tests for #1450: AUTH0_IGNORE_DRY_RUN_FIELDS was silently a no-op
+  // for databases because dryRunChanges used this.ignoreDryRunFields (constructor
+  // defaults only) instead of this.getEffectiveIgnoreDryRunFields() (which merges
+  // in the AUTH0_IGNORE_DRY_RUN_FIELDS config value).
+
+  const pool = {
+    addEachTask: (data) => {
+      if (data.data && data.data.length) data.generator(data.data[0]);
+      return { promise: () => null };
+    },
+    addSingleTask: (task) => {
+      const result = task.generator(task.data);
+      return { promise: () => Promise.resolve(result) };
+    },
+  };
+
+  it('should suppress diffs for fields listed in AUTH0_IGNORE_DRY_RUN_FIELDS', async () => {
+    const auth0 = {
+      connections: {
+        // Remote includes options: {} so getFormattedOptions doesn't produce a spurious diff
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            {
+              id: 'con_1',
+              name: 'test-db',
+              strategy: 'auth0',
+              options: {},
+              noisy_field: 'remote_value',
+            },
+          ]),
+      },
+      clients: {
+        list: (params) => mockPagedData(params, 'clients', []),
+      },
+      actions: {
+        list: (params) => mockPagedData(params, 'actions', []),
+      },
+      pool,
+    };
+
+    const config = (key) => {
+      if (key === 'AUTH0_IGNORE_DRY_RUN_FIELDS') return { databases: ['noisy_field'] };
+      if (key === 'AUTH0_CLIENT_ID') return 'client_id';
+    };
+
+    const handler = new databases.default({ client: pageClient(auth0), config });
+
+    const assets = {
+      databases: [
+        {
+          name: 'test-db',
+          strategy: 'auth0',
+          options: {},
+          noisy_field: 'local_value', // differs from remote — but must be ignored
+        },
+      ],
+    };
+
+    const changes = await handler.dryRunChanges(assets);
+
+    // noisy_field is configured to be ignored — no update should be reported
+    expect(changes.update).to.have.length(0);
+  });
+
+  it('should report diffs for fields not in AUTH0_IGNORE_DRY_RUN_FIELDS', async () => {
+    const auth0 = {
+      connections: {
+        list: (params) =>
+          mockPagedData(params, 'connections', [
+            {
+              id: 'con_1',
+              name: 'test-db',
+              strategy: 'auth0',
+              options: {},
+              tracked_field: 'remote_value',
+            },
+          ]),
+      },
+      clients: {
+        list: (params) => mockPagedData(params, 'clients', []),
+      },
+      actions: {
+        list: (params) => mockPagedData(params, 'actions', []),
+      },
+      pool,
+    };
+
+    // No AUTH0_IGNORE_DRY_RUN_FIELDS configured
+    const config = (key) => ({ AUTH0_CLIENT_ID: 'client_id' }[key]);
+
+    const handler = new databases.default({ client: pageClient(auth0), config });
+
+    const assets = {
+      databases: [
+        {
+          name: 'test-db',
+          strategy: 'auth0',
+          options: {},
+          tracked_field: 'local_value', // differs from remote — should be detected
+        },
+      ],
+    };
+
+    const changes = await handler.dryRunChanges(assets);
+
+    expect(changes.update).to.have.length(1);
+  });
+});

--- a/test/tools/calculateDryRunChanges.test.ts
+++ b/test/tools/calculateDryRunChanges.test.ts
@@ -605,6 +605,45 @@ describe('#utils calculateDryRunChanges', () => {
     const updatedGrant = changes.update[0] as any;
     expect(updatedGrant._clientName).to.equal('My M2M App');
   });
+
+  it('should classify asset as update when a field inside an array item changes', () => {
+    // Regression test for #1451: array index path guard was suppressing diffs for
+    // paths containing "[N]", causing field changes inside array items to go undetected.
+    const changes = calculateDryRunChanges({
+      type: 'organizations',
+      assets: [
+        {
+          name: 'acme',
+          connections: [{ connection_id: 'con_abc', assign_membership_on_login: true }],
+        },
+      ],
+      existing: [
+        {
+          name: 'acme',
+          connections: [{ connection_id: 'con_abc', assign_membership_on_login: false }],
+        },
+      ],
+      identifiers: ['id', 'name'],
+      ignoreDryRunFields: [],
+    });
+    expect(changes.update).to.have.length(1);
+    expect(changes.update[0].name).to.equal('acme');
+  });
+
+  it('should treat null existing as empty and classify all local assets as creates', () => {
+    // Regression test for null crash: when getType() returns null (e.g. 403 or empty tenant),
+    // existing is null — must not crash and must classify all local assets as creates.
+    const changes = calculateDryRunChanges({
+      type: 'clients',
+      assets: [{ name: 'My App', app_type: 'spa' }],
+      existing: null,
+      identifiers: ['client_id', 'name'],
+      ignoreDryRunFields: [],
+    });
+    expect(changes.create).to.have.length(1);
+    expect(changes.update).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+  });
 });
 
 describe('#getObjectDifferences', () => {

--- a/test/tools/calculateDryRunChanges.test.ts
+++ b/test/tools/calculateDryRunChanges.test.ts
@@ -544,6 +544,45 @@ describe('#utils calculateDryRunChanges', () => {
     expect(changes.update[0].client_id).to.equal('cli_abc');
   });
 
+  it('should classify asset as update when a field inside an array item changes', () => {
+    // Regression test for #1451: value change inside array item was silently dropped
+    const changes = calculateDryRunChanges({
+      type: 'organizations',
+      assets: [
+        {
+          name: 'acme',
+          connections: [{ connection_id: 'con_abc', assign_membership_on_login: true }],
+        },
+      ],
+      existing: [
+        {
+          name: 'acme',
+          connections: [{ connection_id: 'con_abc', assign_membership_on_login: false }],
+        },
+      ],
+      identifiers: ['id', 'name'],
+      ignoreDryRunFields: [],
+    });
+
+    expect(changes.update).to.have.length(1);
+    expect(changes.update[0].name).to.equal('acme');
+  });
+
+  it('should treat null existing as empty and classify all local assets as creates', () => {
+    // Regression test for null crash: [null] was used as remoteAssets, causing TypeError
+    const changes = calculateDryRunChanges({
+      type: 'clients',
+      assets: [{ name: 'My App', app_type: 'spa' }],
+      existing: null,
+      identifiers: ['client_id', 'name'],
+      ignoreDryRunFields: [],
+    });
+
+    expect(changes.create).to.have.length(1);
+    expect(changes.update).to.have.length(0);
+    expect(changes.del).to.have.length(0);
+  });
+
   it('should use _clientName in the UPDATE identifier for clientGrants', () => {
     const changes = calculateDryRunChanges({
       type: 'clientGrants',
@@ -659,6 +698,30 @@ describe('#getObjectDifferences', () => {
       'test'
     );
     expect(diffs.length).to.be.greaterThan(0);
+  });
+
+  it('should report value differences for fields inside array items', () => {
+    // Regression test for #1451: array index path guard was suppressing these diffs
+    const diffs = getObjectDifferences(
+      { connections: [{ connection_id: 'con_abc', assign_membership_on_login: true }] },
+      { connections: [{ connection_id: 'con_abc', assign_membership_on_login: false }] },
+      'acme',
+      'organizations'
+    );
+    expect(diffs.length).to.be.greaterThan(0);
+    expect(diffs.some((d) => d.includes('assign_membership_on_login'))).to.be.true;
+  });
+
+  it('should serialize object array items as JSON in diff messages, not as [object Object]', () => {
+    // Regression test for #1452: objects were rendered via .toString() → [object Object]
+    const diffs = getObjectDifferences(
+      { connections: [{ connection_id: 'con_abc', assign_membership_on_login: false }] },
+      { connections: [] },
+      'acme',
+      'organizations'
+    );
+    expect(diffs.some((d) => d.includes('[object Object]'))).to.be.false;
+    expect(diffs.some((d) => d.includes('connection_id'))).to.be.true;
   });
 });
 

--- a/test/tools/calculateDryRunChanges.test.ts
+++ b/test/tools/calculateDryRunChanges.test.ts
@@ -544,45 +544,6 @@ describe('#utils calculateDryRunChanges', () => {
     expect(changes.update[0].client_id).to.equal('cli_abc');
   });
 
-  it('should classify asset as update when a field inside an array item changes', () => {
-    // Regression test for #1451: value change inside array item was silently dropped
-    const changes = calculateDryRunChanges({
-      type: 'organizations',
-      assets: [
-        {
-          name: 'acme',
-          connections: [{ connection_id: 'con_abc', assign_membership_on_login: true }],
-        },
-      ],
-      existing: [
-        {
-          name: 'acme',
-          connections: [{ connection_id: 'con_abc', assign_membership_on_login: false }],
-        },
-      ],
-      identifiers: ['id', 'name'],
-      ignoreDryRunFields: [],
-    });
-
-    expect(changes.update).to.have.length(1);
-    expect(changes.update[0].name).to.equal('acme');
-  });
-
-  it('should treat null existing as empty and classify all local assets as creates', () => {
-    // Regression test for null crash: [null] was used as remoteAssets, causing TypeError
-    const changes = calculateDryRunChanges({
-      type: 'clients',
-      assets: [{ name: 'My App', app_type: 'spa' }],
-      existing: null,
-      identifiers: ['client_id', 'name'],
-      ignoreDryRunFields: [],
-    });
-
-    expect(changes.create).to.have.length(1);
-    expect(changes.update).to.have.length(0);
-    expect(changes.del).to.have.length(0);
-  });
-
   it('should use _clientName in the UPDATE identifier for clientGrants', () => {
     const changes = calculateDryRunChanges({
       type: 'clientGrants',


### PR DESCRIPTION
### 🔧 Changes

 This PR fixes 5 dry-run bugs affecting accuracy and reliability of a0deploy import --dry-run output:

  - #1451 - Changes to fields inside array items (e.g. connections[0].assign_membership_on_login) were silently ignored. A path guard `!/\[\d+\]/g/` was suppressing every diff message whose path contained an array index.
  - #1452 - Diff log messages showed `[object Object]` when an object array item had no counterpart on the other side, because template literal interpolation was used directly on an object value.
  - #1450 - `AUTH0_IGNORE_DRY_RUN_FIELDS` config had no effect on databases. The databases handler passed `this.ignoreDryRunFields` (constructor-only) instead of `this.getEffectiveIgnoreDryRunFields()` (config-merged).
  - Phantom DELETEs for included connections - filterIncluded/filterExcluded were applied in processChanges but not in dryRunChanges, so the dry-run reported DELETE for every connection outside `AUTH0_INCLUDED_CONNECTIONS`.
    - Identified while reviewing community PR #1442 (auth0/auth0-deploy-cli#1442), which fixed the same gap on the export path - this PR extends the fix to dry-run
  - Null crash in calculateDryRunChanges - When `getType()` returns null (e.g. 403 or empty tenant), wrapping it in [null] caused downstream crashes. Guard changed to `existing ? [existing] : []`.

### 📚 References

- Fixes #1451
- Fixes #1452
- Fixes #1450

### 🔬 Testing

**Manual E2E** - `a0deploy import --dry-run` against a live tenant:

  - **#1451:** Modified an org's `connections[0].assign_membership_on_login: false → true`. Dry-run correctly reported the org as `UPDATE`. Before the fix, no UPDATE was reported.
  - **#1452:** Verified `getObjectDifferences` output with a local array longer than remote. Message shows `local:{"flag":2,"name":"b"} vs remote:undefined` - no `[object Object]`.
  - **Phantom DELETEs:** Ran with `AUTH0_INCLUDED_CONNECTIONS: ["google-oauth2"]`, only `google-oauth2.json` in input, 8 connections on tenant. Result: `No changes detected` - zero phantom DELETEs for the 7 excluded connections.
  - **#1450:** Added `"AUTH0_IGNORE_DRY_RUN_FIELDS": {"databases": ["enabled_clients"]}`. Database UPDATE count dropped from 5 to 1 - `enabled_clients` noise correctly suppressed.
  - **Null crash:** Covered by unit test - all local assets classified as creates, no crash when `existing` is `null`

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
