### PR TITLE
feat: add otp_settings support for database connections

### DIFF
--- a/src/tools/auth0/handlers/databases.ts
+++ b/src/tools/auth0/handlers/databases.ts
@@ -152,6 +152,25 @@ export const schema = {
               action_id: { type: 'string' },
             },
           },
+          otp_settings: {
+            type: 'object',
+            properties: {
+              email: {
+                type: 'object',
+                properties: {
+                  otp_length: { type: 'integer' },
+                  otp_expiry: { type: 'integer' },
+                },
+              },
+              phone: {
+                type: 'object',
+                properties: {
+                  otp_length: { type: 'integer' },
+                  otp_expiry: { type: 'integer' },
+                },
+              },
+            },
+          },
           password_options: {
             type: 'object',
             properties: {

--- a/test/tools/auth0/handlers/databases.tests.js
+++ b/test/tools/auth0/handlers/databases.tests.js
@@ -842,6 +842,80 @@ describe('#databases handler', () => {
       ]);
     });
 
+    it('should pass validation for a valid otp_settings payload', async () => {
+      const handler = new databases.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+
+      await stageFn.apply(handler, [
+        {
+          databases: [
+            {
+              name: 'testDatabase',
+              options: {
+                otp_settings: {
+                  email: { otp_length: 8, otp_expiry: 600 },
+                  phone: { otp_length: 6, otp_expiry: 300 },
+                },
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should export otp_settings unchanged', async () => {
+      const auth0 = {
+        connections: {
+          list: function (params) {
+            return mockPagedData(params, 'connections', [
+              {
+                id: 'con1',
+                strategy: 'auth0',
+                name: 'Username-Password-Authentication',
+                options: {
+                  otp_settings: {
+                    email: { otp_length: 8, otp_expiry: 600 },
+                    phone: { otp_length: 6, otp_expiry: 300 },
+                  },
+                  brute_force_protection: true,
+                },
+              },
+            ]);
+          },
+          clients: {
+            get: () => Promise.resolve(mockPagedData({}, 'clients', [])),
+          },
+        },
+        clients: {
+          list: function (params) {
+            return mockPagedData(params, 'clients', []);
+          },
+        },
+        actions: {
+          list: (params) => mockPagedData(params, 'actions', []),
+        },
+        pool,
+      };
+
+      const handler = new databases.default({ client: pageClient(auth0), config });
+      const data = await handler.getType();
+
+      expect(data).to.deep.equal([
+        {
+          id: 'con1',
+          strategy: 'auth0',
+          name: 'Username-Password-Authentication',
+          options: {
+            otp_settings: {
+              email: { otp_length: 8, otp_expiry: 600 },
+              phone: { otp_length: 6, otp_expiry: 300 },
+            },
+            brute_force_protection: true,
+          },
+        },
+      ]);
+    });
+
     it('should strip legacy password fields on export when password_options is present', async () => {
       const auth0 = {
         connections: {


### PR DESCRIPTION
### 🔧 Changes

Adds support for `otp_settings` on database connections (`strategy: auth0`), allowing configuration of OTP length and expiry per delivery channel (email and phone).

`otp_settings` is accepted and returned by the Management API only on strategy: auth0 connections. The property passes through deploy-cli without any special import/export handling, partial updates (e.g. setting only `email.otp_length`) are supported natively by the API's PATCH endpoint.

> **Note:** The `auth0` SDK version bump to 6.4.0 is tracked in a separate PR. `otp_settings` is not yet explicitly typed in the SDK, but `ConnectionOptionsAuth0` carries `[key: string]: any` so the Fern serializer passes it through at runtime,  import and export work end-to-end today.

### 📚 References


### 🔬 Testing

- Unit tests added for schema validation and export round-trip, all passing
- E2E tested against a real tenant: export → import with updated `otp_expiry` values → re-export confirmed values persisted correctly

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)