### PR TITLE
fix: preserve keyword placeholder strings for all email provider credentials

### DIFF
--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -25,10 +25,12 @@ export function emailProviderDefaults(
   const { name } = updated;
 
   if (apiKeyProviders.includes(name)) {
-    updated.credentials = {
-      api_key: `##${name.toUpperCase()}_API_KEY##`,
-      ...(updated.credentials || {}),
-    };
+    if (typeof updated.credentials !== 'string') {
+      updated.credentials = {
+        api_key: `##${name.toUpperCase()}_API_KEY##`,
+        ...(updated.credentials || {}),
+      };
+    }
   }
 
   if (name === 'smtp') {
@@ -50,28 +52,34 @@ export function emailProviderDefaults(
   }
 
   if (name === 'ses') {
-    updated.credentials = {
-      accessKeyId: '##SES_ACCESS_KEY_ID##',
-      secretAccessKey: '##SES_ACCESS_SECRET_KEY##',
-      region: '##SES_AWS_REGION##',
-      ...(updated.credentials || {}),
-    };
+    if (typeof updated.credentials !== 'string') {
+      updated.credentials = {
+        accessKeyId: '##SES_ACCESS_KEY_ID##',
+        secretAccessKey: '##SES_ACCESS_SECRET_KEY##',
+        region: '##SES_AWS_REGION##',
+        ...(updated.credentials || {}),
+      };
+    }
   }
 
   if (name === 'azure_cs') {
-    updated.credentials = {
-      connectionString: '##AZURE_CS_CONNECTION_KEY##',
-      ...(updated.credentials || {}),
-    };
+    if (typeof updated.credentials !== 'string') {
+      updated.credentials = {
+        connectionString: '##AZURE_CS_CONNECTION_KEY##',
+        ...(updated.credentials || {}),
+      };
+    }
   }
 
   if (name === 'ms365') {
-    updated.credentials = {
-      tenantId: '##MS365_TENANT_ID##',
-      clientId: '##MS365_CLIENT_ID##',
-      clientSecret: '##MS365_CLIENT_SECRET##',
-      ...(updated.credentials || {}),
-    };
+    if (typeof updated.credentials !== 'string') {
+      updated.credentials = {
+        tenantId: '##MS365_TENANT_ID##',
+        clientId: '##MS365_CLIENT_ID##',
+        clientSecret: '##MS365_CLIENT_SECRET##',
+        ...(updated.credentials || {}),
+      };
+    }
   }
 
   return updated;

--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -32,17 +32,21 @@ export function emailProviderDefaults(
   }
 
   if (name === 'smtp') {
-    // This is to mask smtp_user to '##SMTP_USER##'
-    if (updated.credentials && 'smtp_user' in updated.credentials) {
-      delete updated.credentials.smtp_user;
+    // If credentials is a keyword placeholder string (e.g. @@SMTP_CREDENTIALS@@), preserve it as-is.
+    // The `in` operator requires an object and would throw a TypeError on a string.
+    if (typeof updated.credentials !== 'string') {
+      // This is to mask smtp_user to '##SMTP_USER##'
+      if (updated.credentials && 'smtp_user' in updated.credentials) {
+        delete updated.credentials.smtp_user;
+      }
+      updated.credentials = {
+        smtp_host: '##SMTP_HOSTNAME##',
+        smtp_port: '##SMTP_PORT##',
+        smtp_user: '##SMTP_USER##',
+        smtp_pass: '##SMTP_PASS##',
+        ...(updated.credentials || {}),
+      };
     }
-    updated.credentials = {
-      smtp_host: '##SMTP_HOSTNAME##',
-      smtp_port: '##SMTP_PORT##',
-      smtp_user: '##SMTP_USER##',
-      smtp_pass: '##SMTP_PASS##',
-      ...(updated.credentials || {}),
-    };
   }
 
   if (name === 'ses') {

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -22,6 +22,20 @@ describe('#context defaults', () => {
       });
     });
 
+    it('should preserve smtp credentials when it is a keyword placeholder string', async () => {
+      const emailProvider = {
+        name: 'smtp',
+        credentials: '@@SMTP_CREDENTIALS@@',
+      };
+
+      const result = emailProviderDefaults(emailProvider);
+
+      expect(result).to.deep.equal({
+        name: 'smtp',
+        credentials: '@@SMTP_CREDENTIALS@@',
+      });
+    });
+
     it('should set emailProvider defaults for smtp and remove existing smtp_user', async () => {
       const emailProvider = {
         name: 'smtp',

--- a/test/context/defaults.test.js
+++ b/test/context/defaults.test.js
@@ -36,6 +36,32 @@ describe('#context defaults', () => {
       });
     });
 
+    it('should preserve ses credentials when it is a keyword placeholder string', async () => {
+      const result = emailProviderDefaults({ name: 'ses', credentials: '@@SES_CREDENTIALS@@' });
+      expect(result).to.deep.equal({ name: 'ses', credentials: '@@SES_CREDENTIALS@@' });
+    });
+
+    it('should preserve mailgun credentials when it is a keyword placeholder string', async () => {
+      const result = emailProviderDefaults({
+        name: 'mailgun',
+        credentials: '@@MAILGUN_CREDENTIALS@@',
+      });
+      expect(result).to.deep.equal({ name: 'mailgun', credentials: '@@MAILGUN_CREDENTIALS@@' });
+    });
+
+    it('should preserve azure_cs credentials when it is a keyword placeholder string', async () => {
+      const result = emailProviderDefaults({
+        name: 'azure_cs',
+        credentials: '@@AZURE_CREDENTIALS@@',
+      });
+      expect(result).to.deep.equal({ name: 'azure_cs', credentials: '@@AZURE_CREDENTIALS@@' });
+    });
+
+    it('should preserve ms365 credentials when it is a keyword placeholder string', async () => {
+      const result = emailProviderDefaults({ name: 'ms365', credentials: '@@MS365_CREDENTIALS@@' });
+      expect(result).to.deep.equal({ name: 'ms365', credentials: '@@MS365_CREDENTIALS@@' });
+    });
+
     it('should set emailProvider defaults for smtp and remove existing smtp_user', async () => {
       const emailProvider = {
         name: 'smtp',


### PR DESCRIPTION
### 🔧 Changes

When `AUTH0_PRESERVE_KEYWORDS` is enabled and a local config file uses a keyword placeholder string for `credentials` (e.g. "`@@SMTP_CREDENTIALS@@`"), `emailProviderDefaults` now preserves it as-is instead of attempting to apply masking logic.                                                                                                                 
                                                                                                                                                                                   
Previously, for `smtp`, the `in` operator was used directly on the placeholder string, causing a hard `TypeError` crash during export. For all other providers (`ses`, `mailgun`, `mandrill`, `sendgrid`, `sparkpost`, `azure_cs`, `ms365`), the string was silently spread into the credentials object as character-indexed keys (e.g. `{"0": "@", "1": "@", ...}`), which caused Auth0 API to reject the payload with a 400 on subsequent deploy.

The fix adds a `typeof credentials !== 'string'` guard to each provider block in `emailProviderDefaults`. This is purely additive — all existing behavior for object and undefined credentials is unchanged.

### 📚 References

Fixes #1467

### 🔬 Testing

Unit tests added for all affected providers (`smtp`, `ses`, `mailgun`, `azure_cs`, `ms365`) covering the keyword placeholder string case.

Manual end-to-end testing performed:
  - Confirmed the `TypeError` crash during export with `AUTH0_PRESERVE_KEYWORDS=true` and `credentials: "@@SMTP_CREDENTIALS@@"` in local config
  - Confirmed export succeeds after the fix and the placeholder is preserved in the output file
  - Confirmed Auth0 API returns 400 **Additional properties not allowed** when garbage character-indexed keys are deployed (validating the severity of the other providers' issue)

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
