### PR TITLE
fix: include empty credentials for custom phone provider on import and export to prevent 400 errors

### DIFF
--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -99,6 +99,11 @@ export function phoneProviderDefaults(phoneProvider) {
     updated.credentials = {
       auth_token: `##${name.toUpperCase()}_AUTH_TOKEN##`,
     };
+  } else if (name === 'custom') {
+    // The `custom` provider has no exportable secrets, but the API requires a
+    // `credentials` object on import even when empty. Emit an empty object so
+    // exported configs round-trip cleanly.
+    updated.credentials = {};
   }
   return updated;
 }

--- a/src/tools/auth0/handlers/phoneProvider.ts
+++ b/src/tools/auth0/handlers/phoneProvider.ts
@@ -192,6 +192,18 @@ export default class PhoneProviderHandler extends DefaultHandler {
         delete payload.id;
       }
 
+      // The `custom` provider requires a `credentials` object in the payload even
+      // when it is empty. Exported configs omit credentials, so inject an empty
+      // object here to avoid a "Missing required property: credentials" 400 error.
+      const payloadWithCreds = payload as PhoneProvider & { credentials?: object };
+      if (
+        payloadWithCreds &&
+        payloadWithCreds.name === 'custom' &&
+        payloadWithCreds.credentials == null
+      ) {
+        payloadWithCreds.credentials = {};
+      }
+
       return payload;
     })();
 

--- a/src/tools/auth0/handlers/phoneProvider.ts
+++ b/src/tools/auth0/handlers/phoneProvider.ts
@@ -184,24 +184,21 @@ export default class PhoneProviderHandler extends DefaultHandler {
     const currentProviders = await this.getPhoneProviders();
 
     const providerReqPayload = ((): Omit<PhoneProvider, 'id'> => {
+      // Work on a shallow copy so we don't mutate the caller's asset (phoneProviders[0]).
+      // The SDK response type doesn't declare `credentials`, so widen it here.
+      const payload = { ...phoneProviders[0] } as PhoneProvider & { credentials?: object };
+
       // Removing id from update and create payloads, otherwise API will error
       // id may be required to handle if `--export_ids=true`
-      const payload = phoneProviders[0];
-
-      if (payload && 'id' in payload) {
+      if ('id' in payload) {
         delete payload.id;
       }
 
       // The `custom` provider requires a `credentials` object in the payload even
       // when it is empty. Exported configs omit credentials, so inject an empty
       // object here to avoid a "Missing required property: credentials" 400 error.
-      const payloadWithCreds = payload as PhoneProvider & { credentials?: object };
-      if (
-        payloadWithCreds &&
-        payloadWithCreds.name === 'custom' &&
-        payloadWithCreds.credentials == null
-      ) {
-        payloadWithCreds.credentials = {};
+      if (payload.name === 'custom' && payload.credentials == null) {
+        payload.credentials = {};
       }
 
       return payload;

--- a/test/context/yaml/phoneProviders.test.js
+++ b/test/context/yaml/phoneProviders.test.js
@@ -108,4 +108,34 @@ phoneProviders:
       ],
     });
   });
+
+  it('should reset custom phone provider credentials to empty on dump', async () => {
+    // Custom credentials are never exportable, so any incoming credentials are
+    // stripped and replaced with an empty object on export.
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
+    context.assets.phoneProviders = [
+      {
+        disabled: false,
+        name: 'custom',
+        configuration: {
+          delivery_methods: ['text', 'voice'],
+        },
+        credentials: { some_key: 'some_value' },
+      },
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      phoneProviders: [
+        {
+          disabled: false,
+          name: 'custom',
+          configuration: {
+            delivery_methods: ['text', 'voice'],
+          },
+          credentials: {},
+        },
+      ],
+    });
+  });
 });

--- a/test/context/yaml/phoneProviders.test.js
+++ b/test/context/yaml/phoneProviders.test.js
@@ -80,4 +80,32 @@ phoneProviders:
       ],
     });
   });
+
+  it('should dump custom phone provider with empty credentials', async () => {
+    const context = new Context({ AUTH0_INPUT_FILE: './test.yml' }, mockMgmtClient());
+    context.assets.phoneProviders = [
+      {
+        id: 'pro_5nbdb4pWifFdA1rV6pW6BE',
+        disabled: false,
+        name: 'custom',
+        configuration: {
+          delivery_methods: ['text', 'voice'],
+        },
+      },
+    ];
+
+    const dumped = await handler.dump(context);
+    expect(dumped).to.deep.equal({
+      phoneProviders: [
+        {
+          disabled: false,
+          name: 'custom',
+          configuration: {
+            delivery_methods: ['text', 'voice'],
+          },
+          credentials: {},
+        },
+      ],
+    });
+  });
 });

--- a/test/tools/auth0/handlers/phoneProvider.test.ts
+++ b/test/tools/auth0/handlers/phoneProvider.test.ts
@@ -129,6 +129,110 @@ describe('#phoneProviders handler', () => {
       await stageFn.apply(handler, [{ phoneProviders: data }]);
     });
 
+    it('should inject empty credentials when creating a custom provider without credentials', async () => {
+      let createPayload;
+      const auth0 = {
+        branding: {
+          phone: {
+            providers: {
+              list: () => Promise.resolve({ providers: [] }),
+              create: (data) => {
+                createPayload = data;
+                return Promise.resolve(data);
+              },
+            },
+          },
+        },
+      };
+
+      const handler = new phoneProviderHandler({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'custom',
+          disabled: false,
+          configuration: {
+            delivery_methods: ['text', 'voice'],
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ phoneProviders: data }]);
+
+      expect(createPayload.name).to.equal('custom');
+      expect(createPayload.credentials).to.deep.equal({});
+    });
+
+    it('should inject empty credentials when updating a custom provider without credentials', async () => {
+      let updatePayload;
+      const auth0 = {
+        branding: {
+          phone: {
+            providers: {
+              list: () =>
+                Promise.resolve({
+                  providers: [{ id: 'pro_5nbdb4pWifFdA1rV6pW6BE' }],
+                }),
+              update: (id, data) => {
+                updatePayload = data;
+                return Promise.resolve({ ...data, id });
+              },
+            },
+          },
+        },
+      };
+
+      const handler = new phoneProviderHandler({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'custom',
+          disabled: false,
+          configuration: {
+            delivery_methods: ['text', 'voice'],
+          },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ phoneProviders: data }]);
+
+      expect(updatePayload.credentials).to.deep.equal({});
+    });
+
+    it('should not overwrite existing custom provider credentials', async () => {
+      let createPayload;
+      const auth0 = {
+        branding: {
+          phone: {
+            providers: {
+              list: () => Promise.resolve({ providers: [] }),
+              create: (data) => {
+                createPayload = data;
+                return Promise.resolve(data);
+              },
+            },
+          },
+        },
+      };
+
+      const handler = new phoneProviderHandler({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'custom',
+          disabled: false,
+          configuration: {
+            delivery_methods: ['text'],
+          },
+          credentials: { some_key: 'some_value' },
+        },
+      ];
+
+      await stageFn.apply(handler, [{ phoneProviders: data }]);
+
+      expect(createPayload.credentials).to.deep.equal({ some_key: 'some_value' });
+    });
+
     it('should delete the phone provider when provider exists and AUTH0_ALLOW_DELETE is true', async () => {
       const AUTH0_ALLOW_DELETE = true;
 


### PR DESCRIPTION
### 🔧 Changes

Fixes an issue where a custom phone provider exported from one tenant could not be imported into another.

The custom phone provider API requires a `credentials` object in the request payload even when it is empty. Previously the CLI stripped `credentials` on export and only re-added a placeholder for twilio, so custom providers were exported without any `credentials` key. On import that payload was rejected with:

```
400 Bad Request
Payload validation error: 'Missing required property: credentials'.
```

Two changes address this:

- Import (src/tools/auth0/handlers/phoneProvider.ts): when the provider is `custom` and no credentials are present in the payload, inject an empty `credentials: {}` before calling create/update. This also repairs configs that were already exported by older versions of the CLI.
- Export (src/context/defaults.ts): `phoneProviderDefaults` now emits `credentials: {}` for custom providers so newly exported configs round-trip cleanly. Twilio behaviour is unchanged.

Exported shape change for custom providers:

YAML (tenant.yaml)

Before:

```
phoneProviders:
  - name: custom
    configuration:
      delivery_methods:
        - text
        - voice
    disabled: false
```

After:

```
phoneProviders:
  - name: custom
    configuration:
      delivery_methods:
        - text
        - voice
    credentials: {}
    disabled: false
```

Directory (phone-providers/provider.json)

Before:

```
[
  {
    "name": "custom",
    "disabled": false,
    "configuration": {
      "delivery_methods": ["text", "voice"]
    }
  }
]
```

After:

```
[
  {
    "name": "custom",
    "disabled": false,
    "configuration": {
      "delivery_methods": ["text", "voice"]
    },
    "credentials": {}
  }
]
```

### 🔬 Testing

Unit tests added in test/tools/auth0/handlers/phoneProvider.test.ts and test/context/yaml/phoneProviders.test.js:

- Injects empty credentials when creating a custom provider without credentials
- Injects empty credentials when updating a custom provider without credentials
- Does not overwrite existing custom provider credentials
- Dumps custom provider with empty credentials on export

Manual test end to end against a live tenant:

- Imported a custom provider config with no credentials (YAML and directory formats), both dry run and real. The provider was created and updated successfully, where before the fix it failed with the 400 above.
- Exported in both YAML and directory formats and confirmed the output contains `credentials: {}` for the custom provider.

Note: the tenant level Phone Provider toggle must be enabled in the dashboard for custom providers, as it is not settable via a public API.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
