### PR TITLE
fix: preserve idpinitiated.enabled:false on SAML connection export instead of emitting undefined_clientId

### DIFF
--- a/src/tools/auth0/handlers/connections.ts
+++ b/src/tools/auth0/handlers/connections.ts
@@ -448,12 +448,15 @@ export default class ConnectionsHandler extends DefaultAPIHandler {
 
   getFormattedOptions(connection, clients) {
     try {
+      const { idpinitiated } = connection.options;
       return {
         options: {
           ...connection.options,
           idpinitiated: {
-            ...connection.options.idpinitiated,
-            client_id: convertClientNameToId(connection.options.idpinitiated.client_id, clients),
+            ...idpinitiated,
+            ...(idpinitiated.client_id && {
+              client_id: convertClientNameToId(idpinitiated.client_id, clients),
+            }),
           },
         },
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -334,12 +334,15 @@ export const decodeBase64ToCertString = (base64Cert: string) => {
 // Format connection options by converting client IDs to client names for SAML connections
 export const getFormattedOptions = (connection, clients) => {
   try {
+    const { idpinitiated } = connection.options;
     return {
       options: {
         ...connection.options,
         idpinitiated: {
-          ...connection.options.idpinitiated,
-          client_id: convertClientIdToName(connection.options.idpinitiated.client_id, clients),
+          ...idpinitiated,
+          ...(idpinitiated.client_id && {
+            client_id: convertClientIdToName(idpinitiated.client_id, clients),
+          }),
         },
       },
     };

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -154,6 +154,31 @@ describe('#directory context connections', () => {
     );
   });
 
+  it('should dump samlp connection with idpinitiated login disabled', async () => {
+    const dir = path.join(testDataDir, 'directory', 'connectionsDump');
+    cleanThenMkdir(dir);
+    const context = new Context({ AUTH0_INPUT_FILE: dir }, mockMgmtClient());
+
+    context.assets.connections = [
+      {
+        name: 'someSamlConnectionIdpInitiatedDisabled',
+        strategy: 'samlp',
+        enabled_clients: [],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: { enabled: false },
+        },
+      },
+    ];
+
+    await handler.dump(context);
+    const connectionsFolder = path.join(dir, constants.CONNECTIONS_DIRECTORY);
+    expect(
+      loadJSON(path.join(connectionsFolder, 'someSamlConnectionIdpInitiatedDisabled.json')).options
+        .idpinitiated
+    ).to.deep.equal({ enabled: false });
+  });
+
   it('should dump connections sanitized', async () => {
     const dir = path.join(testDataDir, 'directory', 'connectionsDump');
     cleanThenMkdir(dir);

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -189,6 +189,17 @@ describe('#YAML context connections', () => {
           },
         },
       },
+      {
+        name: 'someSamlConnectionIdpInitiatedDisabled',
+        strategy: 'samlp',
+        enabled_clients: [],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            enabled: false,
+          },
+        },
+      },
     ];
 
     const target = [
@@ -235,6 +246,17 @@ describe('#YAML context connections', () => {
             client_id: 'client-idp-three-id',
             client_protocol: 'samlp',
             client_authorizequery: '',
+          },
+        },
+      },
+      {
+        name: 'someSamlConnectionIdpInitiatedDisabled',
+        strategy: 'samlp',
+        enabled_clients: [],
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: {
+            enabled: false,
           },
         },
       },

--- a/test/tools/auth0/handlers/connections.tests.js
+++ b/test/tools/auth0/handlers/connections.tests.js
@@ -1476,6 +1476,22 @@ describe('#connections handler', () => {
       await stageFn.apply(handler, [{ connections: data }]);
     });
 
+    it('should not add a client_id to idpinitiated when login is disabled', () => {
+      const handler = new connections.default({ client: pageClient({ pool }), config });
+      const connection = {
+        options: {
+          passwordPolicy: 'testPolicy',
+          idpinitiated: { enabled: false },
+        },
+      };
+
+      const formatted = handler.getFormattedOptions(connection, [
+        { name: 'client1', client_id: 'client1-id' },
+      ]);
+
+      expect(formatted.options.idpinitiated).to.deep.equal({ enabled: false });
+    });
+
     // If client is excluded and in the existing connection this client is enabled, it should keep enabled
     // If client is excluded and in the existing connection this client is disabled, it should keep disabled
     it('should handle excluded clients properly', async () => {


### PR DESCRIPTION
### 🔧 Changes

Fixes a serialization bug where exporting a SAML (samlp) connection with IDP-initiated login disabled produced a malformed `idpinitiated` block. Previously the exporter unconditionally injected a `client_id`, and when none existed the helper substituted the literal string `undefined_clientId`. On import this present block was treated as enabled, silently flipping IDP-initiated login ON in the target tenant.

- `getFormattedOptions` in `src/utils.ts` (export path, ID to name) now only adds `client_id` when one is actually present; otherwise the `idpinitiated` block passes through untouched, preserving `enabled: false`.
- `getFormattedOptions` in `src/tools/auth0/handlers/connections.ts` (diff/import path, name to ID) receives the same guard so both directions stay symmetric. A third resolver in `src/tools/calculateDryRunChanges.ts` was reviewed and is already guarded by `?.client_id`, so it needs no change.

Note on scope: the guard omits `client_id` whenever it is falsy (`enabled: false`, empty string, null, or absent), not only the disabled case. This is the intended, more-correct behavior, but the output change is slightly wider than "disabled connections" alone.

**Exported config shape change (both YAML and JSON/directory formats):**

For a connection with IDP-initiated login disabled, the export now emits:

```yaml
idpinitiated:
  enabled: false
```

```json
"idpinitiated": {
  "enabled": false
}
```

instead of the previous malformed output:

```yaml
idpinitiated:
  client_id: undefined_clientId
```

```json
"idpinitiated": {
  "client_id": "undefined_clientId"
}
```

Connections that have IDP-initiated login enabled are unaffected and continue to export their resolved `client_id`.

### 🔬 Testing

- Added a disabled IDP-initiated connection to the YAML dump test, asserting `enabled: false` round-trips without a bogus `client_id`. This covers both the YAML and directory export paths, since both share `utils.getFormattedOptions`.
- Added a focused unit test on the handler's `getFormattedOptions` (the import/diff name-to-ID path) verifying no `client_id` is re-injected when a disabled `{ enabled: false }` block is processed - directly pinning the reported "login flipped ON" symptom.
- Full connections, dry-run, and YAML/directory context suites pass.

Verified end-to-end against a real tenant:

- Created a samlp connection with `idpinitiated.enabled: false` via import.
- Pre-fix build reproduced the bug: the export emitted `enabled: false` **and** a stray `client_id: undefined_clientId`.
- Fixed build exported the block as `enabled: false` only, with no `undefined_clientId` placeholder, so the disabled state round-trips correctly.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
