### PR TITLE
feat: support third_party_client_access and cross_app_access_resource_app

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -1297,6 +1297,11 @@ Example `phone-templates/otp_verify.json`:
 
 Application specific configuration for use with the OIN Express Configuration feature
 
+The `cross_app_access_resource_app` field controls whether organization admins may enable Cross App Access (XAA) on their Identity Providers:
+
+- `cross_app_access_resource_app.status.default_value` (`"enabled"` | `"disabled"`): The default Cross App Access resource app status.
+- `cross_app_access_resource_app.status.allowed_values` (array of `"enabled"` | `"disabled"`): The allowed status values.
+
 ### YAML Example
 
 ```yaml
@@ -1310,6 +1315,12 @@ connectionProfiles:
     enabled_features:
       - scim
       - universal_logout
+    cross_app_access_resource_app:
+      status:
+        default_value: 'enabled'
+        allowed_values:
+          - enabled
+          - disabled
     strategy_overrides:
       samlp:
         enabled_features:
@@ -1339,6 +1350,12 @@ File: `./connection-profiles/Enterprise SSO Profile.json`
   },
   "connection_name_prefix_template": "org-{organization_name}",
   "enabled_features": ["scim", "universal_logout"],
+  "cross_app_access_resource_app": {
+    "status": {
+      "default_value": "enabled",
+      "allowed_values": ["enabled", "disabled"]
+    }
+  },
   "strategy_overrides": {
     "samlp": {
       "enabled_features": ["universal_logout"]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@clack/prompts": "1.4.0",
     "ajv": "^6.12.6",
-    "auth0": "^6.2.0",
+    "auth0": "^6.3.0",
     "chalk": "5.6.2",
     "dot-prop": "^5.3.0",
     "fs-extra": "^10.1.0",

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -57,6 +57,32 @@ const myOrganizationConfigurationSchema = {
       enum: Object.values(Management.ClientMyOrganizationDeletionBehaviorEnum),
       description: 'The deletion behavior for My Organization connections created by this client',
     },
+    third_party_client_access: {
+      type: 'object',
+      description:
+        'Controls whether third-party clients can access the organization via the My Organization API.',
+      properties: {
+        default_value: {
+          type: 'string',
+          enum: Object.values(
+            Management.ClientMyOrganizationConfigurationThirdPartyClientAccessDefaultValueEnum
+          ),
+          description: 'The default third-party client access value.',
+        },
+        allowed_values: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: Object.values(
+              Management.ClientMyOrganizationConfigurationThirdPartyClientAccessAllowedValuesEnum
+            ),
+          },
+          uniqueItems: true,
+          description: 'The allowed third-party client access values.',
+        },
+      },
+      required: ['default_value', 'allowed_values'],
+    },
     invitation_landing_client_id: {
       type: 'string',
       description:

--- a/src/tools/auth0/handlers/connectionProfiles.ts
+++ b/src/tools/auth0/handlers/connectionProfiles.ts
@@ -66,6 +66,8 @@ export const schema = {
                 description: 'The allowed Cross App Access resource app status values.',
               },
             },
+            // allowed_values is optional per the SDK type (unlike the client's
+            // third_party_client_access, which requires both fields).
             required: ['default_value'],
           },
         },

--- a/src/tools/auth0/handlers/connectionProfiles.ts
+++ b/src/tools/auth0/handlers/connectionProfiles.ts
@@ -39,6 +39,38 @@ export const schema = {
       connection_config: {
         type: ['object', 'null'],
       },
+      cross_app_access_resource_app: {
+        type: 'object',
+        description:
+          'Controls whether organization admins may enable Cross App Access (XAA) on their Identity Providers.',
+        properties: {
+          status: {
+            type: 'object',
+            properties: {
+              default_value: {
+                type: 'string',
+                enum: Object.values(
+                  Management.ConnectionProfileCrossAppAccessResourceAppStatusDefaultValueEnum
+                ),
+                description: 'The default Cross App Access resource app status.',
+              },
+              allowed_values: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: Object.values(
+                    Management.ConnectionProfileCrossAppAccessResourceAppStatusValueEnum
+                  ),
+                },
+                uniqueItems: true,
+                description: 'The allowed Cross App Access resource app status values.',
+              },
+            },
+            required: ['default_value'],
+          },
+        },
+        required: ['status'],
+      },
       strategy_overrides: {
         type: ['object', 'null'],
         properties: {

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -93,6 +93,40 @@ describe('#clients handler', () => {
       ]);
       expect(valid).to.equal(false);
     });
+
+    it('should pass validation with my_organization_configuration.third_party_client_access', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someMyOrgClient',
+          my_organization_configuration: {
+            allowed_strategies: ['oidc'],
+            connection_deletion_behavior: 'allow',
+            third_party_client_access: {
+              default_value: 'block',
+              allowed_values: ['allow', 'block'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should fail validation with third_party_client_access missing allowed_values', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someMyOrgClient',
+          my_organization_configuration: {
+            allowed_strategies: ['oidc'],
+            connection_deletion_behavior: 'allow',
+            third_party_client_access: {
+              default_value: 'block',
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
   });
 
   describe('#clients validate', () => {

--- a/test/tools/auth0/handlers/connectionProfiles.tests.js
+++ b/test/tools/auth0/handlers/connectionProfiles.tests.js
@@ -1,3 +1,4 @@
+const Ajv = require('ajv');
 const { expect } = require('chai');
 const connectionProfiles = require('../../../../src/tools/auth0/handlers/connectionProfiles');
 const { mockPagedData } = require('../../../utils');
@@ -20,6 +21,65 @@ describe('#connectionProfiles handler', () => {
   config.data = {
     AUTH0_ALLOW_DELETE: true,
   };
+
+  describe('#connectionProfiles schema', () => {
+    const ajv = new Ajv({ useDefaults: true, nullable: true });
+
+    it('should pass validation with cross_app_access_resource_app', () => {
+      const valid = ajv.validate(connectionProfiles.schema, [
+        {
+          name: 'someProfile',
+          cross_app_access_resource_app: {
+            status: {
+              default_value: 'enabled',
+              allowed_values: ['enabled', 'disabled'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should pass validation with cross_app_access_resource_app omitting optional allowed_values', () => {
+      const valid = ajv.validate(connectionProfiles.schema, [
+        {
+          name: 'someProfile',
+          cross_app_access_resource_app: {
+            status: {
+              default_value: 'disabled',
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should fail validation with cross_app_access_resource_app.status missing default_value', () => {
+      const valid = ajv.validate(connectionProfiles.schema, [
+        {
+          name: 'someProfile',
+          cross_app_access_resource_app: {
+            status: {
+              allowed_values: ['enabled', 'disabled'],
+            },
+          },
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
+
+    it('should fail validation with cross_app_access_resource_app missing status', () => {
+      const valid = ajv.validate(connectionProfiles.schema, [
+        {
+          name: 'someProfile',
+          cross_app_access_resource_app: {},
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
+  });
 
   describe('#connectionProfiles validate', () => {
     it('should not allow same names', async () => {
@@ -48,24 +108,6 @@ describe('#connectionProfiles handler', () => {
       const data = [
         {
           name: 'someProfile',
-        },
-      ];
-
-      await stageFn.apply(handler, [{ connectionProfiles: data }]);
-    });
-
-    it('should pass validation with cross_app_access_resource_app', async () => {
-      const handler = new connectionProfiles.default({ client: {}, config });
-      const stageFn = Object.getPrototypeOf(handler).validate;
-      const data = [
-        {
-          name: 'someProfile',
-          cross_app_access_resource_app: {
-            status: {
-              default_value: 'enabled',
-              allowed_values: ['enabled', 'disabled'],
-            },
-          },
         },
       ];
 

--- a/test/tools/auth0/handlers/connectionProfiles.tests.js
+++ b/test/tools/auth0/handlers/connectionProfiles.tests.js
@@ -53,6 +53,24 @@ describe('#connectionProfiles handler', () => {
 
       await stageFn.apply(handler, [{ connectionProfiles: data }]);
     });
+
+    it('should pass validation with cross_app_access_resource_app', async () => {
+      const handler = new connectionProfiles.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          name: 'someProfile',
+          cross_app_access_resource_app: {
+            status: {
+              default_value: 'enabled',
+              allowed_values: ['enabled', 'disabled'],
+            },
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ connectionProfiles: data }]);
+    });
   });
 
   describe('#connectionProfiles process', () => {


### PR DESCRIPTION
### 🔧 Changes

Adds support for two new Early Access properties introduced in node-auth0 6.3.0. Bumps the `auth0` dependency to `^6.3.0`.

**1. `clients` -> `my_organization_configuration.third_party_client_access`**

Controls whether third-party clients can access the organization via the My Organization API. Shape: `{ default_value, allowed_values }` where `default_value` is `block` and `allowed_values` is an array of `allow` / `block`.

**2. `connectionProfiles` -> `cross_app_access_resource_app`**

Controls whether organization admins may enable Cross App Access (XAA) on their Identity Providers. Shape: `{ status: { default_value, allowed_values } }` where `default_value` is `enabled` / `disabled` and `allowed_values` is an array of `enabled` / `disabled`.

Both properties are optional and are gated behind tenant feature flags on the Management API side.

#### YAML examples

```yaml
clients:
  - name: "My Enterprise App"
    my_organization_configuration:
      allowed_strategies:
        - okta
      connection_deletion_behavior: allow_if_empty
      third_party_client_access:
        default_value: block
        allowed_values:
          - allow
          - block

connectionProfiles:
  - name: "Enterprise SSO Profile"
    enabled_features:
      - scim
    cross_app_access_resource_app:
      status:
        default_value: enabled
        allowed_values:
          - enabled
          - disabled
```

#### JSON (directory format) examples

`clients/My Enterprise App.json`

```json
{
  "name": "My Enterprise App",
  "my_organization_configuration": {
    "allowed_strategies": ["okta"],
    "connection_deletion_behavior": "allow_if_empty",
    "third_party_client_access": {
      "default_value": "block",
      "allowed_values": ["allow", "block"]
    }
  }
}
```

`connection-profiles/Enterprise SSO Profile.json`

```json
{
  "name": "Enterprise SSO Profile",
  "enabled_features": ["scim"],
  "cross_app_access_resource_app": {
    "status": {
      "default_value": "enabled",
      "allowed_values": ["enabled", "disabled"]
    }
  }
}
```

### 🔬 Testing

- Added unit tests covering AJV schema validation for both new properties (valid payloads pass, missing required sub-fields fail).
- Verified end to end against a live tenant: `import` correctly serializes and sends both new fields to the Management API. On a tenant without the feature flags enabled, the API returns the expected `403 operation_not_supported` responses, confirming the fields reach the API rather than being stripped:
  - `third_party_client_access`: "The account is not allowed to set third_party_client_access"
  - `cross_app_access_resource_app`: "The account is not enabled to set cross_app_access_resource_app"
- Full round-trip create + export requires these tenant feature flags: `organizations_third_party_client_support`, `my_orgs_cross_app_access_resource_app`, `cross_app_access_resource_application_beta`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
