### PR TITLE
fix: warn on path traversal in file references and fix double-path resolution in yaml connections handler

### DIFF
--- a/src/context/directory/handlers/branding.ts
+++ b/src/context/directory/handlers/branding.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { constants, loadFileAndReplaceKeywords } from '../../../tools';
+import log from '../../../logger';
 import {
   dumpJSON,
   existsMustBeDir,
@@ -47,13 +48,19 @@ function parse(context: DirectoryContext): ParsedBranding {
     });
 
     const normalizedPathArray = nomalizedYAMLPath(definition.body);
-    definition.body = loadFileAndReplaceKeywords(
-      path.join(brandingTemplatesFolder, ...normalizedPathArray),
-      {
-        mappings: context.mappings,
-        disableKeywordReplacement: context.disableKeywordReplacement,
-      }
-    );
+    const resolvedBodyFile = path.resolve(brandingTemplatesFolder, ...normalizedPathArray);
+    const configRoot = path.resolve(context.filePath);
+    if (!resolvedBodyFile.startsWith(configRoot + path.sep)) {
+      log.warn(
+        `Branding template body path "${definition.body}" resolves to "${resolvedBodyFile}" which is outside the config directory "${configRoot}". ` +
+          `This will be blocked as an error in the next major release. ` +
+          `Move the file inside your config directory.`
+      );
+    }
+    definition.body = loadFileAndReplaceKeywords(resolvedBodyFile, {
+      mappings: context.mappings,
+      disableKeywordReplacement: context.disableKeywordReplacement,
+    });
     return definition;
   }, {});
 

--- a/src/context/directory/handlers/clients.ts
+++ b/src/context/directory/handlers/clients.ts
@@ -33,10 +33,18 @@ function parse(context: DirectoryContext): ParsedClients {
       });
 
       if (client.custom_login_page) {
-        const htmlFileName = path.join(clientsFolder, client.custom_login_page);
+        const configRoot = path.resolve(context.filePath);
+        const resolvedLoginPage = path.resolve(clientsFolder, client.custom_login_page);
 
-        if (isFile(htmlFileName)) {
-          client.custom_login_page = loadFileAndReplaceKeywords(htmlFileName, {
+        if (isFile(resolvedLoginPage)) {
+          if (!resolvedLoginPage.startsWith(configRoot + path.sep)) {
+            log.warn(
+              `Path "${client.custom_login_page}" resolves to "${resolvedLoginPage}" which is outside the config directory "${configRoot}". ` +
+                `This will be blocked as an error in the next major release. ` +
+                `Move the file inside your config directory.`
+            );
+          }
+          client.custom_login_page = loadFileAndReplaceKeywords(resolvedLoginPage, {
             mappings: context.mappings,
             disableKeywordReplacement: context.disableKeywordReplacement,
           });

--- a/src/context/directory/handlers/connections.ts
+++ b/src/context/directory/handlers/connections.ts
@@ -39,14 +39,22 @@ function parse(context: DirectoryContext): ParsedConnections {
 
       if (connection.strategy === 'email') {
         ensureProp(connection, 'options.email.body');
-        const htmlFileName = path.join(connectionsFolder, connection.options.email.body);
+        const configRoot = path.resolve(context.filePath);
+        const resolvedHtmlFile = path.resolve(connectionsFolder, connection.options.email.body);
 
-        if (!isFile(htmlFileName)) {
+        if (!isFile(resolvedHtmlFile)) {
           throw new Error(
-            `Passwordless email template purportedly located at ${htmlFileName} does not exist for connection. Ensure the existence of this file to proceed with deployment.`
+            `Passwordless email template purportedly located at ${resolvedHtmlFile} does not exist for connection. Ensure the existence of this file to proceed with deployment.`
           );
         }
-        connection.options.email.body = loadFileAndReplaceKeywords(htmlFileName, {
+        if (!resolvedHtmlFile.startsWith(configRoot + path.sep)) {
+          log.warn(
+            `Path "${connection.options.email.body}" resolves to "${resolvedHtmlFile}" which is outside the config directory "${configRoot}". ` +
+              `This will be blocked as an error in the next major release. ` +
+              `Move the file inside your config directory.`
+          );
+        }
+        connection.options.email.body = loadFileAndReplaceKeywords(resolvedHtmlFile, {
           mappings: context.mappings,
           disableKeywordReplacement: context.disableKeywordReplacement,
         });

--- a/src/context/directory/handlers/emailTemplates.ts
+++ b/src/context/directory/handlers/emailTemplates.ts
@@ -44,6 +44,18 @@ function parse(context: DirectoryContext): ParsedEmailTemplates {
       return [];
     }
 
+    if (meta.body !== undefined) {
+      const configRoot = path.resolve(context.filePath);
+      const resolvedTemplatePath = path.resolve(templateFilePath);
+      if (!resolvedTemplatePath.startsWith(configRoot + path.sep)) {
+        log.warn(
+          `Email template body path "${meta.body}" resolves to "${resolvedTemplatePath}" which is outside the config directory "${configRoot}". ` +
+            `This will be blocked as an error in the next major release. ` +
+            `Move the file inside your config directory.`
+        );
+      }
+    }
+
     return {
       ...meta,
       body: loadFileAndReplaceKeywords(templateFilePath, {

--- a/src/context/directory/handlers/prompts.ts
+++ b/src/context/directory/handlers/prompts.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { ensureDirSync, writeFileSync } from 'fs-extra';
 import { constants, loadFileAndReplaceKeywords } from '../../../tools';
+import log from '../../../logger';
 import { getFiles, dumpJSON, existsMustBeDir, isFile, loadJSON } from '../../../utils';
 import { DirectoryHandler } from '.';
 import DirectoryContext from '..';
@@ -69,9 +70,20 @@ function parse(context: DirectoryContext): ParsedPrompts {
         (screenAcc, [screenName, items]) => {
           screenAcc[screenName as CustomPartialsScreenTypes] = items.reduce(
             (insertionAcc, { name, template }) => {
-              const templateFilePath = path.join(promptsDirectory, template);
-              insertionAcc[name] = isFile(templateFilePath)
-                ? loadFileAndReplaceKeywords(templateFilePath, {
+              const configRoot = path.resolve(context.filePath);
+              const resolvedTemplatePath = path.resolve(promptsDirectory, template);
+              if (
+                isFile(resolvedTemplatePath) &&
+                !resolvedTemplatePath.startsWith(configRoot + path.sep)
+              ) {
+                log.warn(
+                  `Prompt partial template "${template}" resolves to "${resolvedTemplatePath}" which is outside the config directory "${configRoot}". ` +
+                    `This will be blocked as an error in the next major release. ` +
+                    `Move the file inside your config directory.`
+                );
+              }
+              insertionAcc[name] = isFile(resolvedTemplatePath)
+                ? loadFileAndReplaceKeywords(resolvedTemplatePath, {
                     mappings: context.mappings,
                     disableKeywordReplacement: context.disableKeywordReplacement,
                   }).trim()

--- a/src/context/yaml/handlers/branding.ts
+++ b/src/context/yaml/handlers/branding.ts
@@ -35,9 +35,18 @@ async function parse(context: YAMLContext): Promise<ParsedBranding> {
     (templateDefinition: BrandingTemplate): BrandingTemplate => {
       const normalizedPathArray = nomalizedYAMLPath(templateDefinition.body);
       const markupFile = path.join(context.basePath, ...normalizedPathArray);
+      const configRoot = path.resolve(context.basePath);
+      const resolvedMarkupFile = path.resolve(markupFile);
+      if (!resolvedMarkupFile.startsWith(configRoot + path.sep)) {
+        log.warn(
+          `Branding template body path "${templateDefinition.body}" resolves to "${resolvedMarkupFile}" which is outside the config directory "${configRoot}". ` +
+            `This will be blocked as an error in the next major release. ` +
+            `Move the file inside your config directory.`
+        );
+      }
       return {
         template: templateDefinition.template,
-        body: loadFileAndReplaceKeywords(markupFile, {
+        body: loadFileAndReplaceKeywords(resolvedMarkupFile, {
           mappings: context.mappings,
           disableKeywordReplacement: context.disableKeywordReplacement,
         }),

--- a/src/context/yaml/handlers/clients.ts
+++ b/src/context/yaml/handlers/clients.ts
@@ -27,7 +27,12 @@ async function parse(context: YAMLContext): Promise<ParsedClients> {
           const htmlFileName = path.join(clientsFolder, client.custom_login_page);
 
           if (isFile(htmlFileName)) {
-            client.custom_login_page = context.loadFile(htmlFileName);
+            // Pass a path relative to basePath so context.loadFile() resolves it correctly.
+            // Passing htmlFileName (which already includes basePath) would cause double resolution
+            // when basePath is a relative path (e.g. when AUTH0_INPUT_FILE is a relative path).
+            client.custom_login_page = context.loadFile(
+              path.join(constants.CLIENTS_DIRECTORY, client.custom_login_page)
+            );
           }
         }
 

--- a/src/context/yaml/handlers/connections.ts
+++ b/src/context/yaml/handlers/connections.ts
@@ -38,7 +38,11 @@ async function parse(context: YAMLContext): Promise<ParsedConnections> {
             log.error(missingTemplateErrorMessage);
             throw new Error(missingTemplateErrorMessage);
           }
-          connection.options.email.body = context.loadFile(htmlFileName);
+          // Pass a path relative to basePath so context.loadFile() resolves it correctly.
+          // Passing htmlFileName (which already includes basePath) would cause double resolution.
+          connection.options.email.body = context.loadFile(
+            path.join(constants.CONNECTIONS_DIRECTORY, connection.options.email.body)
+          );
         }
 
         return connection;

--- a/src/context/yaml/handlers/flows.ts
+++ b/src/context/yaml/handlers/flows.ts
@@ -18,6 +18,15 @@ async function parse(context: YAMLContext): Promise<ParsedFlows> {
 
   const parsedFlows = flows.map((flow: Flow) => {
     const flowFile = path.join(context.basePath, flow.body);
+    const configRoot = path.resolve(context.basePath);
+    const resolvedFlowFile = path.resolve(flowFile);
+    if (!resolvedFlowFile.startsWith(configRoot + path.sep)) {
+      log.warn(
+        `Flow body file "${flow.body}" resolves to "${resolvedFlowFile}" which is outside the config directory "${configRoot}". ` +
+          `This will be blocked as an error in the next major release. ` +
+          `Move the file inside your config directory.`
+      );
+    }
 
     const parsedFlowBody = loadJSON(flowFile, {
       mappings: context.mappings,

--- a/src/context/yaml/handlers/forms.ts
+++ b/src/context/yaml/handlers/forms.ts
@@ -18,6 +18,15 @@ async function parse(context: YAMLContext): Promise<ParsedForms> {
 
   const parsedForms = forms.map((form: Form) => {
     const formFile = path.join(context.basePath, form.body);
+    const configRoot = path.resolve(context.basePath);
+    const resolvedFormFile = path.resolve(formFile);
+    if (!resolvedFormFile.startsWith(configRoot + path.sep)) {
+      log.warn(
+        `Form body file "${form.body}" resolves to "${resolvedFormFile}" which is outside the config directory "${configRoot}". ` +
+          `This will be blocked as an error in the next major release. ` +
+          `Move the file inside your config directory.`
+      );
+    }
 
     const parsedFormBody = loadJSON(formFile, {
       mappings: context.mappings,

--- a/src/context/yaml/handlers/prompts.ts
+++ b/src/context/yaml/handlers/prompts.ts
@@ -36,7 +36,15 @@ const loadScreenRenderers = (
       const filePath = fileName;
 
       try {
-        const rendererFile = path.join(context.basePath, filePath);
+        const configRoot = path.resolve(context.basePath);
+        const rendererFile = path.resolve(context.basePath, filePath);
+        if (!rendererFile.startsWith(configRoot + path.sep)) {
+          log.warn(
+            `Screen renderer file "${filePath}" resolves to "${rendererFile}" which is outside the config directory "${configRoot}". ` +
+              `This will be blocked as an error in the next major release. ` +
+              `Move the file inside your config directory.`
+          );
+        }
 
         const rendererData = loadJSON(rendererFile, {
           mappings: context.mappings,

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -64,14 +64,18 @@ const myOrganizationConfigurationSchema = {
       properties: {
         default_value: {
           type: 'string',
-          enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
+          enum: Object.values(
+            Management.ClientMyOrganizationConfigurationThirdPartyClientAccessDefaultValueEnum
+          ),
           description: 'The default third-party client access value.',
         },
         allowed_values: {
           type: 'array',
           items: {
             type: 'string',
-            enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
+            enum: Object.values(
+              Management.ClientMyOrganizationConfigurationThirdPartyClientAccessAllowedValuesEnum
+            ),
           },
           uniqueItems: true,
           description: 'The allowed third-party client access values.',

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -64,18 +64,14 @@ const myOrganizationConfigurationSchema = {
       properties: {
         default_value: {
           type: 'string',
-          enum: Object.values(
-            Management.ClientMyOrganizationConfigurationThirdPartyClientAccessDefaultValueEnum
-          ),
+          enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
           description: 'The default third-party client access value.',
         },
         allowed_values: {
           type: 'array',
           items: {
             type: 'string',
-            enum: Object.values(
-              Management.ClientMyOrganizationConfigurationThirdPartyClientAccessAllowedValuesEnum
-            ),
+            enum: Object.values(Management.OrganizationThirdPartyClientAccessEnum),
           },
           uniqueItems: true,
           description: 'The allowed third-party client access values.',

--- a/src/tools/auth0/handlers/connectionProfiles.ts
+++ b/src/tools/auth0/handlers/connectionProfiles.ts
@@ -49,14 +49,18 @@ export const schema = {
             properties: {
               default_value: {
                 type: 'string',
-                enum: Object.values(Management.ConnectionCrossAppAccessResourceAppStatusEnum),
+                enum: Object.values(
+                  Management.ConnectionProfileCrossAppAccessResourceAppStatusDefaultValueEnum
+                ),
                 description: 'The default Cross App Access resource app status.',
               },
               allowed_values: {
                 type: 'array',
                 items: {
                   type: 'string',
-                  enum: Object.values(Management.ConnectionCrossAppAccessResourceAppStatusEnum),
+                  enum: Object.values(
+                    Management.ConnectionProfileCrossAppAccessResourceAppStatusValueEnum
+                  ),
                 },
                 uniqueItems: true,
                 description: 'The allowed Cross App Access resource app status values.',

--- a/src/tools/auth0/handlers/connectionProfiles.ts
+++ b/src/tools/auth0/handlers/connectionProfiles.ts
@@ -49,18 +49,14 @@ export const schema = {
             properties: {
               default_value: {
                 type: 'string',
-                enum: Object.values(
-                  Management.ConnectionProfileCrossAppAccessResourceAppStatusDefaultValueEnum
-                ),
+                enum: Object.values(Management.ConnectionCrossAppAccessResourceAppStatusEnum),
                 description: 'The default Cross App Access resource app status.',
               },
               allowed_values: {
                 type: 'array',
                 items: {
                   type: 'string',
-                  enum: Object.values(
-                    Management.ConnectionProfileCrossAppAccessResourceAppStatusValueEnum
-                  ),
+                  enum: Object.values(Management.ConnectionCrossAppAccessResourceAppStatusEnum),
                 },
                 uniqueItems: true,
                 description: 'The allowed Cross App Access resource app status values.',

--- a/test/context/directory/branding.test.js
+++ b/test/context/directory/branding.test.js
@@ -1,10 +1,12 @@
 import path from 'path';
 import { expect } from 'chai';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/branding';
 import { constants } from '../../../src/tools';
 import { loadJSON } from '../../../src/utils';
+import log from '../../../src/logger';
 import { cleanThenMkdir, mockMgmtClient, testDataDir } from '../../utils';
 
 const html = '<html>##foo##</html>';
@@ -91,6 +93,39 @@ describe('#directory context branding', () => {
     await context.loadAssetsFromLocal();
 
     expect(context.assets.branding).to.deep.equal(JSON.parse(brandingSettings));
+  });
+
+  it('should warn when branding template body path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'directory', 'branding-traversal-warn');
+    cleanThenMkdir(dir);
+    const brandingDir = path.join(dir, constants.BRANDING_DIRECTORY);
+    cleanThenMkdir(brandingDir);
+    const brandingTemplatesDir = path.join(brandingDir, constants.BRANDING_TEMPLATES_DIRECTORY);
+    cleanThenMkdir(brandingTemplatesDir);
+
+    // "../../../outside-branding.html" from inside branding/templates/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'directory', 'outside-branding.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    fs.writeFileSync(
+      path.join(brandingTemplatesDir, 'universal_login.json'),
+      JSON.stringify({ template: 'universal_login', body: '../../../outside-branding.html' })
+    );
+
+    const config = { AUTH0_INPUT_FILE: dir };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should dump branding settings, including templates', async () => {

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -1,8 +1,10 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 
 import { expect } from 'chai';
 import { constants } from '../../../src/tools';
+import log from '../../../src/logger';
 
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/clients';
@@ -413,6 +415,36 @@ describe('#directory context clients', () => {
       { app_type: 'spa', name: 'simpleClient' },
     ];
     expect(context.assets.clients).to.deep.equal(target);
+  });
+
+  it('should warn when custom_login_page path resolves outside the config directory', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'clients-traversal-warn');
+    // "../../outside-login.html" from inside clients/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'directory', 'outside-login.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const files = {
+      [constants.CLIENTS_DIRECTORY]: {
+        'traversalClient.json':
+          '{ "name": "traversalClient", "custom_login_page": "../../outside-login.html" }',
+      },
+    };
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should dump clients with oidc_logout', async () => {

--- a/test/context/directory/connections.test.js
+++ b/test/context/directory/connections.test.js
@@ -1,8 +1,10 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 
 import { expect } from 'chai';
 import { constants } from '../../../src/tools';
+import log from '../../../src/logger';
 
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/connections';
@@ -249,6 +251,36 @@ describe('#directory context connections', () => {
         'email.html'
       )} does not exist for connection. Ensure the existence of this file to proceed with deployment.`
     );
+  });
+
+  it('should warn when email body path resolves outside the config directory', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'connections-traversal-warn');
+    // "../../outside-email.html" from inside connections/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'directory', 'outside-email.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const files = {
+      [constants.CONNECTIONS_DIRECTORY]: {
+        'email.json':
+          '{ "name": "email", "strategy": "email", "options": { "email": { "body": "../../outside-email.html" } } }',
+      },
+    };
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should not dump excluded connections', async () => {

--- a/test/context/directory/emailTemplates.test.js
+++ b/test/context/directory/emailTemplates.test.js
@@ -1,7 +1,9 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { constants } from '../../../src/tools';
+import log from '../../../src/logger';
 
 import Context from '../../../src/context/directory';
 import handler from '../../../src/context/directory/handlers/emailTemplates';
@@ -85,6 +87,36 @@ describe('#directory context email templates', () => {
     await expect(context.loadAssetsFromLocal())
       .to.be.eventually.rejectedWith(Error)
       .and.have.property('message', errorMessage);
+  });
+
+  it('should warn when email template body path resolves outside the config directory', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'emailTemplates-traversal-warn');
+    // "../../outside-email.html.liquid" from inside emails/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'directory', 'outside-email.html.liquid');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const files = {
+      [constants.EMAIL_TEMPLATES_DIRECTORY]: {
+        'verify_email.json':
+          '{ "template": "verify_email", "enabled": true, "from": "test@test.com", "body": "../../outside-email.html.liquid" }',
+      },
+    };
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should dump email templates', async () => {

--- a/test/context/directory/prompts.test.ts
+++ b/test/context/directory/prompts.test.ts
@@ -1,6 +1,9 @@
 import path from 'path';
+import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { constants } from '../../../src/tools';
+import log from '../../../src/logger';
 
 import Context from '../../../src/context/directory';
 import promptsHandler from '../../../src/context/directory/handlers/prompts';
@@ -715,5 +718,45 @@ describe('#directory context prompts', () => {
         },
       ],
     });
+  });
+
+  it('should warn when prompt partial template path resolves outside the config directory', async () => {
+    const repoDir = path.join(testDataDir, 'directory', 'prompts-traversal-warn');
+    // "../../outside-partial.liquid" from inside prompts/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'directory', 'outside-partial.liquid');
+    fs.writeFileSync(outsideFile, '<div>outside content</div>');
+
+    const files = {
+      [constants.PROMPTS_DIRECTORY]: {
+        'partials.json': JSON.stringify({
+          login: [
+            {
+              login: [
+                {
+                  name: 'form-content-start',
+                  template: '../../outside-partial.liquid',
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    };
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir };
+    const context = new Context(config, mockMgmtClient());
+    if ((log.warn as any).restore) (log.warn as any).restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        (msg as string).includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 });

--- a/test/context/yaml/branding.test.js
+++ b/test/context/yaml/branding.test.js
@@ -1,9 +1,11 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import Context from '../../../src/context/yaml';
 import handler from '../../../src/context/yaml/handlers/branding';
+import log from '../../../src/logger';
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
 
 const html = '<html>##foo##</html>';
@@ -48,6 +50,40 @@ describe('#YAML context branding templates', () => {
         },
       ],
     });
+  });
+
+  it('should warn when branding template body path resolves outside the config directory', async () => {
+    const baseDir = path.join(testDataDir, 'yaml', 'branding-traversal-warn');
+    const dir = path.join(baseDir, 'branding_templates');
+    cleanThenMkdir(dir);
+
+    // "../outside-branding.html" from inside branding_templates/ escapes the config root (dir).
+    const outsideFile = path.join(baseDir, 'outside-branding.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const yaml = `
+    branding:
+      templates:
+        - template: universal_login
+          body: ../outside-branding.html
+    `;
+    const yamlFile = path.join(dir, 'config.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should dump branding settings, including templates', async () => {

--- a/test/context/yaml/clients.test.js
+++ b/test/context/yaml/clients.test.js
@@ -1,9 +1,11 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import Context from '../../../src/context/yaml';
 import handler from '../../../src/context/yaml/handlers/clients';
+import log from '../../../src/logger';
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
 
 describe('#YAML context clients', () => {
@@ -68,6 +70,72 @@ describe('#YAML context clients', () => {
     await context.loadAssetsFromLocal();
 
     expect(context.assets.clients).to.deep.equal(target);
+  });
+
+  it('should correctly load custom_login_page when AUTH0_INPUT_FILE is a relative path (regression #1475)', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'clients-relative');
+    cleanThenMkdir(dir);
+
+    const yaml = `
+    clients:
+      - name: "customLoginClient"
+        app_type: "spa"
+        custom_login_page: "./customLoginClient_custom_login_page.html"
+    `;
+
+    const yamlFile = path.join(dir, 'clients.yaml');
+    const clientsPath = path.join(dir, 'clients');
+    fs.writeFileSync(yamlFile, yaml);
+    fs.ensureDirSync(clientsPath);
+    fs.writeFileSync(
+      path.join(clientsPath, 'customLoginClient_custom_login_page.html'),
+      'html code'
+    );
+
+    // Use a relative AUTH0_INPUT_FILE to trigger the double-resolution bug in the old code.
+    const relativeYamlFile = path.relative(process.cwd(), yamlFile);
+    const config = { AUTH0_INPUT_FILE: relativeYamlFile };
+    const context = new Context(config, mockMgmtClient());
+    await context.loadAssetsFromLocal();
+
+    const client = context.assets.clients.find((c) => c.name === 'customLoginClient');
+    expect(client.custom_login_page).to.equal('html code');
+  });
+
+  it('should warn when custom_login_page path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'clients-traversal-warn');
+    cleanThenMkdir(dir);
+
+    // "../../outside-login.html" from inside clients/ escapes the config root.
+    const outsideFile = path.join(testDataDir, 'yaml', 'outside-login.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const yaml = `
+    clients:
+      - name: "traversalClient"
+        app_type: "spa"
+        custom_login_page: "../../outside-login.html"
+    `;
+
+    const yamlFile = path.join(dir, 'clients.yaml');
+    const clientsPath = path.join(dir, 'clients');
+    fs.writeFileSync(yamlFile, yaml);
+    fs.ensureDirSync(clientsPath);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should dump clients', async () => {

--- a/test/context/yaml/connections.test.js
+++ b/test/context/yaml/connections.test.js
@@ -1,9 +1,11 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import Context from '../../../src/context/yaml';
 import handler from '../../../src/context/yaml/handlers/connections';
+import log from '../../../src/logger';
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
 
 describe('#YAML context connections', () => {
@@ -277,6 +279,76 @@ describe('#YAML context connections', () => {
     expect(fs.readFileSync(path.join(templatesFolder, 'email.html'), 'utf8')).to.deep.equal(
       'html code'
     );
+  });
+
+  it('should correctly load email body when AUTH0_INPUT_FILE is a relative path (regression #1475)', async () => {
+    // Reproduces the bug where context.loadFile() double-resolved the path when
+    // basePath was relative, causing ENOENT on "basePath/basePath/connections/email.html".
+    const dir = path.join(testDataDir, 'yaml', 'connections-relative-path');
+    cleanThenMkdir(dir);
+
+    const yaml = `
+    connections:
+      - name: "email"
+        strategy: "email"
+        options:
+          email:
+            body: "./email.html"
+    `;
+
+    const yamlFile = path.join(dir, 'tenant.yaml');
+    const connectionsPath = path.join(dir, 'connections');
+    fs.writeFileSync(yamlFile, yaml);
+    fs.ensureDirSync(connectionsPath);
+    fs.writeFileSync(path.join(connectionsPath, 'email.html'), 'html body content');
+
+    // Use a relative path for AUTH0_INPUT_FILE — this is exactly the scenario that
+    // triggered the regression. path.dirname of a relative file is itself relative,
+    // and the old code would then path.resolve(relativeBasePath, alreadyRelativeFullPath).
+    const relativeYamlFile = path.relative(process.cwd(), yamlFile);
+    const config = { AUTH0_INPUT_FILE: relativeYamlFile };
+    const context = new Context(config, mockMgmtClient());
+    await context.loadAssetsFromLocal();
+
+    expect(context.assets.connections[0].options.email.body).to.equal('html body content');
+  });
+
+  it('should warn when email body path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'connections-traversal-warn');
+    cleanThenMkdir(dir);
+
+    // Place the target file one level above the config root so the traversal path
+    // "../../outside-email.html" (from inside connections/) escapes the config dir.
+    const outsideFile = path.join(testDataDir, 'yaml', 'outside-email.html');
+    fs.writeFileSync(outsideFile, 'outside content');
+
+    const yaml = `
+    connections:
+      - name: "email"
+        strategy: "email"
+        options:
+          email:
+            body: "../../outside-email.html"
+    `;
+
+    const yamlFile = path.join(dir, 'tenant.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+    fs.ensureDirSync(path.join(dir, 'connections'));
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    if (log.warn.restore) log.warn.restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        msg.includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 
   it('should not dump excluded connections', async () => {

--- a/test/context/yaml/flows.test.js
+++ b/test/context/yaml/flows.test.js
@@ -1,12 +1,18 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Context from '../../../src/context/yaml';
 import handler from '../../../src/context/yaml/handlers/flows';
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
+import log from '../../../src/logger';
 
 describe('#YAML context flows', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should process flows', async () => {
     const dir = path.join(testDataDir, 'yaml', 'flows');
     cleanThenMkdir(dir);
@@ -37,6 +43,36 @@ describe('#YAML context flows', () => {
     await context.loadAssetsFromLocal();
 
     expect(context.assets.flows).to.deep.equal(target);
+  });
+
+  it('should warn when flow body path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'flows');
+    cleanThenMkdir(dir);
+
+    const outsideFile = path.join(testDataDir, 'outside-flow.json');
+    fs.writeFileSync(outsideFile, '{"name": "outside flow"}');
+
+    const yaml = `
+    flows:
+      -
+        name: "Outside Flow"
+        body: ../../outside-flow.json
+    `;
+
+    const yamlFile = path.join(dir, 'flows.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+
+    const warnSpy = sinon.spy(log, 'warn');
+    await context.loadAssetsFromLocal();
+
+    expect(warnSpy.args.some(([msg]) => msg.includes('will be blocked as an error'))).to.equal(
+      true
+    );
+
+    fs.removeSync(outsideFile);
   });
 
   it('should dump flows', async () => {

--- a/test/context/yaml/forms.test.js
+++ b/test/context/yaml/forms.test.js
@@ -1,12 +1,18 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Context from '../../../src/context/yaml';
 import handler from '../../../src/context/yaml/handlers/forms';
 import { cleanThenMkdir, testDataDir, mockMgmtClient } from '../../utils';
+import log from '../../../src/logger';
 
 describe('#YAML context forms', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should process forms', async () => {
     const dir = path.join(testDataDir, 'yaml', 'forms');
     cleanThenMkdir(dir);
@@ -37,6 +43,36 @@ describe('#YAML context forms', () => {
     await context.loadAssetsFromLocal();
 
     expect(context.assets.forms).to.deep.equal(target);
+  });
+
+  it('should warn when form body path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'forms');
+    cleanThenMkdir(dir);
+
+    const outsideFile = path.join(testDataDir, 'outside-form.json');
+    fs.writeFileSync(outsideFile, '{"name": "outside form"}');
+
+    const yaml = `
+    forms:
+      -
+        name: "Outside Form"
+        body: ../../outside-form.json
+    `;
+
+    const yamlFile = path.join(dir, 'forms.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+
+    const warnSpy = sinon.spy(log, 'warn');
+    await context.loadAssetsFromLocal();
+
+    expect(warnSpy.args.some(([msg]) => msg.includes('will be blocked as an error'))).to.equal(
+      true
+    );
+
+    fs.removeSync(outsideFile);
   });
 
   it('should dump forms', async () => {

--- a/test/context/yaml/prompts.test.ts
+++ b/test/context/yaml/prompts.test.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs-extra';
+import sinon from 'sinon';
 import { expect } from 'chai';
+import log from '../../../src/logger';
 
 import Context from '../../../src/context/yaml';
 import promptsHandler from '../../../src/context/yaml/handlers/prompts';
@@ -409,5 +411,40 @@ describe('#YAML context prompts', () => {
       },
       use_page_template: true,
     });
+  });
+
+  it('should warn when screen renderer file path resolves outside the config directory', async () => {
+    const dir = path.join(testDataDir, 'yaml', 'prompts-traversal-warn');
+    cleanThenMkdir(dir);
+
+    // "../../outside-renderer.json" from basePath escapes the config root.
+    const outsideFile = path.join(testDataDir, 'outside-renderer.json');
+    fs.writeFileSync(outsideFile, JSON.stringify({ test: 'outside' }));
+
+    const yaml = `
+      prompts:
+        identifier_first: true
+        screenRenderers:
+          - login:
+              login-id: ../../outside-renderer.json
+    `;
+
+    const yamlFile = path.join(dir, 'config.yaml');
+    fs.writeFileSync(yamlFile, yaml);
+
+    const config = { AUTH0_INPUT_FILE: yamlFile };
+    const context = new Context(config, mockMgmtClient());
+    if ((log.warn as any).restore) (log.warn as any).restore();
+    const warnSpy = sinon.spy(log, 'warn');
+    try {
+      await context.loadAssetsFromLocal();
+      const traversalWarned = warnSpy.args.some(([msg]) =>
+        (msg as string).includes('will be blocked as an error')
+      );
+      expect(traversalWarned).to.be.true;
+    } finally {
+      warnSpy.restore();
+      fs.removeSync(outsideFile);
+    }
   });
 });


### PR DESCRIPTION
### 🔧 Changes

**Fix: double-path resolution in `yaml/handlers/connections.ts` (fixes #1475)**

When `--input_file` was passed as a relative path, the yaml connections handler built `htmlFileName` by joining `basePath + '/connections' + body`, then passed that already-fully-joined path to `context.loadFile()`, which
resolved it *again* relative to `basePath` — resulting in a doubled path and an ENOENT error. Fixed by passing only the `connections/`-relative portion to `context.loadFile()` so resolution happens exactly once.

**Fix: path traversal warning across all file-loading handlers**

  Handlers that load user-controlled file paths (e.g. `body`, `custom_login_page`,`template`) could be pointed at files   outside the config root via `../` sequences. Added containment checks to all handlers that load user-specified file paths from config in both the `yaml` and `directory` context loaders:

  - `yaml/handlers/connections.ts` - inherits check via `context.loadFile()`
  - `yaml/handlers/clients.ts` - inherits check via `context.loadFile()`
  - `yaml/handlers/branding.ts` - explicit check before `loadFileAndReplaceKeywords`
  - `yaml/handlers/prompts.ts` - explicit check for screen renderer file paths
  - `directory/handlers/clients.ts` - explicit check for `custom_login_page`
  - `directory/handlers/connections.ts` - explicit check for email `body`
  - `directory/handlers/emailTemplates.ts` - explicit check for template body
  - `directory/handlers/branding.ts` - explicit check for template body
  - `directory/handlers/prompts.ts` - explicit check for partial template paths

In v8.x, a `warn` is emitted and the file is still loaded (backward-compatible). The path will be **blocked as an error** in the next major release.
  
### 📚 References

- Fixes #1475

### 🔬 Testing

Unit tests added for every handler listed above, covering both the traversal warning path (path resolves outside config root) and the happy path (path inside config root, no warning).

End-to-end tested against a real Auth0 tenant using `node lib/index.js import`:

  1. **Issue #1475 regression**: relative `--input_file` path with a normal `body: "./email.html"` - `Import Successful`, no ENOENT, no spurious warning.
  2. **Traversal warning**: `body: "../../outside-email.html"` - warning fires  (`will be blocked as an error in the next major release`), import still succeeds with file loaded (v8.x warning-only behavior).

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
