### PR TITLE
Guard undefined `handler.identifiers` in keywordPreservation.ts

### DIFF
--- a/src/keywordPreservation.ts
+++ b/src/keywordPreservation.ts
@@ -254,6 +254,7 @@ export const preserveKeywords = ({
 
   const resourceSpecificIdentifiers: Partial<Record<AssetTypes, string[]>> = auth0Handlers.reduce(
     (acc, handler) => {
+      if (handler.identifiers === undefined) return acc;
       acc[handler.type] = handler.identifiers.flat();
       return acc;
     },

--- a/test/keywordPreservation.test.ts
+++ b/test/keywordPreservation.test.ts
@@ -10,6 +10,8 @@ import {
 } from '../src/keywordPreservation';
 import { cloneDeep } from 'lodash';
 import log from '../src/logger';
+import Auth0 from '../src/tools/auth0';
+import { Assets, Auth0APIClient } from '../src/types';
 
 describe('#Keyword Preservation', () => {
   describe('doesHaveKeywordMarker', () => {
@@ -1074,5 +1076,76 @@ describe('preserveKeywords', () => {
     );
 
     log.debug = originalLogDebug;
+  });
+});
+
+describe('preserveKeywords with handlers that do not define identifiers', () => {
+  // Regression test for a crash during export with AUTH0_PRESERVE_KEYWORDS enabled:
+  // `TypeError: Cannot read properties of undefined (reading 'flat')`.
+  // Handlers that do not extend the default APIHandler (ex: clientAuthCredentials)
+  // never receive the `['id', 'name']` identifiers default, so `handler.identifiers`
+  // is undefined when preserveKeywords builds its identifier map.
+  it('should not crash when a handler is missing the identifiers property', () => {
+    const mockLocalAssets = {
+      tenant: {
+        friendly_name: '##COMPANY_NAME## Tenant',
+      },
+    };
+
+    const mockRemoteAssets = {
+      tenant: {
+        friendly_name: 'Travel0 Tenant',
+      },
+    };
+
+    const preservedAssets = preserveKeywords({
+      localAssets: mockLocalAssets,
+      remoteAssets: mockRemoteAssets,
+      keywordMappings: {
+        COMPANY_NAME: 'Travel0',
+      },
+      auth0Handlers: [
+        { id: 'id', identifiers: ['id', 'name'], type: 'clients' },
+        //@ts-expect-error because handlers not extending the default APIHandler lack identifiers
+        { id: 'id', type: 'clientAuthCredentials' },
+      ],
+    });
+
+    expect(preservedAssets).to.deep.equal({
+      tenant: {
+        friendly_name: '##COMPANY_NAME## Tenant',
+      },
+    });
+  });
+
+  it('should not crash when passed the actual set of Auth0 handlers', () => {
+    const auth0 = new Auth0({} as Auth0APIClient, {} as Assets, () => undefined);
+
+    const mockLocalAssets = {
+      tenant: {
+        friendly_name: '##COMPANY_NAME## Tenant',
+      },
+    };
+
+    const mockRemoteAssets = {
+      tenant: {
+        friendly_name: 'Travel0 Tenant',
+      },
+    };
+
+    const preservedAssets = preserveKeywords({
+      localAssets: mockLocalAssets,
+      remoteAssets: mockRemoteAssets,
+      keywordMappings: {
+        COMPANY_NAME: 'Travel0',
+      },
+      auth0Handlers: auth0.handlers as Parameters<typeof preserveKeywords>[0]['auth0Handlers'],
+    });
+
+    expect(preservedAssets).to.deep.equal({
+      tenant: {
+        friendly_name: '##COMPANY_NAME## Tenant',
+      },
+    });
   });
 });


### PR DESCRIPTION
### 🔧 Changes

This rescues an error in _src/keywordPreservation.ts_ when `handler.identifiers` is `undefined`
https://github.com/auth0/auth0-deploy-cli/issues/1446

### 📚 References

Uses @rdroe 's suggested fix _Option B_ described in https://github.com/auth0/auth0-deploy-cli/issues/1446

> Option B — skip handlers without identifiers:
> ```typescript
> if (handler.identifiers === undefined) return acc;
> acc[handler.type] = handler.identifiers.flat();
> ```

### 🔬 Testing

With `AUTH0_PRESERVE_KEYWORDS: true` in config, perform an export for example like so:

```bash
npx auth0-deploy-cli export \
  --strip \
  --format directory \
  --output_folder ./${output_folder} \
  --config_file ./${output_folder}/${from_tenant}.json \
  --debug true
```
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [N/A] I have added documentation for all new/changed functionality (or N/A)
