### PR TITLE
fix: strip form_submission_mode and form_submission_behavior from bruteForceProtection on export and import

### DIFF
--- a/src/readonly.ts
+++ b/src/readonly.ts
@@ -24,6 +24,11 @@ const readOnlyFields: Partial<Record<AssetTypes, string[]>> = {
     'config_route',
     'owners',
   ],
+  attackProtection: [
+    // Returned by GET but rejected by PATCH with "Additional properties not allowed"
+    'bruteForceProtection.form_submission_mode',
+    'bruteForceProtection.form_submission_behavior',
+  ],
 };
 
 function getExcludedFields(config: Config) {

--- a/src/tools/auth0/handlers/attackProtection.ts
+++ b/src/tools/auth0/handlers/attackProtection.ts
@@ -353,11 +353,10 @@ export default class AttackProtectionHandler extends DefaultAPIHandler {
     }
 
     if (attackProtection.bruteForceProtection) {
-      updates.push(
-        this.client.attackProtection.bruteForceProtection.update(
-          attackProtection.bruteForceProtection
-        )
-      );
+      // Strip fields returned by GET but rejected by PATCH
+      const { form_submission_mode, form_submission_behavior, ...bruteForcePayload } =
+        attackProtection.bruteForceProtection as any;
+      updates.push(this.client.attackProtection.bruteForceProtection.update(bruteForcePayload));
     }
 
     if (attackProtection.suspiciousIpThrottling) {

--- a/test/tools/auth0/handlers/attackProtection.tests.js
+++ b/test/tools/auth0/handlers/attackProtection.tests.js
@@ -223,6 +223,66 @@ describe('#attackProtection handler', () => {
       ]);
     });
 
+    it('should strip form_submission_mode and form_submission_behavior from bruteForceProtection before update', async () => {
+      let capturedPayload;
+      const auth0 = {
+        attackProtection: {
+          botDetection: { update: (data) => Promise.resolve(data) },
+          breachedPasswordDetection: { update: (data) => Promise.resolve(data) },
+          captcha: { update: (data) => Promise.resolve(data) },
+          suspiciousIpThrottling: { update: (data) => Promise.resolve(data) },
+          bruteForceProtection: {
+            update: (data) => {
+              capturedPayload = data;
+              return Promise.resolve(data);
+            },
+          },
+        },
+      };
+
+      const handler = new attackProtection.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          attackProtection: {
+            botDetection: {
+              bot_detection_level: 'medium',
+              monitoring_mode_enabled: false,
+              allowlist: [],
+            },
+            breachedPasswordDetection: {
+              admin_notification_frequency: [],
+              enabled: true,
+              method: 'standard',
+              shields: [],
+            },
+            captcha: { selected: 'friendly_captcha', policy: 'always' },
+            suspiciousIpThrottling: { allowlist: [], enabled: true, shields: [], stage: {} },
+            bruteForceProtection: {
+              allowlist: [],
+              enabled: true,
+              max_attempts: 10,
+              mode: 'count_per_identifier_and_ip',
+              shields: ['block', 'user_notification'],
+              form_submission_mode: 'auto',
+              form_submission_behavior: 'auto_submit',
+            },
+          },
+        },
+      ]);
+
+      expect(capturedPayload).to.deep.equal({
+        allowlist: [],
+        enabled: true,
+        max_attempts: 10,
+        mode: 'count_per_identifier_and_ip',
+        shields: ['block', 'user_notification'],
+      });
+      expect(capturedPayload).to.not.have.property('form_submission_mode');
+      expect(capturedPayload).to.not.have.property('form_submission_behavior');
+    });
+
     it('should handle 403 error when fetching bot detection and preserve captcha data', async () => {
       const auth0 = {
         attackProtection: {


### PR DESCRIPTION
### 🔧 Changes

The Auth0 Management API returns `form_submission_mode` and `form_submission_behavior` in the `GET /attack-protection/brute-force-protection` response, but rejects both fields with a 400 Additional properties not allowed error on PATCH. This breaks the standard export→import round-trip.

  - Added `bruteForceProtection.form_submission_mode` and `bruteForceProtection.form_submission_behavior` to readOnlyFields in `src/readonly.ts` so they are stripped from exported files going forward
  - Added handler-level stripping in `src/tools/auth0/handlers/attackProtection.ts` before calling the PATCH API, to also cover users who already have either field in existing exported files

### 📚 References

Fixes #1469

### 🔬 Testing

 - Added a unit test that passes bruteForceProtection with both `form_submission_mode` and `form_submission_behavior` in the input and asserts neither field is present in the payload sent to the update API
  - Manually verified end-to-end: export no longer includes the fields, and import succeeds without a 400 error

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
