### PR TITLE
fix: prevent false enabled_clients diff in database dry-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Makefile
 .github/skills/*
 package-lock.json
 .github/hooks/*
+.DS_Store

--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -605,6 +605,22 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       }),
     ]);
 
+    // `enabled_clients` is no longer returned by connections.list; it must be fetched from the
+    // dedicated enabled-clients endpoint. Without this enrichment the remote connection lacks the
+    // field entirely, so the dry-run diff reports a false "found in localObj but not in remoteObj".
+    const existingWithEnabledClients = await Promise.all(
+      existingDatabasesConnections.map(async (con) => {
+        if (!con?.id) return con;
+
+        const enabledClients = await getConnectionEnabledClients(this.client, con.id);
+        if (enabledClients && enabledClients.length) {
+          return { ...con, enabled_clients: enabledClients };
+        }
+
+        return con;
+      })
+    );
+
     const formatted = databases.map((db) => {
       const { options, ...rest } = db;
       const formattedOptions = this.getFormattedOptions(options, actions);
@@ -614,7 +630,7 @@ export default class DatabaseHandler extends DefaultAPIHandler {
         formattedDb.enabled_clients = getEnabledClients(
           assets,
           db,
-          existingDatabasesConnections,
+          existingWithEnabledClients,
           clients
         );
       }
@@ -625,7 +641,7 @@ export default class DatabaseHandler extends DefaultAPIHandler {
     return calculateDryRunChanges({
       type: this.type,
       assets: formatted,
-      existing: existingDatabasesConnections,
+      existing: existingWithEnabledClients,
       identifiers: this.identifiers,
       ignoreDryRunFields: this.getEffectiveIgnoreDryRunFields(),
     });

--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -447,6 +447,28 @@ export default class DatabaseHandler extends DefaultAPIHandler {
     return this.client.connections[fn].bind(this.client.connections);
   }
 
+  // `enabled_clients` is no longer returned by connections.list; it must be fetched from the
+  // dedicated enabled-clients endpoint. Enriching the remote connections keeps the diff and the
+  // excluded-client preservation in `getEnabledClients` correct. Without it the dry-run diff
+  // reports a false "found in localObj but not in remoteObj" and a real import can silently
+  // disable an excluded-but-enabled client.
+  private async enrichConnectionsWithEnabledClients(
+    connections: Connection[]
+  ): Promise<Connection[]> {
+    return Promise.all(
+      connections.map(async (con) => {
+        if (!con?.id) return con;
+
+        const enabledClients = await getConnectionEnabledClients(this.client, con.id);
+        if (enabledClients?.length) {
+          return { ...con, enabled_clients: enabledClients };
+        }
+
+        return con;
+      })
+    );
+  }
+
   async getType() {
     if (this.existing) return this.existing;
 
@@ -462,19 +484,8 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       }),
     ]);
 
-    const dbConnectionsWithEnabledClients = await Promise.all(
-      connections.map(async (con) => {
-        if (!con?.id) return con;
-
-        const enabledClients = await getConnectionEnabledClients(this.client, con.id);
-        const connection = { ...con };
-
-        if (enabledClients && enabledClients?.length) {
-          connection.enabled_clients = enabledClients;
-        }
-
-        return connection;
-      })
+    const dbConnectionsWithEnabledClients = await this.enrichConnectionsWithEnabledClients(
+      connections
     );
 
     // Convert action ID back to action name for export
@@ -541,22 +552,21 @@ export default class DatabaseHandler extends DefaultAPIHandler {
         conflicts: [],
       };
 
-    // Convert enabled_clients by name to the id
-    // Fetch clients, connections, and actions concurrently
-    const [clients, existingDatabasesConnections, actions] = await Promise.all([
+    // Convert enabled_clients by name to the id. `getType()` fetches and enriches the existing
+    // connections with `enabled_clients` and caches the result in `this.existing`, so the
+    // `super.calcChanges()` call below reuses it instead of fetching again.
+    const [clients, actions, existingWithEnabledClients] = await Promise.all([
       paginate<Client>(this.client.clients.list, {
         paginate: true,
-      }),
-      paginate<Connection>(this.client.connections.list, {
-        strategy: [Management.ConnectionStrategyEnum.Auth0],
-        checkpoint: true,
-        include_totals: true,
       }),
       paginate<Action>(this.client.actions.list, {
         paginate: true,
         include_totals: true,
       }),
+      this.getType(),
     ]);
+
+    const existingConnections = (existingWithEnabledClients as Connection[]) || [];
 
     const formatted = databases.map((db) => {
       const { options, ...rest } = db;
@@ -564,12 +574,7 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       const formattedDb: any = { ...rest, options: formattedOptions };
 
       if (db.enabled_clients) {
-        formattedDb.enabled_clients = getEnabledClients(
-          assets,
-          db,
-          existingDatabasesConnections,
-          clients
-        );
+        formattedDb.enabled_clients = getEnabledClients(assets, db, existingConnections, clients);
       }
 
       return formattedDb;
@@ -605,20 +610,8 @@ export default class DatabaseHandler extends DefaultAPIHandler {
       }),
     ]);
 
-    // `enabled_clients` is no longer returned by connections.list; it must be fetched from the
-    // dedicated enabled-clients endpoint. Without this enrichment the remote connection lacks the
-    // field entirely, so the dry-run diff reports a false "found in localObj but not in remoteObj".
-    const existingWithEnabledClients = await Promise.all(
-      existingDatabasesConnections.map(async (con) => {
-        if (!con?.id) return con;
-
-        const enabledClients = await getConnectionEnabledClients(this.client, con.id);
-        if (enabledClients && enabledClients.length) {
-          return { ...con, enabled_clients: enabledClients };
-        }
-
-        return con;
-      })
+    const existingWithEnabledClients = await this.enrichConnectionsWithEnabledClients(
+      existingDatabasesConnections
     );
 
     const formatted = databases.map((db) => {

--- a/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
+++ b/test/e2e/recordings/should-deploy-while-deleting-resources-if-AUTH0_ALLOW_DELETE-is-true.json
@@ -36,7 +36,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 9,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -122,7 +122,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+                    "client_id": "e3IwJYpmY17X5sgtIlwqtjccPKIOAa9N",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -134,448 +134,12 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                    "callback_url_template": false,
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
                 }
             ]
         },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k/credentials",
-        "body": "",
-        "status": 200,
-        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -1936,7 +1500,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "total": 9,
+            "total": 2,
             "start": 0,
             "limit": 100,
             "clients": [
@@ -2022,7 +1586,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+                    "client_id": "e3IwJYpmY17X5sgtIlwqtjccPKIOAa9N",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -2034,382 +1598,6 @@
                         "authorization_code",
                         "implicit",
                         "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "API Explorer Application",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Node App",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                    "callback_url_template": false,
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "app_type": "regular_web",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "web_origins": [],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Quickstarts API (Test Application)",
-                    "client_metadata": {
-                        "foo": "bar"
-                    },
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Terraform Provider",
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "The Default App",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": false,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso": false,
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token",
-                        "client_credentials"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "Test SPA",
-                    "allowed_clients": [],
-                    "allowed_logout_urls": [
-                        "http://localhost:3000"
-                    ],
-                    "callbacks": [
-                        "http://localhost:3000"
-                    ],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "expiring",
-                        "leeway": 0,
-                        "token_lifetime": 2592000,
-                        "idle_token_lifetime": 1296000,
-                        "infinite_token_lifetime": false,
-                        "infinite_idle_token_lifetime": false,
-                        "rotation_type": "rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "none",
-                    "app_type": "spa",
-                    "grant_types": [
-                        "authorization_code",
-                        "implicit",
-                        "refresh_token"
-                    ],
-                    "web_origins": [
-                        "http://localhost:3000"
-                    ],
-                    "custom_login_page_on": true
-                },
-                {
-                    "tenant": "auth0-deploy-cli-e2e",
-                    "global": false,
-                    "is_token_endpoint_ip_header_trusted": false,
-                    "name": "auth0-deploy-cli-extension",
-                    "allowed_clients": [],
-                    "callbacks": [],
-                    "client_metadata": {},
-                    "cross_origin_authentication": false,
-                    "is_first_party": true,
-                    "native_social_login": {
-                        "apple": {
-                            "enabled": false
-                        },
-                        "facebook": {
-                            "enabled": false
-                        }
-                    },
-                    "oidc_conformant": true,
-                    "refresh_token": {
-                        "expiration_type": "non-expiring",
-                        "leeway": 0,
-                        "infinite_token_lifetime": true,
-                        "infinite_idle_token_lifetime": true,
-                        "token_lifetime": 31557600,
-                        "idle_token_lifetime": 2592000,
-                        "rotation_type": "non-rotating"
-                    },
-                    "sso_disabled": false,
-                    "cross_origin_auth": false,
-                    "signing_keys": [
-                        {
-                            "cert": "[REDACTED]",
-                            "pkcs7": "[REDACTED]",
-                            "subject": "deprecated"
-                        }
-                    ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
-                    "callback_url_template": false,
-                    "client_secret": "[REDACTED]",
-                    "jwt_configuration": {
-                        "alg": "RS256",
-                        "lifetime_in_seconds": 36000,
-                        "secret_encoded": false
-                    },
-                    "client_aliases": [],
-                    "token_endpoint_auth_method": "client_secret_post",
-                    "app_type": "non_interactive",
-                    "grant_types": [
                         "client_credentials"
                     ],
                     "custom_login_page_on": true
@@ -2421,28 +1609,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
-        "body": "",
-        "status": 200,
-        "response": [
-            {
-                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
-                "credential_type": "public_key",
-                "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
-                "alg": "RS256",
-                "name": "e2e-test-key",
-                "created_at": "2026-08-10T13:55:22.110Z",
-                "updated_at": "2026-08-10T13:55:22.110Z"
-            }
-        ],
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/4KWdBigdmxBionUsdewvtlj7npUfWHTA",
+        "path": "/api/v2/clients/e3IwJYpmY17X5sgtIlwqtjccPKIOAa9N",
         "body": "",
         "status": 204,
         "response": "",
@@ -2451,8 +1619,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "API Explorer Application",
             "allowed_clients": [],
@@ -2469,7 +1637,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -2492,7 +1661,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -2523,14 +1692,16 @@
             },
             "sso_disabled": false,
             "cross_origin_auth": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+            "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2551,8 +1722,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Node App",
             "allowed_clients": [],
@@ -2574,7 +1745,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -2597,7 +1769,7 @@
             "sso_disabled": false,
             "web_origins": []
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -2629,25 +1801,19 @@
             },
             "sso_disabled": false,
             "cross_origin_auth": false,
-            "client_authentication_methods": {
-                "private_key_jwt": {
-                    "credentials": [
-                        {
-                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                        }
-                    ]
-                }
-            },
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
             "allowed_origins": [],
-            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+            "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
             "callback_url_template": false,
+            "client_secret": "[REDACTED]",
             "jwt_configuration": {
                 "alg": "RS256",
                 "lifetime_in_seconds": 36000,
@@ -2669,8 +1835,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Quickstarts API (Test Application)",
             "app_type": "non_interactive",
@@ -2686,7 +1852,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "oidc_conformant": true,
             "refresh_token": {
@@ -2701,7 +1868,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -2724,14 +1891,16 @@
             },
             "sso_disabled": false,
             "cross_origin_auth": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+            "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -2751,190 +1920,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
-        "body": {
-            "name": "Terraform Provider",
-            "app_type": "non_interactive",
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "Terraform Provider",
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "oidc_conformant": true,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 31557600,
-                "idle_token_lifetime": 2592000,
-                "rotation_type": "non-rotating"
-            },
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "token_endpoint_auth_method": "client_secret_post",
-            "app_type": "non_interactive",
-            "grant_types": [
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-        "body": {
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_aliases": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "custom_login_page_on": true,
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "is_first_party": true,
-            "is_token_endpoint_ip_header_trusted": false,
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000
-            },
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "token_endpoint_auth_method": "client_secret_post"
-        },
-        "status": 200,
-        "response": {
-            "tenant": "auth0-deploy-cli-e2e",
-            "global": false,
-            "is_token_endpoint_ip_header_trusted": false,
-            "name": "The Default App",
-            "allowed_clients": [],
-            "callbacks": [],
-            "client_metadata": {},
-            "cross_origin_authentication": false,
-            "is_first_party": true,
-            "native_social_login": {
-                "apple": {
-                    "enabled": false
-                },
-                "facebook": {
-                    "enabled": false
-                }
-            },
-            "oidc_conformant": false,
-            "refresh_token": {
-                "expiration_type": "non-expiring",
-                "leeway": 0,
-                "infinite_token_lifetime": true,
-                "infinite_idle_token_lifetime": true,
-                "token_lifetime": 2592000,
-                "idle_token_lifetime": 1296000,
-                "rotation_type": "non-rotating"
-            },
-            "sso": false,
-            "sso_disabled": false,
-            "cross_origin_auth": false,
-            "signing_keys": [
-                {
-                    "cert": "[REDACTED]",
-                    "pkcs7": "[REDACTED]",
-                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
-                }
-            ],
-            "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-            "callback_url_template": false,
-            "client_secret": "[REDACTED]",
-            "jwt_configuration": {
-                "alg": "RS256",
-                "lifetime_in_seconds": 36000,
-                "secret_encoded": false
-            },
-            "client_aliases": [],
-            "token_endpoint_auth_method": "client_secret_post",
-            "grant_types": [
-                "authorization_code",
-                "implicit",
-                "refresh_token",
-                "client_credentials"
-            ],
-            "custom_login_page_on": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "Test SPA",
             "allowed_clients": [],
@@ -2958,7 +1945,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -2984,7 +1972,7 @@
                 "http://localhost:3000"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -3020,14 +2008,16 @@
             },
             "sso_disabled": false,
             "cross_origin_auth": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+            "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3053,8 +2043,196 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "Terraform Provider",
+            "app_type": "non_interactive",
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "Terraform Provider",
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "oidc_conformant": true,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 31557600,
+                "idle_token_lifetime": 2592000,
+                "rotation_type": "non-rotating"
+            },
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "token_endpoint_auth_method": "client_secret_post",
+            "app_type": "non_interactive",
+            "grant_types": [
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
+        "body": {
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_aliases": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "custom_login_page_on": true,
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "is_first_party": true,
+            "is_token_endpoint_ip_header_trusted": false,
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "token_endpoint_auth_method": "client_secret_post"
+        },
+        "status": 201,
+        "response": {
+            "tenant": "auth0-deploy-cli-e2e",
+            "global": false,
+            "is_token_endpoint_ip_header_trusted": false,
+            "name": "The Default App",
+            "allowed_clients": [],
+            "callbacks": [],
+            "client_metadata": {},
+            "cross_origin_authentication": false,
+            "is_first_party": true,
+            "native_social_login": {
+                "apple": {
+                    "enabled": false
+                },
+                "facebook": {
+                    "enabled": false
+                }
+            },
+            "oidc_conformant": false,
+            "refresh_token": {
+                "expiration_type": "non-expiring",
+                "leeway": 0,
+                "infinite_token_lifetime": true,
+                "infinite_idle_token_lifetime": true,
+                "token_lifetime": 2592000,
+                "idle_token_lifetime": 1296000,
+                "rotation_type": "non-rotating"
+            },
+            "sso": false,
+            "sso_disabled": false,
+            "cross_origin_auth": false,
+            "encrypted": true,
+            "signing_keys": [
+                {
+                    "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
+                    "pkcs7": "[REDACTED]",
+                    "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
+                }
+            ],
+            "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
+            "callback_url_template": false,
+            "client_secret": "[REDACTED]",
+            "jwt_configuration": {
+                "alg": "RS256",
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
+            },
+            "client_aliases": [],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": [
+                "authorization_code",
+                "implicit",
+                "refresh_token",
+                "client_credentials"
+            ],
+            "custom_login_page_on": true
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients",
         "body": {
             "name": "auth0-deploy-cli-extension",
             "allowed_clients": [],
@@ -3071,7 +2249,8 @@
             "is_token_endpoint_ip_header_trusted": false,
             "jwt_configuration": {
                 "alg": "RS256",
-                "lifetime_in_seconds": 36000
+                "lifetime_in_seconds": 36000,
+                "secret_encoded": false
             },
             "native_social_login": {
                 "apple": {
@@ -3094,7 +2273,7 @@
             "sso_disabled": false,
             "token_endpoint_auth_method": "client_secret_post"
         },
-        "status": 200,
+        "status": 201,
         "response": {
             "tenant": "auth0-deploy-cli-e2e",
             "global": false,
@@ -3125,14 +2304,16 @@
             },
             "sso_disabled": false,
             "cross_origin_auth": false,
+            "encrypted": true,
             "signing_keys": [
                 {
                     "cert": "[REDACTED]",
+                    "key": "[REDACTED]",
                     "pkcs7": "[REDACTED]",
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+            "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -3154,7 +2335,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -3182,13 +2363,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
-            "enabled": true
+            "enabled": false
         },
         "status": 200,
         "response": {
-            "enabled": true
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3238,13 +2419,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
-            "enabled": false
+            "enabled": true
         },
         "status": 200,
         "response": {
-            "enabled": false
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3252,7 +2433,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -3327,36 +2508,9 @@
                 "user_notification"
             ],
             "mode": "count_per_identifier_and_ip",
+            "form_submission_behavior": "auto_submit",
             "allowlist": [],
             "max_attempts": 66
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/attack-protection/breached-password-detection",
-        "body": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard"
-        },
-        "status": 200,
-        "response": {
-            "enabled": false,
-            "shields": [],
-            "admin_notification_frequency": [],
-            "method": "standard",
-            "stage": {
-                "pre-user-registration": {
-                    "shields": []
-                },
-                "pre-change-password": {
-                    "shields": []
-                }
-            }
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3413,6 +2567,34 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/attack-protection/breached-password-detection",
+        "body": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard"
+        },
+        "status": 200,
+        "response": {
+            "enabled": false,
+            "shields": [],
+            "admin_notification_frequency": [],
+            "method": "standard",
+            "stage": {
+                "pre-user-registration": {
+                    "shields": []
+                },
+                "pre-change-password": {
+                    "shields": []
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/network-acls?page=0&per_page=100&include_totals=true",
         "body": "",
@@ -3438,7 +2620,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-08-10T13:55:03.319Z",
+                    "updated_at": "2026-08-12T09:59:29.652Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -3483,7 +2665,7 @@
                 }
             },
             "created_at": "2026-01-29T08:17:51.522Z",
-            "updated_at": "2026-08-10T13:58:56.622Z",
+            "updated_at": "2026-09-01T12:16:08.693Z",
             "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
         },
         "rawHeaders": [],
@@ -3547,50 +2729,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/user-attribute-profiles/uap_1csDj3szFsgxGS1oTZTdFm",
-        "body": {
-            "name": "test-user-attribute-profile-2",
-            "user_attributes": {
-                "email": {
-                    "description": "Email of the User",
-                    "label": "Email",
-                    "profile_required": true,
-                    "auth0_mapping": "email"
-                }
-            },
-            "user_id": {
-                "oidc_mapping": "sub",
-                "scim_mapping": "externalId"
-            }
-        },
-        "status": 200,
-        "response": {
-            "id": "uap_1csDj3szFsgxGS1oTZTdFm",
-            "name": "test-user-attribute-profile-2",
-            "user_id": {
-                "oidc_mapping": "sub",
-                "saml_mapping": [
-                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
-                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn",
-                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
-                ],
-                "scim_mapping": "externalId"
-            },
-            "user_attributes": {
-                "email": {
-                    "label": "Email",
-                    "description": "Email of the User",
-                    "auth0_mapping": "email",
-                    "profile_required": true
-                }
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
         "path": "/api/v2/user-attribute-profiles/uap_1csDj3sAVu6n5eTzLw6XZg",
         "body": {
             "name": "test-user-attribute-profile",
@@ -3634,6 +2772,50 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/user-attribute-profiles/uap_1csDj3szFsgxGS1oTZTdFm",
+        "body": {
+            "name": "test-user-attribute-profile-2",
+            "user_attributes": {
+                "email": {
+                    "description": "Email of the User",
+                    "label": "Email",
+                    "profile_required": true,
+                    "auth0_mapping": "email"
+                }
+            },
+            "user_id": {
+                "oidc_mapping": "sub",
+                "scim_mapping": "externalId"
+            }
+        },
+        "status": 200,
+        "response": {
+            "id": "uap_1csDj3szFsgxGS1oTZTdFm",
+            "name": "test-user-attribute-profile-2",
+            "user_id": {
+                "oidc_mapping": "sub",
+                "saml_mapping": [
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn",
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+                ],
+                "scim_mapping": "externalId"
+            },
+            "user_attributes": {
+                "email": {
+                    "label": "Email",
+                    "description": "Email of the User",
+                    "auth0_mapping": "email",
+                    "profile_required": true
+                }
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/actions/modules?page=0&per_page=100",
         "body": "",
@@ -3654,56 +2836,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
-                {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:55:04.948366503Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 1,
-                        "build_time": "2026-08-10T13:55:05.631088679Z",
-                        "created_at": "2026-08-10T13:55:05.534632268Z",
-                        "updated_at": "2026-08-10T13:55:05.632719953Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
-                        "deployed": true,
-                        "number": 1,
-                        "built_at": "2026-08-10T13:55:05.631088679Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-10T13:55:05.534632268Z",
-                        "updated_at": "2026-08-10T13:55:05.632719953Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
-                }
-            ],
-            "total": 1,
+            "actions": [],
             "per_page": 100
         },
         "rawHeaders": [],
@@ -3711,8 +2844,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118",
+        "method": "POST",
+        "path": "/api/v2/actions/actions",
         "body": {
             "name": "My Custom Action",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
@@ -3726,9 +2859,9 @@
                 }
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+            "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
             "name": "My Custom Action",
             "supported_triggers": [
                 {
@@ -3736,43 +2869,14 @@
                     "version": "v2"
                 }
             ],
-            "created_at": "2026-08-10T13:55:04.937881440Z",
-            "updated_at": "2026-08-10T13:58:58.256171458Z",
+            "created_at": "2026-09-01T12:16:10.591262148Z",
+            "updated_at": "2026-09-01T12:16:10.606852319Z",
             "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
             "dependencies": [],
             "runtime": "node18",
             "status": "pending",
             "secrets": [],
-            "current_version": {
-                "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "runtime": "node18",
-                "status": "BUILT",
-                "number": 1,
-                "build_time": "2026-08-10T13:55:05.631088679Z",
-                "created_at": "2026-08-10T13:55:05.534632268Z",
-                "updated_at": "2026-08-10T13:55:05.632719953Z"
-            },
-            "deployed_version": {
-                "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                "dependencies": [],
-                "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
-                "deployed": true,
-                "number": 1,
-                "built_at": "2026-08-10T13:55:05.631088679Z",
-                "secrets": [],
-                "status": "built",
-                "created_at": "2026-08-10T13:55:05.534632268Z",
-                "updated_at": "2026-08-10T13:55:05.632719953Z",
-                "runtime": "node18",
-                "supported_triggers": [
-                    {
-                        "id": "post-login",
-                        "version": "v2"
-                    }
-                ]
-            },
-            "all_changes_deployed": true
+            "all_changes_deployed": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -3786,7 +2890,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -3794,34 +2898,107 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:58:58.256171458Z",
+                    "created_at": "2026-09-01T12:16:10.591262148Z",
+                    "updated_at": "2026-09-01T12:16:10.606852319Z",
+                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+                    "dependencies": [],
+                    "runtime": "node18",
+                    "status": "built",
+                    "secrets": [],
+                    "all_changes_deployed": false
+                }
+            ],
+            "total": 1,
+            "per_page": 100
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/actions/actions/eeed49f4-903d-45fb-b428-9bd32678edc4/deploy",
+        "body": "",
+        "status": 200,
+        "response": {
+            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
+            "dependencies": [],
+            "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
+            "deployed": false,
+            "number": 1,
+            "secrets": [],
+            "status": "built",
+            "created_at": "2026-09-01T12:16:11.264413432Z",
+            "updated_at": "2026-09-01T12:16:11.264413432Z",
+            "runtime": "node18",
+            "supported_triggers": [
+                {
+                    "id": "post-login",
+                    "version": "v2"
+                }
+            ],
+            "action": {
+                "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
+                "name": "My Custom Action",
+                "supported_triggers": [
+                    {
+                        "id": "post-login",
+                        "version": "v2"
+                    }
+                ],
+                "created_at": "2026-09-01T12:16:10.591262148Z",
+                "updated_at": "2026-09-01T12:16:10.591262148Z",
+                "all_changes_deployed": false
+            }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "actions": [
+                {
+                    "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
+                    "name": "My Custom Action",
+                    "supported_triggers": [
+                        {
+                            "id": "post-login",
+                            "version": "v2"
+                        }
+                    ],
+                    "created_at": "2026-09-01T12:16:10.591262148Z",
+                    "updated_at": "2026-09-01T12:16:10.606852319Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
                         "number": 1,
-                        "build_time": "2026-08-10T13:55:05.631088679Z",
-                        "created_at": "2026-08-10T13:55:05.534632268Z",
-                        "updated_at": "2026-08-10T13:55:05.632719953Z"
+                        "build_time": "2026-09-01T12:16:11.370071109Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "c3ffe37e-e8ea-4b24-8611-a5923c4f320b",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "deployed": true,
                         "number": 1,
-                        "built_at": "2026-08-10T13:55:05.631088679Z",
+                        "built_at": "2026-09-01T12:16:11.370071109Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-10T13:55:05.534632268Z",
-                        "updated_at": "2026-08-10T13:55:05.632719953Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -3841,46 +3018,6 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "POST",
-        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118/deploy",
-        "body": "",
-        "status": 200,
-        "response": {
-            "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-            "dependencies": [],
-            "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
-            "deployed": false,
-            "number": 2,
-            "secrets": [],
-            "status": "built",
-            "created_at": "2026-08-10T13:58:58.846471999Z",
-            "updated_at": "2026-08-10T13:58:58.846471999Z",
-            "runtime": "node18",
-            "supported_triggers": [
-                {
-                    "id": "post-login",
-                    "version": "v2"
-                }
-            ],
-            "action": {
-                "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
-                "name": "My Custom Action",
-                "supported_triggers": [
-                    {
-                        "id": "post-login",
-                        "version": "v2"
-                    }
-                ],
-                "created_at": "2026-08-10T13:55:04.937881440Z",
-                "updated_at": "2026-08-10T13:58:58.246770448Z",
-                "all_changes_deployed": false
-            }
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
         "body": "",
@@ -3888,109 +3025,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-                    ]
-                },
-                {
-                    "id": "con_zXAdAJ7zaBMcTUlE",
+                    "id": "con_qZkLApJOKyxNL9kJ",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4140,7 +3175,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4187,15 +3222,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -4204,8 +3230,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -4251,7 +3278,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4292,7 +3319,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4345,7 +3372,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4405,7 +3432,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4463,7 +3490,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -4532,7 +3559,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -4540,34 +3567,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:58:58.256171458Z",
+                    "created_at": "2026-09-01T12:16:10.591262148Z",
+                    "updated_at": "2026-09-01T12:16:10.606852319Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-08-10T13:58:58.918670443Z",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z"
+                        "number": 1,
+                        "build_time": "2026-09-01T12:16:11.370071109Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-08-10T13:58:58.918670443Z",
+                        "number": 1,
+                        "built_at": "2026-09-01T12:16:11.370071109Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -4588,61 +3615,146 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/actions/actions?page=0&per_page=100",
+        "path": "/api/v2/connections/con_qZkLApJOKyxNL9kJ/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
-            "actions": [
+            "clients": [
                 {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
-                    "name": "My Custom Action",
-                    "supported_triggers": [
-                        {
-                            "id": "post-login",
-                            "version": "v2"
-                        }
-                    ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:58:58.256171458Z",
-                    "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                    "dependencies": [],
-                    "runtime": "node18",
-                    "status": "built",
-                    "secrets": [],
-                    "current_version": {
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "runtime": "node18",
-                        "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-08-10T13:58:58.918670443Z",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z"
-                    },
-                    "deployed_version": {
-                        "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
-                        "dependencies": [],
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
-                        "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-08-10T13:58:58.918670443Z",
-                        "secrets": [],
-                        "status": "built",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z",
-                        "runtime": "node18",
-                        "supported_triggers": [
-                            {
-                                "id": "post-login",
-                                "version": "v2"
-                            }
-                        ]
-                    },
-                    "all_changes_deployed": true
+                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
                 }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "DELETE",
+        "path": "/api/v2/connections/con_qZkLApJOKyxNL9kJ",
+        "body": "",
+        "status": 202,
+        "response": {
+            "deleted_at": "2026-09-01T12:16:12.564Z"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/connections",
+        "body": {
+            "name": "boo-baz-db-connection-test",
+            "strategy": "auth0",
+            "is_domain_connection": false,
+            "realms": [
+                "boo-baz-db-connection-test"
             ],
-            "total": 1,
-            "per_page": 100
+            "options": {
+                "mfa": {
+                    "active": true,
+                    "return_enroll_settings": true
+                },
+                "import_mode": false,
+                "customScripts": {
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                },
+                "disable_signup": false,
+                "passwordPolicy": "low",
+                "password_history": {
+                    "size": 5,
+                    "enable": false
+                },
+                "strategy_version": 2,
+                "requires_username": true,
+                "password_dictionary": {
+                    "enable": true,
+                    "dictionary": []
+                },
+                "brute_force_protection": true,
+                "password_no_personal_info": {
+                    "enable": true
+                },
+                "password_complexity_options": {
+                    "min_length": 8
+                },
+                "enabledDatabaseCustomization": true,
+                "disable_self_service_change_password": false
+            }
+        },
+        "status": 201,
+        "response": {
+            "id": "con_lEo3NS2yglrPS29s",
+            "options": {
+                "mfa": {
+                    "active": true,
+                    "return_enroll_settings": true
+                },
+                "passwordPolicy": "low",
+                "import_mode": false,
+                "customScripts": {
+                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                },
+                "disable_signup": false,
+                "password_history": {
+                    "size": 5,
+                    "enable": false
+                },
+                "strategy_version": 2,
+                "requires_username": true,
+                "password_dictionary": {
+                    "enable": true,
+                    "dictionary": []
+                },
+                "brute_force_protection": true,
+                "password_no_personal_info": {
+                    "enable": true
+                },
+                "password_complexity_options": {
+                    "min_length": 8
+                },
+                "enabledDatabaseCustomization": true,
+                "disable_self_service_change_password": false,
+                "authentication_methods": {
+                    "password": {
+                        "enabled": true,
+                        "api_behavior": "required",
+                        "signup_behavior": "allow"
+                    },
+                    "passkey": {
+                        "enabled": false
+                    }
+                },
+                "passkey_options": {
+                    "challenge_ui": "both",
+                    "progressive_enrollment_enabled": true,
+                    "local_enrollment_enabled": true
+                }
+            },
+            "strategy": "auth0",
+            "name": "boo-baz-db-connection-test",
+            "is_domain_connection": false,
+            "authentication": {
+                "active": true
+            },
+            "connected_accounts": {
+                "active": false
+            },
+            "enabled_clients": [],
+            "realms": [
+                "boo-baz-db-connection-test"
+            ]
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -4650,13 +3762,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=boo-baz-db-connection-test&include_fields=true",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
+                    "id": "con_lEo3NS2yglrPS29s",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -4681,38 +3793,6 @@
                         "password_history": {
                             "size": 5,
                             "enable": false
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "requires_username": true,
@@ -4752,212 +3832,8 @@
                     "realms": [
                         "boo-baz-db-connection-test"
                     ],
-                    "enabled_clients": [
-                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-                    ]
-                },
-                {
-                    "id": "con_zXAdAJ7zaBMcTUlE",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                    ]
+                    "enabled_clients": []
                 }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-                },
-                {
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw"
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "DELETE",
-        "path": "/api/v2/connections/con_zXAdAJ7zaBMcTUlE",
-        "body": "",
-        "status": 202,
-        "response": {
-            "deleted_at": "2026-08-10T13:59:00.087Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
-        "body": "",
-        "status": 200,
-        "response": {
-            "id": "con_u6eDOnzfycy2sDLb",
-            "options": {
-                "mfa": {
-                    "active": true,
-                    "return_enroll_settings": true
-                },
-                "import_mode": false,
-                "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                },
-                "disable_signup": false,
-                "passwordPolicy": "low",
-                "passkey_options": {
-                    "challenge_ui": "both",
-                    "local_enrollment_enabled": true,
-                    "progressive_enrollment_enabled": true
-                },
-                "password_history": {
-                    "size": 5,
-                    "enable": false
-                },
-                "password_options": {
-                    "history": {
-                        "size": 3,
-                        "active": false
-                    },
-                    "complexity": {
-                        "min_length": 15,
-                        "character_types": [],
-                        "character_type_rule": "all",
-                        "max_length_exceeded": "error",
-                        "identical_characters": "allow",
-                        "sequential_characters": "allow"
-                    },
-                    "dictionary": {
-                        "active": false,
-                        "custom": [],
-                        "default": "en_100k"
-                    },
-                    "profile_data": {
-                        "active": false,
-                        "blocked_fields": [
-                            "name",
-                            "username",
-                            "nickname",
-                            "email",
-                            "phone_number",
-                            "user_metadata.name",
-                            "user_metadata.first",
-                            "user_metadata.last"
-                        ]
-                    }
-                },
-                "strategy_version": 2,
-                "requires_username": true,
-                "password_dictionary": {
-                    "enable": true,
-                    "dictionary": []
-                },
-                "authentication_methods": {
-                    "passkey": {
-                        "enabled": false
-                    },
-                    "password": {
-                        "enabled": true,
-                        "api_behavior": "required",
-                        "signup_behavior": "allow"
-                    }
-                },
-                "brute_force_protection": true,
-                "password_no_personal_info": {
-                    "enable": true
-                },
-                "password_complexity_options": {
-                    "min_length": 8
-                },
-                "enabledDatabaseCustomization": true,
-                "disable_self_service_change_password": false
-            },
-            "strategy": "auth0",
-            "name": "boo-baz-db-connection-test",
-            "is_domain_connection": false,
-            "authentication": {
-                "active": true
-            },
-            "connected_accounts": {
-                "active": false
-            },
-            "enabled_clients": [
-                "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-            ],
-            "realms": [
-                "boo-baz-db-connection-test"
             ]
         },
         "rawHeaders": [],
@@ -4966,135 +3842,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
-        "body": {
-            "is_domain_connection": false,
-            "realms": [
-                "boo-baz-db-connection-test"
-            ],
-            "options": {
-                "mfa": {
-                    "active": true,
-                    "return_enroll_settings": true
-                },
-                "import_mode": false,
-                "customScripts": {
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                },
-                "disable_signup": false,
-                "passwordPolicy": "low",
-                "passkey_options": {
-                    "challenge_ui": "both",
-                    "local_enrollment_enabled": true,
-                    "progressive_enrollment_enabled": true
-                },
-                "password_history": {
-                    "size": 5,
-                    "enable": false
-                },
-                "strategy_version": 2,
-                "requires_username": true,
-                "password_dictionary": {
-                    "enable": true,
-                    "dictionary": []
-                },
-                "authentication_methods": {
-                    "passkey": {
-                        "enabled": false
-                    },
-                    "password": {
-                        "enabled": true,
-                        "api_behavior": "required",
-                        "signup_behavior": "allow"
-                    }
-                },
-                "brute_force_protection": true,
-                "password_no_personal_info": {
-                    "enable": true
-                },
-                "password_complexity_options": {
-                    "min_length": 8
-                },
-                "enabledDatabaseCustomization": true,
-                "disable_self_service_change_password": false
+        "path": "/api/v2/connections/con_lEo3NS2yglrPS29s/clients",
+        "body": [
+            {
+                "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
+                "status": true
+            },
+            {
+                "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
+                "status": true
             }
-        },
-        "status": 200,
-        "response": {
-            "id": "con_u6eDOnzfycy2sDLb",
-            "options": {
-                "mfa": {
-                    "active": true,
-                    "return_enroll_settings": true
-                },
-                "import_mode": false,
-                "customScripts": {
-                    "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                    "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                },
-                "disable_signup": false,
-                "passwordPolicy": "low",
-                "passkey_options": {
-                    "challenge_ui": "both",
-                    "local_enrollment_enabled": true,
-                    "progressive_enrollment_enabled": true
-                },
-                "password_history": {
-                    "size": 5,
-                    "enable": false
-                },
-                "strategy_version": 2,
-                "requires_username": true,
-                "password_dictionary": {
-                    "enable": true,
-                    "dictionary": []
-                },
-                "authentication_methods": {
-                    "passkey": {
-                        "enabled": false
-                    },
-                    "password": {
-                        "enabled": true,
-                        "api_behavior": "required",
-                        "signup_behavior": "allow"
-                    }
-                },
-                "brute_force_protection": true,
-                "password_no_personal_info": {
-                    "enable": true
-                },
-                "password_complexity_options": {
-                    "min_length": 8
-                },
-                "enabledDatabaseCustomization": true,
-                "disable_self_service_change_password": false
-            },
-            "strategy": "auth0",
-            "name": "boo-baz-db-connection-test",
-            "is_domain_connection": false,
-            "authentication": {
-                "active": true
-            },
-            "connected_accounts": {
-                "active": false
-            },
-            "enabled_clients": [
-                "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-            ],
-            "realms": [
-                "boo-baz-db-connection-test"
-            ]
-        },
+        ],
+        "status": 204,
+        "response": "",
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -5201,7 +3961,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5248,15 +4008,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -5265,8 +4016,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -5312,7 +4064,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5353,7 +4105,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5406,7 +4158,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5466,7 +4218,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5524,7 +4276,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -5593,7 +4345,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
+                    "id": "con_lEo3NS2yglrPS29s",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -5658,22 +4410,78 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                        "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
+                        "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u"
                     ]
-                },
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
                 {
-                    "id": "con_Dyc8vFGQ4ncArPi0",
+                    "id": "con_lEo3NS2yglrPS29s",
                     "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "import_mode": false,
+                        "customScripts": {
+                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
+                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
+                        },
+                        "disable_signup": false,
+                        "passwordPolicy": "low",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "password_history": {
+                            "size": 5,
+                            "enable": false
+                        },
+                        "strategy_version": 2,
+                        "requires_username": true,
+                        "password_dictionary": {
+                            "enable": true,
+                            "dictionary": []
+                        },
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "password_no_personal_info": {
+                            "enable": true
+                        },
+                        "password_complexity_options": {
+                            "min_length": 8
+                        },
+                        "enabledDatabaseCustomization": true,
+                        "disable_self_service_change_password": false
                     },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
+                    "strategy": "auth0",
+                    "name": "boo-baz-db-connection-test",
                     "is_domain_connection": false,
                     "authentication": {
                         "active": true
@@ -5682,11 +4490,11 @@
                         "active": false
                     },
                     "realms": [
-                        "google-oauth2"
+                        "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                        "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
+                        "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u"
                     ]
                 }
             ]
@@ -5711,84 +4519,59 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/connections",
+        "body": {
+            "name": "google-oauth2",
+            "strategy": "google-oauth2",
+            "is_domain_connection": false,
+            "options": {
+                "email": true,
+                "scope": [
+                    "email",
+                    "profile"
+                ],
+                "profile": true
+            }
+        },
+        "status": 201,
+        "response": {
+            "id": "con_JGKwgb1jNU2qksAS",
+            "options": {
+                "email": true,
+                "scope": [
+                    "email",
+                    "profile"
+                ],
+                "profile": true
+            },
+            "strategy": "google-oauth2",
+            "name": "google-oauth2",
+            "is_domain_connection": false,
+            "authentication": {
+                "active": true
+            },
+            "connected_accounts": {
+                "active": false
+            },
+            "enabled_clients": [],
+            "realms": [
+                "google-oauth2"
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50",
+        "path": "/api/v2/connections?include_totals=true&take=1&name=google-oauth2&include_fields=true",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": [
-                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-                    ]
-                },
-                {
-                    "id": "con_Dyc8vFGQ4ncArPi0",
+                    "id": "con_JGKwgb1jNU2qksAS",
                     "options": {
                         "email": true,
                         "scope": [
@@ -5809,29 +4592,7 @@
                     "realms": [
                         "google-oauth2"
                     ],
-                    "enabled_clients": [
-                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
-        "body": "",
-        "status": 200,
-        "response": {
-            "clients": [
-                {
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i"
-                },
-                {
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                    "enabled_clients": []
                 }
             ]
         },
@@ -5841,46 +4602,19 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0",
-        "body": {
-            "is_domain_connection": false,
-            "options": {
-                "email": true,
-                "scope": [
-                    "email",
-                    "profile"
-                ],
-                "profile": true
+        "path": "/api/v2/connections/con_JGKwgb1jNU2qksAS/clients",
+        "body": [
+            {
+                "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
+                "status": true
+            },
+            {
+                "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
+                "status": true
             }
-        },
-        "status": 200,
-        "response": {
-            "id": "con_Dyc8vFGQ4ncArPi0",
-            "options": {
-                "email": true,
-                "scope": [
-                    "email",
-                    "profile"
-                ],
-                "profile": true
-            },
-            "strategy": "google-oauth2",
-            "name": "google-oauth2",
-            "is_domain_connection": false,
-            "authentication": {
-                "active": true
-            },
-            "connected_accounts": {
-                "active": false
-            },
-            "enabled_clients": [
-                "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
-            ],
-            "realms": [
-                "google-oauth2"
-            ]
-        },
+        ],
+        "status": 204,
+        "response": "",
         "rawHeaders": [],
         "responseIsBinary": false
     },
@@ -6024,7 +4758,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6071,15 +4805,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -6088,8 +4813,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -6135,7 +4861,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6176,7 +4902,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6229,7 +4955,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6289,7 +5015,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6347,7 +5073,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -6415,144 +5141,6 @@
         "status": 200,
         "response": {
             "client_grants": [
-                {
-                    "id": "cgr_NUKidZC54pI9CYZV",
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
-                },
                 {
                     "id": "cgr_pbwejzhwoujrsNE8",
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
@@ -6792,144 +5380,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_pzLmQ5o4eKIoCQXe",
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -6938,9 +5388,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_NUKidZC54pI9CYZV",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -7074,10 +5526,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_NUKidZC54pI9CYZV",
-            "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+            "id": "cgr_ZnzE434YO1Afrgrr",
+            "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7218,9 +5670,11 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/client-grants/cgr_pzLmQ5o4eKIoCQXe",
+        "method": "POST",
+        "path": "/api/v2/client-grants",
         "body": {
+            "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
+            "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
                 "create:client_grants",
@@ -7354,10 +5808,10 @@
                 "delete:organization_invitations"
             ]
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "cgr_pzLmQ5o4eKIoCQXe",
-            "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+            "id": "cgr_jjk8kxD2WG1EwOqY",
+            "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
             "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
             "scope": [
                 "read:client_grants",
@@ -7503,47 +5957,7 @@
         "body": "",
         "status": 200,
         "response": {
-            "roles": [
-                {
-                    "id": "rol_suBuW3gIaoRKQ2YI",
-                    "name": "Admin",
-                    "description": "Can read and write things",
-                    "type": "tenant"
-                },
-                {
-                    "id": "rol_ULMlbmvvd3mzoPwt",
-                    "name": "Reader",
-                    "description": "Can only read things",
-                    "type": "tenant"
-                },
-                {
-                    "id": "rol_lkZCKwORLWaTSWuv",
-                    "name": "read_only",
-                    "description": "Read Only",
-                    "type": "tenant"
-                },
-                {
-                    "id": "rol_sQEZiIEgfOQdKTLk",
-                    "name": "read_osnly",
-                    "description": "Readz Only",
-                    "type": "tenant"
-                }
-            ],
-            "start": 0,
-            "limit": 100,
-            "total": 4
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
+            "roles": [],
             "start": 0,
             "limit": 100,
             "total": 0
@@ -7553,78 +5967,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "permissions": [],
-            "start": 0,
-            "limit": 100,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI",
-        "body": {
-            "name": "Admin",
-            "description": "Can read and write things"
-        },
-        "status": 200,
-        "response": {
-            "id": "rol_suBuW3gIaoRKQ2YI",
-            "name": "Admin",
-            "description": "Can read and write things",
-            "type": "tenant"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "Reader",
             "description": "Can only read things"
         },
         "status": 200,
         "response": {
-            "id": "rol_ULMlbmvvd3mzoPwt",
+            "id": "rol_Mog9JkKkC1ABJX66",
             "name": "Reader",
             "description": "Can only read things",
             "type": "tenant"
@@ -7634,15 +5985,33 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv",
+        "method": "POST",
+        "path": "/api/v2/roles",
+        "body": {
+            "name": "Admin",
+            "description": "Can read and write things"
+        },
+        "status": 200,
+        "response": {
+            "id": "rol_hhvfGEVOLl3nYVSB",
+            "name": "Admin",
+            "description": "Can read and write things",
+            "type": "tenant"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "read_only",
             "description": "Read Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_lkZCKwORLWaTSWuv",
+            "id": "rol_oC8EIPEFnHsR8yQu",
             "name": "read_only",
             "description": "Read Only",
             "type": "tenant"
@@ -7652,15 +6021,15 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk",
+        "method": "POST",
+        "path": "/api/v2/roles",
         "body": {
             "name": "read_osnly",
             "description": "Readz Only"
         },
         "status": 200,
         "response": {
-            "id": "rol_sQEZiIEgfOQdKTLk",
+            "id": "rol_WVD3cZM2xor934Nl",
             "name": "read_osnly",
             "description": "Readz Only",
             "type": "tenant"
@@ -7697,7 +6066,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-08-10T13:55:18.245Z",
+                    "updated_at": "2026-08-12T09:59:38.645Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -7773,12 +6142,38 @@
                 "okta"
             ],
             "created_at": "2024-11-26T11:58:18.962Z",
-            "updated_at": "2026-08-10T13:59:07.048Z",
+            "updated_at": "2026-09-01T12:16:24.961Z",
             "branding": {
                 "colors": {
                     "primary": "#19aecc"
                 }
             }
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "PATCH",
+        "path": "/api/v2/email-templates/verify_email",
+        "body": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "enabled": true,
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000
+        },
+        "status": 200,
+        "response": {
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7813,59 +6208,12 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/email-templates/verify_email",
-        "body": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "enabled": true,
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000
-        },
-        "status": 200,
-        "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/organizations?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
-            "organizations": [
-                {
-                    "id": "org_SrEMrFYV9b6phMSo",
-                    "name": "org2",
-                    "display_name": "Organization2",
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                },
-                {
-                    "id": "org_heCvrp0Pkxw4ilGg",
-                    "name": "org1",
-                    "display_name": "Organization",
-                    "branding": {
-                        "colors": {
-                            "page_background": "#fff5f5",
-                            "primary": "#57ddff"
-                        }
-                    },
-                    "third_party_client_access": "block",
-                    "is_app_entitlement_active": false
-                }
-            ]
+            "organizations": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -7973,7 +6321,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8020,15 +6368,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -8037,8 +6376,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -8084,7 +6424,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8125,7 +6465,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8178,7 +6518,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8238,7 +6578,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8296,7 +6636,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -8359,127 +6699,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
-        "body": "",
-        "status": 403,
-        "response": {
-            "statusCode": 403,
-            "error": "Forbidden",
-            "message": "Insufficient scope, expected any of: read:organization_clients",
-            "errorCode": "insufficient_scope"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "client_grants": [],
-            "start": 0,
-            "limit": 50,
-            "total": 0
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "domains": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
-        "body": "",
-        "status": 403,
-        "response": {
-            "statusCode": 403,
-            "error": "Forbidden",
-            "message": "Insufficient scope, expected any of: read:organization_clients",
-            "errorCode": "insufficient_scope"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/connections?include_totals=true&take=50",
         "body": "",
         "status": 200,
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
+                    "id": "con_lEo3NS2yglrPS29s",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -8544,12 +6770,12 @@
                         "boo-baz-db-connection-test"
                     ],
                     "enabled_clients": [
-                        "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                        "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
+                        "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u"
                     ]
                 },
                 {
-                    "id": "con_Dyc8vFGQ4ncArPi0",
+                    "id": "con_JGKwgb1jNU2qksAS",
                     "options": {
                         "email": true,
                         "scope": [
@@ -8571,8 +6797,8 @@
                         "google-oauth2"
                     ],
                     "enabled_clients": [
-                        "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
-                        "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k"
+                        "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
+                        "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u"
                     ]
                 }
             ]
@@ -8589,8 +6815,146 @@
         "response": {
             "client_grants": [
                 {
-                    "id": "cgr_NUKidZC54pI9CYZV",
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "id": "cgr_ZnzE434YO1Afrgrr",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
+                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
+                    "scope": [
+                        "read:client_grants",
+                        "create:client_grants",
+                        "delete:client_grants",
+                        "update:client_grants",
+                        "read:users",
+                        "update:users",
+                        "delete:users",
+                        "create:users",
+                        "read:users_app_metadata",
+                        "update:users_app_metadata",
+                        "delete:users_app_metadata",
+                        "create:users_app_metadata",
+                        "read:user_custom_blocks",
+                        "create:user_custom_blocks",
+                        "delete:user_custom_blocks",
+                        "create:user_tickets",
+                        "read:clients",
+                        "update:clients",
+                        "delete:clients",
+                        "create:clients",
+                        "read:client_keys",
+                        "update:client_keys",
+                        "delete:client_keys",
+                        "create:client_keys",
+                        "read:connections",
+                        "update:connections",
+                        "delete:connections",
+                        "create:connections",
+                        "read:resource_servers",
+                        "update:resource_servers",
+                        "delete:resource_servers",
+                        "create:resource_servers",
+                        "read:device_credentials",
+                        "update:device_credentials",
+                        "delete:device_credentials",
+                        "create:device_credentials",
+                        "read:rules",
+                        "update:rules",
+                        "delete:rules",
+                        "create:rules",
+                        "read:rules_configs",
+                        "update:rules_configs",
+                        "delete:rules_configs",
+                        "read:hooks",
+                        "update:hooks",
+                        "delete:hooks",
+                        "create:hooks",
+                        "read:actions",
+                        "update:actions",
+                        "delete:actions",
+                        "create:actions",
+                        "read:email_provider",
+                        "update:email_provider",
+                        "delete:email_provider",
+                        "create:email_provider",
+                        "blacklist:tokens",
+                        "read:stats",
+                        "read:insights",
+                        "read:tenant_settings",
+                        "update:tenant_settings",
+                        "read:logs",
+                        "read:logs_users",
+                        "read:shields",
+                        "create:shields",
+                        "update:shields",
+                        "delete:shields",
+                        "read:anomaly_blocks",
+                        "delete:anomaly_blocks",
+                        "update:triggers",
+                        "read:triggers",
+                        "read:grants",
+                        "delete:grants",
+                        "read:guardian_factors",
+                        "update:guardian_factors",
+                        "read:guardian_enrollments",
+                        "delete:guardian_enrollments",
+                        "create:guardian_enrollment_tickets",
+                        "read:user_idp_tokens",
+                        "create:passwords_checking_job",
+                        "delete:passwords_checking_job",
+                        "read:custom_domains",
+                        "delete:custom_domains",
+                        "create:custom_domains",
+                        "update:custom_domains",
+                        "read:email_templates",
+                        "create:email_templates",
+                        "update:email_templates",
+                        "read:mfa_policies",
+                        "update:mfa_policies",
+                        "read:roles",
+                        "create:roles",
+                        "delete:roles",
+                        "update:roles",
+                        "read:prompts",
+                        "update:prompts",
+                        "read:branding",
+                        "update:branding",
+                        "delete:branding",
+                        "read:log_streams",
+                        "create:log_streams",
+                        "delete:log_streams",
+                        "update:log_streams",
+                        "create:signing_keys",
+                        "read:signing_keys",
+                        "update:signing_keys",
+                        "read:limits",
+                        "update:limits",
+                        "create:role_members",
+                        "read:role_members",
+                        "delete:role_members",
+                        "read:entitlements",
+                        "read:attack_protection",
+                        "update:attack_protection",
+                        "read:organizations",
+                        "update:organizations",
+                        "create:organizations",
+                        "delete:organizations",
+                        "create:organization_members",
+                        "read:organization_members",
+                        "delete:organization_members",
+                        "create:organization_connections",
+                        "read:organization_connections",
+                        "update:organization_connections",
+                        "delete:organization_connections",
+                        "create:organization_member_roles",
+                        "read:organization_member_roles",
+                        "delete:organization_member_roles",
+                        "create:organization_invitations",
+                        "read:organization_invitations",
+                        "delete:organization_invitations"
+                    ],
+                    "subject_type": "client"
+                },
+                {
+                    "id": "cgr_jjk8kxD2WG1EwOqY",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
                     "scope": [
                         "read:client_grants",
@@ -8965,144 +7329,6 @@
                         "create:connections_keys"
                     ],
                     "subject_type": "client"
-                },
-                {
-                    "id": "cgr_pzLmQ5o4eKIoCQXe",
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
-                    "audience": "https://auth0-deploy-cli-e2e.us.auth0.com/api/v2/",
-                    "scope": [
-                        "read:client_grants",
-                        "create:client_grants",
-                        "delete:client_grants",
-                        "update:client_grants",
-                        "read:users",
-                        "update:users",
-                        "delete:users",
-                        "create:users",
-                        "read:users_app_metadata",
-                        "update:users_app_metadata",
-                        "delete:users_app_metadata",
-                        "create:users_app_metadata",
-                        "read:user_custom_blocks",
-                        "create:user_custom_blocks",
-                        "delete:user_custom_blocks",
-                        "create:user_tickets",
-                        "read:clients",
-                        "update:clients",
-                        "delete:clients",
-                        "create:clients",
-                        "read:client_keys",
-                        "update:client_keys",
-                        "delete:client_keys",
-                        "create:client_keys",
-                        "read:connections",
-                        "update:connections",
-                        "delete:connections",
-                        "create:connections",
-                        "read:resource_servers",
-                        "update:resource_servers",
-                        "delete:resource_servers",
-                        "create:resource_servers",
-                        "read:device_credentials",
-                        "update:device_credentials",
-                        "delete:device_credentials",
-                        "create:device_credentials",
-                        "read:rules",
-                        "update:rules",
-                        "delete:rules",
-                        "create:rules",
-                        "read:rules_configs",
-                        "update:rules_configs",
-                        "delete:rules_configs",
-                        "read:hooks",
-                        "update:hooks",
-                        "delete:hooks",
-                        "create:hooks",
-                        "read:actions",
-                        "update:actions",
-                        "delete:actions",
-                        "create:actions",
-                        "read:email_provider",
-                        "update:email_provider",
-                        "delete:email_provider",
-                        "create:email_provider",
-                        "blacklist:tokens",
-                        "read:stats",
-                        "read:insights",
-                        "read:tenant_settings",
-                        "update:tenant_settings",
-                        "read:logs",
-                        "read:logs_users",
-                        "read:shields",
-                        "create:shields",
-                        "update:shields",
-                        "delete:shields",
-                        "read:anomaly_blocks",
-                        "delete:anomaly_blocks",
-                        "update:triggers",
-                        "read:triggers",
-                        "read:grants",
-                        "delete:grants",
-                        "read:guardian_factors",
-                        "update:guardian_factors",
-                        "read:guardian_enrollments",
-                        "delete:guardian_enrollments",
-                        "create:guardian_enrollment_tickets",
-                        "read:user_idp_tokens",
-                        "create:passwords_checking_job",
-                        "delete:passwords_checking_job",
-                        "read:custom_domains",
-                        "delete:custom_domains",
-                        "create:custom_domains",
-                        "update:custom_domains",
-                        "read:email_templates",
-                        "create:email_templates",
-                        "update:email_templates",
-                        "read:mfa_policies",
-                        "update:mfa_policies",
-                        "read:roles",
-                        "create:roles",
-                        "delete:roles",
-                        "update:roles",
-                        "read:prompts",
-                        "update:prompts",
-                        "read:branding",
-                        "update:branding",
-                        "delete:branding",
-                        "read:log_streams",
-                        "create:log_streams",
-                        "delete:log_streams",
-                        "update:log_streams",
-                        "create:signing_keys",
-                        "read:signing_keys",
-                        "update:signing_keys",
-                        "read:limits",
-                        "update:limits",
-                        "create:role_members",
-                        "read:role_members",
-                        "delete:role_members",
-                        "read:entitlements",
-                        "read:attack_protection",
-                        "update:attack_protection",
-                        "read:organizations",
-                        "update:organizations",
-                        "create:organizations",
-                        "delete:organizations",
-                        "create:organization_members",
-                        "read:organization_members",
-                        "delete:organization_members",
-                        "create:organization_connections",
-                        "read:organization_connections",
-                        "update:organization_connections",
-                        "delete:organization_connections",
-                        "create:organization_member_roles",
-                        "read:organization_member_roles",
-                        "delete:organization_member_roles",
-                        "create:organization_invitations",
-                        "read:organization_invitations",
-                        "delete:organization_invitations"
-                    ],
-                    "subject_type": "client"
                 }
             ]
         },
@@ -9212,7 +7438,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9259,15 +7485,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -9276,8 +7493,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -9323,7 +7541,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9364,7 +7582,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9417,7 +7635,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9477,7 +7695,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9535,7 +7753,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9597,28 +7815,17 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
-            "branding": {
-                "colors": {
-                    "page_background": "#fff5f5",
-                    "primary": "#57ddff"
-                }
-            },
-            "display_name": "Organization"
+            "name": "org2",
+            "display_name": "Organization2"
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "branding": {
-                "colors": {
-                    "page_background": "#fff5f5",
-                    "primary": "#57ddff"
-                }
-            },
-            "id": "org_heCvrp0Pkxw4ilGg",
-            "display_name": "Organization",
-            "name": "org1",
+            "id": "org_dDjIMu0QNzrSxxQF",
+            "display_name": "Organization2",
+            "name": "org2",
             "third_party_client_access": "block",
             "is_app_entitlement_active": false
         },
@@ -9627,16 +7834,29 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo",
+        "method": "POST",
+        "path": "/api/v2/organizations",
         "body": {
-            "display_name": "Organization2"
+            "name": "org1",
+            "branding": {
+                "colors": {
+                    "page_background": "#fff5f5",
+                    "primary": "#57ddff"
+                }
+            },
+            "display_name": "Organization"
         },
-        "status": 200,
+        "status": 201,
         "response": {
-            "id": "org_SrEMrFYV9b6phMSo",
-            "display_name": "Organization2",
-            "name": "org2",
+            "id": "org_8QNnnjHEXgiuo3Xi",
+            "display_name": "Organization",
+            "name": "org1",
+            "branding": {
+                "colors": {
+                    "page_background": "#fff5f5",
+                    "primary": "#57ddff"
+                }
+            },
             "third_party_client_access": "block",
             "is_app_entitlement_active": false
         },
@@ -9649,86 +7869,25 @@
         "path": "/api/v2/log-streams",
         "body": "",
         "status": 200,
-        "response": [
-            {
-                "id": "lst_0000000000030347",
-                "name": "Suspended DD Log Stream",
-                "type": "datadog",
-                "status": "active",
-                "sink": {
-                    "datadogApiKey": "some-sensitive-api-key",
-                    "datadogRegion": "us"
-                },
-                "isPriority": false
-            },
-            {
-                "id": "lst_0000000000030348",
-                "name": "Amazon EventBridge",
-                "type": "eventbridge",
-                "status": "active",
-                "sink": {
-                    "awsAccountId": "123456789012",
-                    "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
-                },
-                "filters": [
-                    {
-                        "type": "category",
-                        "name": "auth.login.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.notification"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.login.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.signup.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.logout.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.fail"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.silent_auth.success"
-                    },
-                    {
-                        "type": "category",
-                        "name": "auth.token_exchange.fail"
-                    }
-                ],
-                "isPriority": false
-            }
-        ],
+        "response": [],
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000030347",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
         "body": {
             "name": "Suspended DD Log Stream",
             "sink": {
                 "datadogApiKey": "some-sensitive-api-key",
                 "datadogRegion": "us"
-            }
+            },
+            "type": "datadog"
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000030347",
+            "id": "lst_0000000000030979",
             "name": "Suspended DD Log Stream",
             "type": "datadog",
             "status": "active",
@@ -9743,8 +7902,8 @@
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "PATCH",
-        "path": "/api/v2/log-streams/lst_0000000000030348",
+        "method": "POST",
+        "path": "/api/v2/log-streams",
         "body": {
             "name": "Amazon EventBridge",
             "filters": [
@@ -9785,18 +7944,22 @@
                     "name": "auth.token_exchange.fail"
                 }
             ],
-            "status": "active"
+            "sink": {
+                "awsAccountId": "123456789012",
+                "awsRegion": "us-east-2"
+            },
+            "type": "eventbridge"
         },
         "status": 200,
         "response": {
-            "id": "lst_0000000000030348",
+            "id": "lst_0000000000030980",
             "name": "Amazon EventBridge",
             "type": "eventbridge",
             "status": "active",
             "sink": {
                 "awsAccountId": "123456789012",
                 "awsRegion": "us-east-2",
-                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
+                "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-dd813140-dcad-4396-a2ac-8c44999772ae/auth0.logs"
             },
             "filters": [
                 {
@@ -9944,7 +8107,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -9991,15 +8154,6 @@
                     },
                     "sso_disabled": false,
                     "cross_origin_auth": false,
-                    "client_authentication_methods": {
-                        "private_key_jwt": {
-                            "credentials": [
-                                {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
-                                }
-                            ]
-                        }
-                    },
                     "signing_keys": [
                         {
                             "cert": "[REDACTED]",
@@ -10008,8 +8162,9 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
+                    "client_secret": "[REDACTED]",
                     "jwt_configuration": {
                         "alg": "RS256",
                         "lifetime_in_seconds": 36000,
@@ -10055,7 +8210,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10096,7 +8251,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10149,7 +8304,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10209,7 +8364,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10267,7 +8422,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -10291,33 +8446,45 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
+        "path": "/api/v2/clients/qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI/credentials",
         "body": "",
         "status": 200,
-        "response": [
-            {
-                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
-                "credential_type": "public_key",
-                "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
-                "alg": "RS256",
-                "name": "e2e-test-key",
-                "created_at": "2026-08-10T13:55:22.110Z",
-                "updated_at": "2026-08-10T13:55:22.110Z"
-            }
-        ],
+        "response": [],
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "POST",
+        "path": "/api/v2/clients/qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI/credentials",
+        "body": {
+            "name": "e2e-test-key",
+            "pem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs8/9RN2qV8HZMunRt8mx\nihqnIX726YqxGwF+7x1A0gpk4TWRpMUWnaaL2D3Nt/Kd5obKM0THZPCuE+Xwncf4\nQloizZEn4jM3PNldweL9qwG160o2wXif2R5zLVQat9/188+Ko/sU/LorHgh23DMp\nznSwIN30AdLG1WRPxqP5s9abVT0WgBt1VuQobw4TS6QltFUnMSEMBsNtMSPK+NPJ\npz9s3ozqkNMLNSLZMTwgODQWchUr2YJeZa5RbM0u5Xt9oF0HtXH8db3L6Rp3TdIA\nuISnZ+mC7zRiCzWljkJZSBrqgtx6Su5wSve9cYGPS23zu3yeSapJWP7pki3G/GBz\nJQIDAQAB\n-----END PUBLIC KEY-----\n",
+            "credential_type": "public_key"
+        },
+        "status": 201,
+        "response": {
+            "id": "cred_21BSV25k7LPDJe3b2AbTdo",
+            "credential_type": "public_key",
+            "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
+            "alg": "RS256",
+            "name": "e2e-test-key",
+            "created_at": "2026-09-01T12:16:28.619Z",
+            "updated_at": "2026-09-01T12:16:28.619Z"
+        },
         "rawHeaders": [],
         "responseIsBinary": false
     },
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+        "path": "/api/v2/clients/qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
         "body": {
             "client_authentication_methods": {
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                            "id": "cred_21BSV25k7LPDJe3b2AbTdo"
                         }
                     ]
                 }
@@ -10360,7 +8527,7 @@
                 "private_key_jwt": {
                     "credentials": [
                         {
-                            "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                            "id": "cred_21BSV25k7LPDJe3b2AbTdo"
                         }
                     ]
                 }
@@ -10373,7 +8540,7 @@
                 }
             ],
             "allowed_origins": [],
-            "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+            "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
             "callback_url_template": false,
             "jwt_configuration": {
                 "alg": "RS256",
@@ -10403,7 +8570,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -10411,34 +8578,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:58:58.256171458Z",
+                    "created_at": "2026-09-01T12:16:10.591262148Z",
+                    "updated_at": "2026-09-01T12:16:10.606852319Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-08-10T13:58:58.918670443Z",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z"
+                        "number": 1,
+                        "build_time": "2026-09-01T12:16:11.370071109Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-08-10T13:58:58.918670443Z",
+                        "number": 1,
+                        "built_at": "2026-09-01T12:16:11.370071109Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -10477,7 +8644,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-08-10T13:55:23.310Z",
+                    "updated_at": "2026-08-12T09:59:44.791Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {
@@ -10533,7 +8700,7 @@
                 }
             ],
             "created_at": "2026-06-29T10:28:33.962Z",
-            "updated_at": "2026-08-10T13:59:13.605Z",
+            "updated_at": "2026-09-01T12:16:29.907Z",
             "destination": {
                 "type": "webhook",
                 "configuration": {
@@ -10566,6 +8733,21 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -10579,24 +8761,9 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-08-10T13:55:26.891Z"
+                    "updated_at": "2026-08-26T17:32:49.419Z"
                 }
             ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10665,7 +8832,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-10T13:55:26.891Z"
+            "updated_at": "2026-08-26T17:32:49.419Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -10805,7 +8972,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-10T13:59:17.158Z"
+            "updated_at": "2026-09-01T12:16:33.655Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -11047,7 +9214,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11098,7 +9265,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                                    "id": "cred_21BSV25k7LPDJe3b2AbTdo"
                                 }
                             ]
                         }
@@ -11111,7 +9278,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -11158,7 +9325,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11199,7 +9366,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11252,7 +9419,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11312,7 +9479,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -11370,7 +9537,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12663,7 +10830,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+                    "client_id": "NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12714,7 +10881,7 @@
                         "private_key_jwt": {
                             "credentials": [
                                 {
-                                    "id": "cred_mMuz56jQ8PQww4wqQbH7S5"
+                                    "id": "cred_21BSV25k7LPDJe3b2AbTdo"
                                 }
                             ]
                         }
@@ -12727,7 +10894,7 @@
                         }
                     ],
                     "allowed_origins": [],
-                    "client_id": "YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+                    "client_id": "qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
                     "callback_url_template": false,
                     "jwt_configuration": {
                         "alg": "RS256",
@@ -12774,7 +10941,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+                    "client_id": "dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12815,7 +10982,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+                    "client_id": "6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12868,7 +11035,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+                    "client_id": "SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12928,7 +11095,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+                    "client_id": "WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -12986,7 +11153,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+                    "client_id": "nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13010,18 +11177,18 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw/credentials",
+        "path": "/api/v2/clients/qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI/credentials",
         "body": "",
         "status": 200,
         "response": [
             {
-                "id": "cred_mMuz56jQ8PQww4wqQbH7S5",
+                "id": "cred_21BSV25k7LPDJe3b2AbTdo",
                 "credential_type": "public_key",
                 "kid": "G-gF8B2XrPd_5oBE7CYMnVdbY1zcTsIabrANfO6E_1I",
                 "alg": "RS256",
                 "name": "e2e-test-key",
-                "created_at": "2026-08-10T13:55:22.110Z",
-                "updated_at": "2026-08-10T13:55:22.110Z"
+                "created_at": "2026-09-01T12:16:28.619Z",
+                "updated_at": "2026-09-01T12:16:28.619Z"
             }
         ],
         "rawHeaders": [],
@@ -13030,7 +11197,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/f6BF9jccB1kQfWP3pCi2WmOaHe1AHrst",
+        "path": "/api/v2/clients/NQeTS8WT7x8ZbU4eDUO1mGj5Qb0Z1fK2",
         "body": "",
         "status": 204,
         "response": "",
@@ -13040,7 +11207,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/FIi9NtvvTVrNrxELQdNe1V0YhZQe1RCV",
+        "path": "/api/v2/clients/dvH2lUGfz8n9tyZFRsNpCAtQ7dokPI54",
         "body": "",
         "status": 204,
         "response": "",
@@ -13050,7 +11217,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/YeEDcxEdxhZLufv6j9ukuUaDHXxF5aVw",
+        "path": "/api/v2/clients/qKWkO5CFXSCX8UGs9KNhdRMjYrX4yLHI",
         "body": "",
         "status": 204,
         "response": "",
@@ -13060,7 +11227,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/HW2hCxrqP6OD4cUBkiDtB3TI95L9ckf7",
+        "path": "/api/v2/clients/6Ku3nB9kEJ0TTHhOTNgbNx4kESZgXtsE",
         "body": "",
         "status": 204,
         "response": "",
@@ -13070,7 +11237,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/O2IjFqR3ICEZHXWQDnLB9UBtHtxzxf8i",
+        "path": "/api/v2/clients/SL6zV4IQxiLUsvLpNmH8tHOVYx8WpfDv",
         "body": "",
         "status": 204,
         "response": "",
@@ -13080,7 +11247,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/rKef1UT7WVa658hbPRUBSKKnJgRbhQMY",
+        "path": "/api/v2/clients/WZKEzw8MaCUjWR4WlGTKlQ1W9rUcIYyE",
         "body": "",
         "status": 204,
         "response": "",
@@ -13090,7 +11257,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/clients/ueTajUntFwiMC0BIZUHBdv0GHUQFLM1k",
+        "path": "/api/v2/clients/nKXOYOWNb0PrqYOtMQqTQ8q6zBsf4h9u",
         "body": "",
         "status": 204,
         "response": "",
@@ -13161,7 +11328,7 @@
                     "subject": "/CN=auth0-deploy-cli-e2e.us.auth0.com"
                 }
             ],
-            "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+            "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
             "callback_url_template": false,
             "client_secret": "[REDACTED]",
             "jwt_configuration": {
@@ -13183,7 +11350,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/email",
+        "path": "/api/v2/guardian/factors/duo",
         "body": {
             "enabled": false
         },
@@ -13197,7 +11364,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/duo",
+        "path": "/api/v2/guardian/factors/email",
         "body": {
             "enabled": false
         },
@@ -13225,7 +11392,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/recovery-code",
+        "path": "/api/v2/guardian/factors/sms",
         "body": {
             "enabled": false
         },
@@ -13239,7 +11406,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/sms",
+        "path": "/api/v2/guardian/factors/recovery-code",
         "body": {
             "enabled": false
         },
@@ -13267,7 +11434,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/webauthn-platform",
+        "path": "/api/v2/guardian/factors/push-notification",
         "body": {
             "enabled": false
         },
@@ -13281,7 +11448,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PUT",
-        "path": "/api/v2/guardian/factors/push-notification",
+        "path": "/api/v2/guardian/factors/webauthn-platform",
         "body": {
             "enabled": false
         },
@@ -13352,6 +11519,7 @@
                 "user_notification"
             ],
             "mode": "count_per_identifier_and_ip",
+            "form_submission_behavior": "auto_submit",
             "allowlist": [],
             "max_attempts": 10
         },
@@ -13458,7 +11626,7 @@
         "response": {
             "actions": [
                 {
-                    "id": "bd67e734-b6ed-4478-a21f-f5646fe69118",
+                    "id": "eeed49f4-903d-45fb-b428-9bd32678edc4",
                     "name": "My Custom Action",
                     "supported_triggers": [
                         {
@@ -13466,34 +11634,34 @@
                             "version": "v2"
                         }
                     ],
-                    "created_at": "2026-08-10T13:55:04.937881440Z",
-                    "updated_at": "2026-08-10T13:58:58.256171458Z",
+                    "created_at": "2026-09-01T12:16:10.591262148Z",
+                    "updated_at": "2026-09-01T12:16:10.606852319Z",
                     "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                     "dependencies": [],
                     "runtime": "node18",
                     "status": "built",
                     "secrets": [],
                     "current_version": {
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "runtime": "node18",
                         "status": "BUILT",
-                        "number": 2,
-                        "build_time": "2026-08-10T13:58:58.918670443Z",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z"
+                        "number": 1,
+                        "build_time": "2026-09-01T12:16:11.370071109Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z"
                     },
                     "deployed_version": {
                         "code": "/**\n * Handler that will be called during the execution of a PostLogin flow.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\nexports.onExecutePostLogin = async (event, api) => {\n  console.log('Some custom action!');\n};\n\n/**\n * Handler that will be invoked when this action is resuming after an external redirect. If your\n * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.\n *\n * @param {Event} event - Details about the user and the context in which they are logging in.\n * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.\n */\n// exports.onContinuePostLogin = async (event, api) => {\n// };\n",
                         "dependencies": [],
-                        "id": "3b4250ec-e722-4eb0-bacf-d015741996ec",
+                        "id": "40b47178-7257-426c-9cb6-9bc75c8b5786",
                         "deployed": true,
-                        "number": 2,
-                        "built_at": "2026-08-10T13:58:58.918670443Z",
+                        "number": 1,
+                        "built_at": "2026-09-01T12:16:11.370071109Z",
                         "secrets": [],
                         "status": "built",
-                        "created_at": "2026-08-10T13:58:58.846471999Z",
-                        "updated_at": "2026-08-10T13:58:58.919104626Z",
+                        "created_at": "2026-09-01T12:16:11.264413432Z",
+                        "updated_at": "2026-09-01T12:16:11.371114484Z",
                         "runtime": "node18",
                         "supported_triggers": [
                             {
@@ -13514,7 +11682,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/actions/actions/bd67e734-b6ed-4478-a21f-f5646fe69118?force=true",
+        "path": "/api/v2/actions/actions/eeed49f4-903d-45fb-b428-9bd32678edc4?force=true",
         "body": "",
         "status": 204,
         "response": "",
@@ -13556,7 +11724,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_u6eDOnzfycy2sDLb",
+                    "id": "con_lEo3NS2yglrPS29s",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -13720,7 +11888,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -13796,87 +11964,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50&strategy=auth0",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_u6eDOnzfycy2sDLb",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "import_mode": false,
-                        "customScripts": {
-                            "login": "function login(email, password, callback) {\n  // This script should authenticate a user against the credentials stored in\n  // your database.\n  // It is executed when a user attempts to log in or immediately after signing\n  // up (as a verification that the user was successfully signed up).\n  //\n  // Everything returned by this script will be set as part of the user profile\n  // and will be visible by any of the tenant admins. Avoid adding attributes\n  // with values such as passwords, keys, secrets, etc.\n  //\n  // The `password` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database. For example:\n  //\n  //     var bcrypt = require('bcrypt@0.8.5');\n  //     bcrypt.compare(password, dbPasswordHash, function(err, res)) { ... }\n  //\n  // There are three ways this script can finish:\n  // 1. The user's credentials are valid. The returned user profile should be in\n  // the following format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema\n  //     var profile = {\n  //       user_id: ..., // user_id is mandatory\n  //       email: ...,\n  //       [...]\n  //     };\n  //     callback(null, profile);\n  // 2. The user's credentials are invalid\n  //     callback(new WrongUsernameOrPasswordError(email, \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n  //\n  // A list of Node.js modules which can be referenced is available here:\n  //\n  //    https://tehsis.github.io/webtaskio-canirequire/\n  console.log('AYYYYYE');\n\n  const msg =\n    'Please implement the Login script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "create": "function create(user, callback) {\n  // This script should create a user entry in your existing database. It will\n  // be executed when a user attempts to sign up, or when a user is created\n  // through the Auth0 dashboard or API.\n  // When this script has finished executing, the Login script will be\n  // executed immediately afterwards, to verify that the user was created\n  // successfully.\n  //\n  // The user object will always contain the following properties:\n  // * email: the user's email\n  // * password: the password entered by the user, in plain text\n  // * tenant: the name of this Auth0 account\n  // * client_id: the client ID of the application where the user signed up, or\n  //              API key if created through the API or Auth0 dashboard\n  // * connection: the name of this database connection\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully created\n  //     callback(null);\n  // 2. This user already exists in your database\n  //     callback(new ValidationError(\"user_exists\", \"my error message\"));\n  // 3. Something went wrong while trying to reach your database\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Create script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "delete": "function remove(id, callback) {\n  // This script remove a user from your existing database.\n  // It is executed whenever a user is deleted from the API or Auth0 dashboard.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user was removed successfully:\n  //     callback(null);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Delete script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "verify": "function verify(email, callback) {\n  // This script should mark the current user's email address as verified in\n  // your database.\n  // It is executed whenever a user clicks the verification link sent by email.\n  // These emails can be customized at https://manage.auth0.com/#/emails.\n  // It is safe to assume that the user's email already exists in your database,\n  // because verification emails, if enabled, are sent immediately after a\n  // successful signup.\n  //\n  // There are two ways that this script can finish:\n  // 1. The user's email was verified successfully\n  //     callback(null, true);\n  // 2. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the verification link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Verify script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "get_user": "function getByEmail(email, callback) {\n  // This script should retrieve a user profile from your existing database,\n  // without authenticating the user.\n  // It is used to check if a user exists before executing flows that do not\n  // require authentication (signup and password reset).\n  //\n  // There are three ways this script can finish:\n  // 1. A user was successfully found. The profile should be in the following\n  // format: https://auth0.com/docs/users/normalized/auth0/normalized-user-profile-schema.\n  //     callback(null, profile);\n  // 2. A user was not found\n  //     callback(null);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n\n  const msg =\n    'Please implement the Get User script for this database connection ' +\n    'at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n",
-                            "change_password": "function changePassword(email, newPassword, callback) {\n  // This script should change the password stored for the current user in your\n  // database. It is executed when the user clicks on the confirmation link\n  // after a reset password request.\n  // The content and behavior of password confirmation emails can be customized\n  // here: https://manage.auth0.com/#/emails\n  // The `newPassword` parameter of this function is in plain text. It must be\n  // hashed/salted to match whatever is stored in your database.\n  //\n  // There are three ways that this script can finish:\n  // 1. The user's password was updated successfully:\n  //     callback(null, true);\n  // 2. The user's password was not updated:\n  //     callback(null, false);\n  // 3. Something went wrong while trying to reach your database:\n  //     callback(new Error(\"my error message\"));\n  //\n  // If an error is returned, it will be passed to the query string of the page\n  // where the user is being redirected to after clicking the confirmation link.\n  // For example, returning `callback(new Error(\"error\"))` and redirecting to\n  // https://example.com would redirect to the following URL:\n  //     https://example.com?email=alice%40example.com&message=error&success=false\n\n  const msg =\n    'Please implement the Change Password script for this database ' +\n    'connection at https://manage.auth0.com/#/connections/database';\n  return callback(new Error(msg));\n}\n"
-                        },
-                        "disable_signup": false,
-                        "passwordPolicy": "low",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_history": {
-                            "size": 5,
-                            "enable": false
-                        },
-                        "strategy_version": 2,
-                        "requires_username": true,
-                        "password_dictionary": {
-                            "enable": true,
-                            "dictionary": []
-                        },
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "password_no_personal_info": {
-                            "enable": true
-                        },
-                        "password_complexity_options": {
-                            "min_length": 8
-                        },
-                        "enabledDatabaseCustomization": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "boo-baz-db-connection-test",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "boo-baz-db-connection-test"
-                    ],
-                    "enabled_clients": []
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb/clients?take=100",
+        "path": "/api/v2/connections/con_lEo3NS2yglrPS29s/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -13888,11 +11976,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_u6eDOnzfycy2sDLb",
+        "path": "/api/v2/connections/con_lEo3NS2yglrPS29s",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-08-10T13:59:29.479Z"
+            "deleted_at": "2026-09-01T12:16:45.988Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -13921,7 +12009,7 @@
         },
         "status": 201,
         "response": {
-            "id": "con_aLhZ4KAMwSo6RqKA",
+            "id": "con_F4vfRV19FwqdHXJp",
             "options": {
                 "mfa": {
                     "active": true,
@@ -13931,38 +12019,6 @@
                 "strategy_version": 2,
                 "brute_force_protection": true,
                 "disable_self_service_change_password": false,
-                "password_options": {
-                    "complexity": {
-                        "character_type_rule": "all",
-                        "identical_characters": "allow",
-                        "sequential_characters": "allow",
-                        "max_length_exceeded": "error",
-                        "min_length": 15,
-                        "character_types": []
-                    },
-                    "profile_data": {
-                        "active": false,
-                        "blocked_fields": [
-                            "name",
-                            "username",
-                            "nickname",
-                            "email",
-                            "phone_number",
-                            "user_metadata.name",
-                            "user_metadata.first",
-                            "user_metadata.last"
-                        ]
-                    },
-                    "history": {
-                        "active": false,
-                        "size": 3
-                    },
-                    "dictionary": {
-                        "active": false,
-                        "custom": [],
-                        "default": "en_100k"
-                    }
-                },
                 "authentication_methods": {
                     "password": {
                         "enabled": true,
@@ -14005,7 +12061,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
+                    "id": "con_F4vfRV19FwqdHXJp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14016,38 +12072,6 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -14085,14 +12109,14 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "PATCH",
-        "path": "/api/v2/connections/con_aLhZ4KAMwSo6RqKA/clients",
+        "path": "/api/v2/connections/con_F4vfRV19FwqdHXJp/clients",
         "body": [
             {
                 "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
                 "status": true
             },
             {
-                "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                 "status": true
             }
         ],
@@ -14194,7 +12218,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14263,7 +12287,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_Dyc8vFGQ4ncArPi0",
+                    "id": "con_JGKwgb1jNU2qksAS",
                     "options": {
                         "email": true,
                         "scope": [
@@ -14287,7 +12311,7 @@
                     "enabled_clients": []
                 },
                 {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
+                    "id": "con_F4vfRV19FwqdHXJp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -14298,38 +12322,6 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -14359,7 +12351,88 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
+                        "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
+                    ]
+                }
+            ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/connections?include_totals=true&take=50",
+        "body": "",
+        "status": 200,
+        "response": {
+            "connections": [
+                {
+                    "id": "con_JGKwgb1jNU2qksAS",
+                    "options": {
+                        "email": true,
+                        "scope": [
+                            "email",
+                            "profile"
+                        ],
+                        "profile": true
+                    },
+                    "strategy": "google-oauth2",
+                    "name": "google-oauth2",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "google-oauth2"
+                    ],
+                    "enabled_clients": []
+                },
+                {
+                    "id": "con_F4vfRV19FwqdHXJp",
+                    "options": {
+                        "mfa": {
+                            "active": true,
+                            "return_enroll_settings": true
+                        },
+                        "passwordPolicy": "good",
+                        "passkey_options": {
+                            "challenge_ui": "both",
+                            "local_enrollment_enabled": true,
+                            "progressive_enrollment_enabled": true
+                        },
+                        "strategy_version": 2,
+                        "authentication_methods": {
+                            "passkey": {
+                                "enabled": false
+                            },
+                            "password": {
+                                "enabled": true,
+                                "api_behavior": "required",
+                                "signup_behavior": "allow"
+                            }
+                        },
+                        "brute_force_protection": true,
+                        "disable_self_service_change_password": false
+                    },
+                    "strategy": "auth0",
+                    "name": "Username-Password-Authentication",
+                    "is_domain_connection": false,
+                    "authentication": {
+                        "active": true
+                    },
+                    "connected_accounts": {
+                        "active": false
+                    },
+                    "realms": [
+                        "Username-Password-Authentication"
+                    ],
+                    "enabled_clients": [
+                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
+                        "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
                     ]
                 }
             ]
@@ -14385,120 +12458,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections?include_totals=true&take=50",
-        "body": "",
-        "status": 200,
-        "response": {
-            "connections": [
-                {
-                    "id": "con_Dyc8vFGQ4ncArPi0",
-                    "options": {
-                        "email": true,
-                        "scope": [
-                            "email",
-                            "profile"
-                        ],
-                        "profile": true
-                    },
-                    "strategy": "google-oauth2",
-                    "name": "google-oauth2",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "google-oauth2"
-                    ],
-                    "enabled_clients": []
-                },
-                {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
-                    "options": {
-                        "mfa": {
-                            "active": true,
-                            "return_enroll_settings": true
-                        },
-                        "passwordPolicy": "good",
-                        "passkey_options": {
-                            "challenge_ui": "both",
-                            "local_enrollment_enabled": true,
-                            "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
-                        },
-                        "strategy_version": 2,
-                        "authentication_methods": {
-                            "passkey": {
-                                "enabled": false
-                            },
-                            "password": {
-                                "enabled": true,
-                                "api_behavior": "required",
-                                "signup_behavior": "allow"
-                            }
-                        },
-                        "brute_force_protection": true,
-                        "disable_self_service_change_password": false
-                    },
-                    "strategy": "auth0",
-                    "name": "Username-Password-Authentication",
-                    "is_domain_connection": false,
-                    "authentication": {
-                        "active": true
-                    },
-                    "connected_accounts": {
-                        "active": false
-                    },
-                    "realms": [
-                        "Username-Password-Authentication"
-                    ],
-                    "enabled_clients": [
-                        "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
-                    ]
-                }
-            ]
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0/clients?take=100",
+        "path": "/api/v2/connections/con_JGKwgb1jNU2qksAS/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
@@ -14510,11 +12470,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/connections/con_Dyc8vFGQ4ncArPi0",
+        "path": "/api/v2/connections/con_JGKwgb1jNU2qksAS",
         "body": "",
         "status": 202,
         "response": {
-            "deleted_at": "2026-08-10T13:59:34.671Z"
+            "deleted_at": "2026-09-01T12:16:51.402Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -14646,7 +12606,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -14968,25 +12928,25 @@
         "response": {
             "roles": [
                 {
-                    "id": "rol_suBuW3gIaoRKQ2YI",
+                    "id": "rol_hhvfGEVOLl3nYVSB",
                     "name": "Admin",
                     "description": "Can read and write things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_ULMlbmvvd3mzoPwt",
+                    "id": "rol_Mog9JkKkC1ABJX66",
                     "name": "Reader",
                     "description": "Can only read things",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_lkZCKwORLWaTSWuv",
+                    "id": "rol_oC8EIPEFnHsR8yQu",
                     "name": "read_only",
                     "description": "Read Only",
                     "type": "tenant"
                 },
                 {
-                    "id": "rol_sQEZiIEgfOQdKTLk",
+                    "id": "rol_WVD3cZM2xor934Nl",
                     "name": "read_osnly",
                     "description": "Readz Only",
                     "type": "tenant"
@@ -15002,7 +12962,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_hhvfGEVOLl3nYVSB/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15017,7 +12977,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_Mog9JkKkC1ABJX66/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15032,7 +12992,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_oC8EIPEFnHsR8yQu/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15047,7 +13007,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk/permissions?per_page=100&page=0&include_totals=true",
+        "path": "/api/v2/roles/rol_WVD3cZM2xor934Nl/permissions?per_page=100&page=0&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15062,7 +13022,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_suBuW3gIaoRKQ2YI",
+        "path": "/api/v2/roles/rol_Mog9JkKkC1ABJX66",
         "body": "",
         "status": 200,
         "response": {},
@@ -15072,7 +13032,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_ULMlbmvvd3mzoPwt",
+        "path": "/api/v2/roles/rol_hhvfGEVOLl3nYVSB",
         "body": "",
         "status": 200,
         "response": {},
@@ -15082,7 +13042,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_sQEZiIEgfOQdKTLk",
+        "path": "/api/v2/roles/rol_oC8EIPEFnHsR8yQu",
         "body": "",
         "status": 200,
         "response": {},
@@ -15092,7 +13052,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/roles/rol_lkZCKwORLWaTSWuv",
+        "path": "/api/v2/roles/rol_WVD3cZM2xor934Nl",
         "body": "",
         "status": 200,
         "response": {},
@@ -15108,14 +13068,14 @@
         "response": {
             "organizations": [
                 {
-                    "id": "org_SrEMrFYV9b6phMSo",
+                    "id": "org_dDjIMu0QNzrSxxQF",
                     "name": "org2",
                     "display_name": "Organization2",
                     "third_party_client_access": "block",
                     "is_app_entitlement_active": false
                 },
                 {
-                    "id": "org_heCvrp0Pkxw4ilGg",
+                    "id": "org_8QNnnjHEXgiuo3Xi",
                     "name": "org1",
                     "display_name": "Organization",
                     "branding": {
@@ -15225,7 +13185,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15288,7 +13248,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_dDjIMu0QNzrSxxQF/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15303,7 +13263,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_dDjIMu0QNzrSxxQF/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15318,7 +13278,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_dDjIMu0QNzrSxxQF/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15330,7 +13290,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo/clients?take=50",
+        "path": "/api/v2/organizations/org_dDjIMu0QNzrSxxQF/clients?take=50",
         "body": "",
         "status": 403,
         "response": {
@@ -15345,7 +13305,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/connections?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_8QNnnjHEXgiuo3Xi/connections?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15360,7 +13320,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/client-grants?page=0&per_page=50&include_totals=true",
+        "path": "/api/v2/organizations/org_8QNnnjHEXgiuo3Xi/client-grants?page=0&per_page=50&include_totals=true",
         "body": "",
         "status": 200,
         "response": {
@@ -15375,7 +13335,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/discovery-domains?take=50",
+        "path": "/api/v2/organizations/org_8QNnnjHEXgiuo3Xi/discovery-domains?take=50",
         "body": "",
         "status": 200,
         "response": {
@@ -15387,7 +13347,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg/clients?take=50",
+        "path": "/api/v2/organizations/org_8QNnnjHEXgiuo3Xi/clients?take=50",
         "body": "",
         "status": 403,
         "response": {
@@ -15408,7 +13368,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
+                    "id": "con_F4vfRV19FwqdHXJp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -15419,38 +13379,6 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -15480,7 +13408,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
+                        "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
                     ]
                 }
             ]
@@ -15834,7 +13762,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -15897,7 +13825,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_heCvrp0Pkxw4ilGg",
+        "path": "/api/v2/organizations/org_dDjIMu0QNzrSxxQF",
         "body": "",
         "status": 204,
         "response": "",
@@ -15907,7 +13835,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/organizations/org_SrEMrFYV9b6phMSo",
+        "path": "/api/v2/organizations/org_8QNnnjHEXgiuo3Xi",
         "body": "",
         "status": 204,
         "response": "",
@@ -15922,7 +13850,7 @@
         "status": 200,
         "response": [
             {
-                "id": "lst_0000000000030347",
+                "id": "lst_0000000000030979",
                 "name": "Suspended DD Log Stream",
                 "type": "datadog",
                 "status": "active",
@@ -15933,14 +13861,14 @@
                 "isPriority": false
             },
             {
-                "id": "lst_0000000000030348",
+                "id": "lst_0000000000030980",
                 "name": "Amazon EventBridge",
                 "type": "eventbridge",
                 "status": "active",
                 "sink": {
                     "awsAccountId": "123456789012",
                     "awsRegion": "us-east-2",
-                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-12f61f8b-bb01-4400-a425-8d3d948df375/auth0.logs"
+                    "awsPartnerEventSource": "aws.partner/auth0.com/auth0-deploy-cli-e2e-dd813140-dcad-4396-a2ac-8c44999772ae/auth0.logs"
                 },
                 "filters": [
                     {
@@ -15989,7 +13917,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000030347",
+        "path": "/api/v2/log-streams/lst_0000000000030979",
         "body": "",
         "status": 204,
         "response": "",
@@ -15999,7 +13927,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "DELETE",
-        "path": "/api/v2/log-streams/lst_0000000000030348",
+        "path": "/api/v2/log-streams/lst_0000000000030980",
         "body": "",
         "status": 204,
         "response": "",
@@ -17490,7 +15418,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -17520,7 +15448,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
+                    "id": "con_F4vfRV19FwqdHXJp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17531,38 +15459,6 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -17592,7 +15488,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
+                        "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
                     ]
                 }
             ]
@@ -17616,13 +15512,13 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/connections/con_aLhZ4KAMwSo6RqKA/clients?take=100",
+        "path": "/api/v2/connections/con_F4vfRV19FwqdHXJp/clients?take=100",
         "body": "",
         "status": 200,
         "response": {
             "clients": [
                 {
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
                 },
                 {
                     "client_id": "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE"
@@ -17656,7 +15552,7 @@
         "response": {
             "connections": [
                 {
-                    "id": "con_aLhZ4KAMwSo6RqKA",
+                    "id": "con_F4vfRV19FwqdHXJp",
                     "options": {
                         "mfa": {
                             "active": true,
@@ -17667,38 +15563,6 @@
                             "challenge_ui": "both",
                             "local_enrollment_enabled": true,
                             "progressive_enrollment_enabled": true
-                        },
-                        "password_options": {
-                            "history": {
-                                "size": 3,
-                                "active": false
-                            },
-                            "complexity": {
-                                "min_length": 15,
-                                "character_types": [],
-                                "character_type_rule": "all",
-                                "max_length_exceeded": "error",
-                                "identical_characters": "allow",
-                                "sequential_characters": "allow"
-                            },
-                            "dictionary": {
-                                "active": false,
-                                "custom": [],
-                                "default": "en_100k"
-                            },
-                            "profile_data": {
-                                "active": false,
-                                "blocked_fields": [
-                                    "name",
-                                    "username",
-                                    "nickname",
-                                    "email",
-                                    "phone_number",
-                                    "user_metadata.name",
-                                    "user_metadata.first",
-                                    "user_metadata.last"
-                                ]
-                            }
                         },
                         "strategy_version": 2,
                         "authentication_methods": {
@@ -17728,7 +15592,7 @@
                     ],
                     "enabled_clients": [
                         "Vp0gMRF8PtMzekil38qWoj4Fjw2VjRZE",
-                        "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw"
+                        "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk"
                     ]
                 }
             ]
@@ -17842,17 +15706,29 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/verify_email",
+        "path": "/api/v2/email-templates/reset_email_by_code",
         "body": "",
-        "status": 200,
+        "status": 404,
         "response": {
-            "template": "verify_email",
-            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
-            "from": "",
-            "subject": "",
-            "syntax": "liquid",
-            "urlLifetimeInSeconds": 432000,
-            "enabled": true
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/blocked_account",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -17875,22 +15751,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/enrollment_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/email-templates/reset_email_by_code",
+        "path": "/api/v2/email-templates/change_password",
         "body": "",
         "status": 404,
         "response": {
@@ -17924,7 +15785,22 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/blocked_account",
+        "path": "/api/v2/email-templates/reset_email",
+        "body": "",
+        "status": 404,
+        "response": {
+            "statusCode": 404,
+            "error": "Not Found",
+            "message": "The template does not exist.",
+            "errorCode": "inexistent_email_template"
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/email-templates/user_invitation",
         "body": "",
         "status": 404,
         "response": {
@@ -17969,21 +15845,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/reset_email",
-        "body": "",
-        "status": 404,
-        "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/email-templates/password_reset",
         "body": "",
         "status": 404,
@@ -17999,7 +15860,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/change_password",
+        "path": "/api/v2/email-templates/enrollment_email",
         "body": "",
         "status": 404,
         "response": {
@@ -18014,14 +15875,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/email-templates/user_invitation",
+        "path": "/api/v2/email-templates/verify_email",
         "body": "",
-        "status": 404,
+        "status": 200,
         "response": {
-            "statusCode": 404,
-            "error": "Not Found",
-            "message": "The template does not exist.",
-            "errorCode": "inexistent_email_template"
+            "template": "verify_email",
+            "body": "<html>\n  <head>\n    <style type=\"text/css\">\n      .ExternalClass,\n      .ExternalClass div,\n      .ExternalClass font,\n      .ExternalClass p,\n      .ExternalClass span,\n      .ExternalClass td,\n      img {\n        line-height: 100%;\n      }\n      #outlook a {\n        padding: 0;\n      }\n      .ExternalClass,\n      .ReadMsgBody {\n        width: 100%;\n      }\n      a,\n      blockquote,\n      body,\n      li,\n      p,\n      table,\n      td {\n        -webkit-text-size-adjust: 100%;\n        -ms-text-size-adjust: 100%;\n      }\n      table,\n      td {\n        mso-table-lspace: 0;\n        mso-table-rspace: 0;\n      }\n      img {\n        -ms-interpolation-mode: bicubic;\n        border: 0;\n        height: auto;\n        outline: 0;\n        text-decoration: none;\n      }\n      table {\n        border-collapse: collapse !important;\n      }\n      #bodyCell,\n      #bodyTable,\n      body {\n        height: 100% !important;\n        margin: 0;\n        padding: 0;\n        font-family: ProximaNova, sans-serif;\n      }\n      #bodyCell {\n        padding: 20px;\n      }\n      #bodyTable {\n        width: 600px;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-regular-webfont-webfont.woff)\n            format('woff');\n        font-weight: 400;\n        font-style: normal;\n      }\n      @font-face {\n        font-family: ProximaNova;\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot);\n        src: url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.eot?#iefix)\n            format('embedded-opentype'),\n          url(https://cdn.auth0.com/fonts/proxima-nova/proximanova-semibold-webfont-webfont.woff)\n            format('woff');\n        font-weight: 600;\n        font-style: normal;\n      }\n      @media only screen and (max-width: 480px) {\n        #bodyTable,\n        body {\n          width: 100% !important;\n        }\n        a,\n        blockquote,\n        body,\n        li,\n        p,\n        table,\n        td {\n          -webkit-text-size-adjust: none !important;\n        }\n        body {\n          min-width: 100% !important;\n        }\n        #bodyTable {\n          max-width: 600px !important;\n        }\n        #signIn {\n          max-width: 280px !important;\n        }\n      }\n    </style>\n  </head>\n  <body>\n    <center>\n      <table\n        style=\"\n          width: 600px;\n          -webkit-text-size-adjust: 100%;\n          -ms-text-size-adjust: 100%;\n          mso-table-lspace: 0pt;\n          mso-table-rspace: 0pt;\n          margin: 0;\n          padding: 0;\n          font-family: 'ProximaNova', sans-serif;\n          border-collapse: collapse !important;\n          height: 100% !important;\n        \"\n        align=\"center\"\n        border=\"0\"\n        cellpadding=\"0\"\n        cellspacing=\"0\"\n        height=\"100%\"\n        width=\"100%\"\n        id=\"bodyTable\"\n      >\n        <tr>\n          <td\n            align=\"center\"\n            valign=\"top\"\n            id=\"bodyCell\"\n            style=\"\n              -webkit-text-size-adjust: 100%;\n              -ms-text-size-adjust: 100%;\n              mso-table-lspace: 0pt;\n              mso-table-rspace: 0pt;\n              margin: 0;\n              padding: 20px;\n              font-family: 'ProximaNova', sans-serif;\n              height: 100% !important;\n            \"\n          >\n            <div class=\"main\">\n              <p\n                style=\"\n                  text-align: center;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                  margin-bottom: 30px;\n                \"\n              >\n                <img\n                  src=\"https://cdn.auth0.com/styleguide/2.0.9/lib/logos/img/badge.png\"\n                  width=\"50\"\n                  alt=\"Your logo goes here\"\n                  style=\"\n                    -ms-interpolation-mode: bicubic;\n                    border: 0;\n                    height: auto;\n                    line-height: 100%;\n                    outline: none;\n                    text-decoration: none;\n                  \"\n                />\n              </p>\n\n              <h1>Welcome to {{ application.name}}!</h1>\n\n              <p>\n                Thank you for signing up. Please verify your email address by clicking the following\n                link:\n              </p>\n\n              <p><a href=\"{{ url }}\">Confirm my account</a></p>\n\n              <p>\n                If you are having any issues with your account, please don’t hesitate to contact us\n                by replying to this mail.\n              </p>\n\n              <br />\n              Haha!!!\n              <br />\n\n              <strong>{{ application.name }}</strong>\n\n              <br /><br />\n              <hr style=\"border: 2px solid #eaeef3; border-bottom: 0; margin: 20px 0\" />\n              <p\n                style=\"\n                  text-align: center;\n                  color: #a9b3bc;\n                  -webkit-text-size-adjust: 100%;\n                  -ms-text-size-adjust: 100%;\n                \"\n              >\n                If you did not make this request, please contact us by replying to this mail.\n              </p>\n            </div>\n          </td>\n        </tr>\n      </table>\n    </center>\n  </body>\n</html>\n",
+            "from": "",
+            "subject": "",
+            "syntax": "liquid",
+            "urlLifetimeInSeconds": 432000,
+            "enabled": true
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -18333,7 +16197,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
+        "path": "/api/v2/guardian/factors/sms/providers/twilio",
         "body": "",
         "status": 200,
         "response": {},
@@ -18343,7 +16207,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/guardian/factors/sms/providers/twilio",
+        "path": "/api/v2/guardian/factors/push-notification/providers/sns",
         "body": "",
         "status": 200,
         "response": {},
@@ -18461,7 +16325,7 @@
                     },
                     "credentials": null,
                     "created_at": "2025-12-09T12:24:00.604Z",
-                    "updated_at": "2026-08-07T09:04:29.688Z"
+                    "updated_at": "2026-08-12T09:59:37.540Z"
                 }
             ]
         },
@@ -18483,7 +16347,7 @@
                     "type": "otp_enroll",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:25.327Z",
-                    "updated_at": "2026-08-07T09:04:31.611Z",
+                    "updated_at": "2026-08-12T09:59:39.430Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18499,7 +16363,7 @@
                     "type": "otp_verify",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:30.547Z",
-                    "updated_at": "2026-08-07T09:04:31.494Z",
+                    "updated_at": "2026-08-12T09:59:39.447Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18515,7 +16379,7 @@
                     "type": "change_password",
                     "disabled": false,
                     "created_at": "2025-12-09T12:26:20.243Z",
-                    "updated_at": "2026-08-07T09:04:31.621Z",
+                    "updated_at": "2026-08-12T09:59:39.575Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18531,7 +16395,7 @@
                     "type": "blocked_account",
                     "disabled": false,
                     "created_at": "2025-12-09T12:22:47.683Z",
-                    "updated_at": "2026-08-07T09:04:31.802Z",
+                    "updated_at": "2026-08-12T09:59:39.767Z",
                     "content": {
                         "syntax": "liquid",
                         "body": {
@@ -18665,7 +16529,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "path": "/api/v2/prompts/signup/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18685,7 +16549,17 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup/custom-text/en",
+        "path": "/api/v2/prompts/login-email-verification/custom-text/en",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/signup-password/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18705,7 +16579,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-password/custom-text/en",
+        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18726,16 +16600,6 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/phone-identifier-challenge/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/prompts/phone-identifier-enrollment/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18775,7 +16639,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/customized-consent/custom-text/en",
+        "path": "/api/v2/prompts/logout/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18785,7 +16649,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/logout/custom-text/en",
+        "path": "/api/v2/prompts/customized-consent/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18805,7 +16669,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
+        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18815,7 +16679,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-voice/custom-text/en",
+        "path": "/api/v2/prompts/mfa-otp/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18835,7 +16699,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
+        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18845,7 +16709,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/mfa-webauthn/custom-text/en",
+        "path": "/api/v2/prompts/mfa-sms/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18875,16 +16739,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/status/custom-text/en",
-        "body": "",
-        "status": 200,
-        "response": {},
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/prompts/mfa/custom-text/en",
         "body": "",
         "status": 200,
@@ -18905,7 +16759,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
+        "path": "/api/v2/prompts/status/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18925,7 +16779,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/organizations/custom-text/en",
+        "path": "/api/v2/prompts/email-otp-challenge/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18935,7 +16789,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/invitation/custom-text/en",
+        "path": "/api/v2/prompts/organizations/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18955,7 +16809,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/passkeys/custom-text/en",
+        "path": "/api/v2/prompts/invitation/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18985,7 +16839,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/login/partials",
+        "path": "/api/v2/prompts/passkeys/custom-text/en",
         "body": "",
         "status": 200,
         "response": {},
@@ -18996,6 +16850,16 @@
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
         "path": "/api/v2/prompts/login-password/partials",
+        "body": "",
+        "status": 200,
+        "response": {},
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/prompts/login/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19035,7 +16899,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-id/partials",
+        "path": "/api/v2/prompts/signup-password/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19055,7 +16919,7 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/prompts/signup-password/partials",
+        "path": "/api/v2/prompts/signup-id/partials",
         "body": "",
         "status": 200,
         "response": {},
@@ -19132,17 +16996,6 @@
                 },
                 {
                     "id": "post-login",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "post-login",
                     "version": "v2",
                     "status": "DEPRECATED",
                     "runtimes": [
@@ -19154,14 +17007,13 @@
                     "compatible_triggers": []
                 },
                 {
-                    "id": "credentials-exchange",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "id": "post-login",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19173,6 +17025,18 @@
                         "node22"
                     ],
                     "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "credentials-exchange",
+                    "version": "v2",
+                    "status": "CURRENT",
+                    "runtimes": [
+                        "node18-actions",
+                        "node22"
+                    ],
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19201,24 +17065,24 @@
                 },
                 {
                     "id": "post-user-registration",
-                    "version": "v1",
-                    "status": "DEPRECATED",
+                    "version": "v2",
+                    "status": "CURRENT",
                     "runtimes": [
+                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node12",
+                    "default_runtime": "node22",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
                 {
                     "id": "post-user-registration",
-                    "version": "v2",
-                    "status": "CURRENT",
+                    "version": "v1",
+                    "status": "DEPRECATED",
                     "runtimes": [
-                        "node18-actions",
                         "node22"
                     ],
-                    "default_runtime": "node22",
+                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19247,6 +17111,17 @@
                 },
                 {
                     "id": "send-phone-message",
+                    "version": "v1",
+                    "status": "DEPRECATED",
+                    "runtimes": [
+                        "node22"
+                    ],
+                    "default_runtime": "node12",
+                    "binding_policy": "trigger-bound",
+                    "compatible_triggers": []
+                },
+                {
+                    "id": "send-phone-message",
                     "version": "v2",
                     "status": "CURRENT",
                     "runtimes": [
@@ -19254,17 +17129,6 @@
                         "node22"
                     ],
                     "default_runtime": "node22",
-                    "binding_policy": "trigger-bound",
-                    "compatible_triggers": []
-                },
-                {
-                    "id": "send-phone-message",
-                    "version": "v1",
-                    "status": "DEPRECATED",
-                    "runtimes": [
-                        "node22"
-                    ],
-                    "default_runtime": "node12",
                     "binding_policy": "trigger-bound",
                     "compatible_triggers": []
                 },
@@ -19628,7 +17492,7 @@
                             "subject": "deprecated"
                         }
                     ],
-                    "client_id": "toqcNRUMWAyNGhwjLrHn7kfuHLyG0Jlw",
+                    "client_id": "bPFDkASgT7PQyuqN9UPSjZHJ6zTCCFzk",
                     "callback_url_template": false,
                     "client_secret": "[REDACTED]",
                     "jwt_configuration": {
@@ -19724,6 +17588,7 @@
                 "user_notification"
             ],
             "mode": "count_per_identifier_and_ip",
+            "form_submission_behavior": "auto_submit",
             "allowlist": [],
             "max_attempts": 10
         },
@@ -19816,11 +17681,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings/new-device",
+        "path": "/api/v2/risk-assessments/settings",
         "body": "",
         "status": 200,
         "response": {
-            "remember_for": 30
+            "enabled": false
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19828,11 +17693,11 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/risk-assessments/settings",
+        "path": "/api/v2/risk-assessments/settings/new-device",
         "body": "",
         "status": 200,
         "response": {
-            "enabled": false
+            "remember_for": 30
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19875,21 +17740,6 @@
     {
         "scope": "https://deploy-cli-dev.eu.auth0.com:443",
         "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
         "path": "/api/v2/forms?page=0&per_page=100&include_totals=true",
         "body": "",
         "status": 200,
@@ -19903,9 +17753,24 @@
                     "name": "Blank-form",
                     "flow_count": 0,
                     "created_at": "2024-11-26T11:58:18.187Z",
-                    "updated_at": "2026-08-10T13:59:17.158Z"
+                    "updated_at": "2026-09-01T12:16:33.655Z"
                 }
             ]
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -19974,22 +17839,7 @@
                 }
             },
             "created_at": "2024-11-26T11:58:18.187Z",
-            "updated_at": "2026-08-10T13:59:17.158Z"
-        },
-        "rawHeaders": [],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
-        "method": "GET",
-        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
-        "body": "",
-        "status": 200,
-        "response": {
-            "limit": 100,
-            "start": 0,
-            "total": 0,
-            "flows": []
+            "updated_at": "2026-09-01T12:16:33.655Z"
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -20005,6 +17855,21 @@
             "start": 0,
             "total": 0,
             "connections": []
+        },
+        "rawHeaders": [],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://deploy-cli-dev.eu.auth0.com:443",
+        "method": "GET",
+        "path": "/api/v2/flows?page=0&per_page=100&include_totals=true",
+        "body": "",
+        "status": 200,
+        "response": {
+            "limit": 100,
+            "start": 0,
+            "total": 0,
+            "flows": []
         },
         "rawHeaders": [],
         "responseIsBinary": false
@@ -20053,7 +17918,7 @@
                         "okta"
                     ],
                     "created_at": "2024-11-26T11:58:18.962Z",
-                    "updated_at": "2026-08-10T13:59:07.048Z",
+                    "updated_at": "2026-09-01T12:16:24.961Z",
                     "branding": {
                         "colors": {
                             "primary": "#19aecc"
@@ -20105,7 +17970,7 @@
                         }
                     },
                     "created_at": "2026-01-29T08:17:51.522Z",
-                    "updated_at": "2026-08-10T13:58:56.622Z",
+                    "updated_at": "2026-09-01T12:16:08.693Z",
                     "id": "acl_5EgHsY1h2Apnv4cvsM6Q9J"
                 }
             ]
@@ -20256,7 +18121,7 @@
                         }
                     ],
                     "created_at": "2026-06-29T10:28:33.962Z",
-                    "updated_at": "2026-08-10T13:59:13.605Z",
+                    "updated_at": "2026-09-01T12:16:29.907Z",
                     "destination": {
                         "type": "webhook",
                         "configuration": {

--- a/test/tools/auth0/handlers/dryRun.tests.ts
+++ b/test/tools/auth0/handlers/dryRun.tests.ts
@@ -185,6 +185,50 @@ describe('#handler dryRunChanges', () => {
     expect(changes.create).to.have.length(0);
   });
 
+  it('databases should not enrich enabled_clients when the connection has none enabled', async () => {
+    const auth0 = {
+      connections: {
+        list: (params: any) =>
+          mockPagedData(params, 'connections', [
+            {
+              id: 'con1',
+              name: 'db-one',
+              strategy: 'auth0',
+              options: {},
+            },
+          ]),
+        clients: {
+          // dedicated endpoint reports no enabled clients, so the remote stays un-enriched
+          get: (_connectionId: any, params: any) => mockPagedData(params, 'connections', []),
+        },
+      },
+      clients: {
+        list: (params: any) =>
+          mockPagedData(params, 'clients', [{ name: 'app-one', client_id: 'client-id-1' }]),
+      },
+      actions: {
+        list: (params: any) => mockPagedData(params, 'actions', []),
+      },
+      pool,
+    };
+
+    const handler = new DatabasesHandler({ client: pageClient(auth0 as any), config } as any);
+
+    const changes = await handler.dryRunChanges({
+      databases: [
+        {
+          name: 'db-one',
+          options: {},
+          // local wants a client enabled that the remote does not have -> genuine update
+          enabled_clients: ['app-one'],
+        },
+      ],
+    } as any);
+
+    expect(changes.create).to.have.length(0);
+    expect(changes.update).to.have.length(1);
+  });
+
   it('actions should enrich module IDs during dry run', async () => {
     const auth0 = {
       actions: {

--- a/test/tools/auth0/handlers/dryRun.tests.ts
+++ b/test/tools/auth0/handlers/dryRun.tests.ts
@@ -141,6 +141,50 @@ describe('#handler dryRunChanges', () => {
     expect(changes.update).to.have.length(0);
   });
 
+  it('databases should not report enabled_clients diff when remote clients match', async () => {
+    const auth0 = {
+      connections: {
+        list: (params: any) =>
+          mockPagedData(params, 'connections', [
+            {
+              id: 'con1',
+              name: 'db-one',
+              strategy: 'auth0',
+              options: {},
+            },
+          ]),
+        clients: {
+          // enabled_clients only comes from this dedicated endpoint, not from connections.list
+          get: (_connectionId: any, params: any) =>
+            mockPagedData(params, 'connections', [{ client_id: 'client-id-1' }]),
+        },
+      },
+      clients: {
+        list: (params: any) =>
+          mockPagedData(params, 'clients', [{ name: 'app-one', client_id: 'client-id-1' }]),
+      },
+      actions: {
+        list: (params: any) => mockPagedData(params, 'actions', []),
+      },
+      pool,
+    };
+
+    const handler = new DatabasesHandler({ client: pageClient(auth0 as any), config } as any);
+
+    const changes = await handler.dryRunChanges({
+      databases: [
+        {
+          name: 'db-one',
+          options: {},
+          enabled_clients: ['app-one'],
+        },
+      ],
+    } as any);
+
+    expect(changes.update).to.have.length(0);
+    expect(changes.create).to.have.length(0);
+  });
+
   it('actions should enrich module IDs during dry run', async () => {
     const auth0 = {
       actions: {


### PR DESCRIPTION
### 🔧 Changes

Fixes a false positive in `--dry-run` mode where database connections with `enabled_clients` were incorrectly reported as changed.

In the database dry-run path (`dryRunChanges`), the local connection had its `enabled_clients` populated, but the remote connection it was compared against was fetched from `connections.list`, which no longer returns `enabled_clients` inline. The field now lives behind the dedicated enabled-clients endpoint. Because the remote object lacked the key entirely, the diff reported a false difference:

````
Key [<connection>.enabled_clients] found in 'localObj' but not in 'remoteObj'.
````

The fix enriches the remote connections with their `enabled_clients` via `getConnectionEnabledClients` before diffing, mirroring what the real import path already does in `getType()`. The change is scoped entirely to `dryRunChanges`, so real import and export behavior is untouched.

### 📚 References

- DXCDT-2281
- Related dry-run reporting fixes: #1462

### 🔬 Testing

Added a regression test in `test/tools/auth0/handlers/dryRun.tests.ts` that fails on the old code (reports a spurious update) and passes with the fix.

Verified end to end against live tenants: exported a tenant to a directory, then ran a dry-run against the identical export. On tenants whose `connections.list` omits `enabled_clients` inline, the old code produced the false positive and the fix removes it. Confirmed the real import and export paths are unaffected.

To reproduce manually:

````
npx a0deploy export -c=config.json --format=directory --output_folder=local
npx a0deploy import -c=config.json --input_file=local --dry-run --debug
````

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
