### PR TITLE
fix: allow system resource servers other than the My Account API to be updated

### DIFF
--- a/src/tools/auth0/handlers/resourceServers.ts
+++ b/src/tools/auth0/handlers/resourceServers.ts
@@ -199,8 +199,13 @@ export default class ResourceServersHandler extends DefaultHandler {
     id: string,
     update: ResourceServer
   ): Promise<Management.UpdateResourceServerResponseContent> {
-    // Exclude name from update as it cannot be modified for system resource servers like Auth0 My Account API
-    if (update.is_system === true || update.name === 'Auth0 My Account API') {
+    // Exclude name from update as it cannot be modified for system resource servers like the
+    // Auth0 My Account API or the Auth0 My Organization API. `is_system` is listed in
+    // `stripUpdateFields`, so it has already been removed from `update` by the time this runs -
+    // read it off the existing resource server instead, which `getType()` retains it on.
+    const existing = this.existing?.find((resourceServer) => resourceServer.id === id);
+
+    if (existing?.is_system === true) {
       const updateFields: Management.UpdateResourceServerRequestContent = {
         token_lifetime: update.token_lifetime,
         proof_of_possession: update.proof_of_possession,

--- a/test/tools/auth0/handlers/resourceServers.tests.js
+++ b/test/tools/auth0/handlers/resourceServers.tests.js
@@ -964,5 +964,47 @@ describe('#resourceServers handler', () => {
       await stageFn.apply(handler, [data]);
       expect(updateCalled).to.equal(true);
     });
+
+    it('should update a system resource server other than "Auth0 My Account API" without name', async () => {
+      let updateCalled = false;
+      const existingResourceServer = {
+        id: 'rs_my_organization',
+        identifier: 'https://auth0.com/my-organization/my-org/',
+        name: 'Auth0 My Organization API',
+        is_system: true,
+      };
+
+      const auth0 = {
+        resourceServers: {
+          create: () => Promise.resolve({ data: [] }),
+          update: function (id, data) {
+            updateCalled = true;
+            expect(id).to.equal('rs_my_organization');
+            expect(data.name).to.equal(undefined);
+            expect(data.is_system).to.equal(undefined);
+            expect(data.token_lifetime).to.equal(600);
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: [] }),
+          list: (params) => mockPagedData(params, 'resource_servers', [existingResourceServer]),
+        },
+        pool,
+      };
+
+      const handler = new resourceServers.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = {
+        resourceServers: [
+          {
+            name: 'Auth0 My Organization API',
+            identifier: 'https://auth0.com/my-organization/my-org/',
+            token_lifetime: 600,
+          },
+        ],
+      };
+
+      await stageFn.apply(handler, [data]);
+      expect(updateCalled).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
### 🔧 Changes

`updateResourceServer()` decides whether to send the restricted payload with this guard:

```ts
if (update.is_system === true || update.name === 'Auth0 My Account API') {
```

Neither half holds up:

- `is_system` is listed in `stripUpdateFields`, and `stripFields()` runs on the payload in
  `DefaultHandler.processChanges()` *before* `updateResourceServer()` is called. `update.is_system`
  is therefore always `undefined` and that branch is dead code.
- The fallback matches one hardcoded name, so the Auth0 My Account API is the only system resource
  server that works. Every other one — the Auth0 My Organization API (`https://{domain}/my-org/`) in
  our case — takes the full-update path, which includes `name`, and the Management API rejects it
  with `Payload validation error: 'Additional properties not allowed: name'`.

Since `calculateChanges()` puts every matched asset into `update` whether or not anything changed,
this makes `import` fail on every run after the first, and it aborts the whole `processChanges` stage
for `resourceServers`.

This reads `is_system` off the existing resource server instead, which is where it actually survives —
`getType()` keeps `is_system` in its allowlist when it sanitizes system resource servers, and it runs
before `processChanges()`. The hardcoded name comparison then has nothing left to do and is removed:
the My Account API is covered by `is_system` like any other system resource server.

No change in behaviour for the My Account API or for non-system resource servers.

### 📚 References

Fixes #1484

### 🔬 Testing

Added `should update a system resource server other than "Auth0 My Account API" without name`, which
mirrors the existing My Account API test with the My Organization API. On master it fails with
`expected 'Auth0 My Organization API' to equal undefined`, which is exactly the `name` that the
Management API rejects; with this change it passes.

The existing system resource server tests (sanitizing in `getType`, `authorization_policy` in the
update payload, `should update "Auth0 My Account API" without name and is_system`) all still pass, so
the removed name comparison is not load-bearing.

Verified end-to-end against a real tenant as well, with `AUTH0_INCLUDED_ONLY: ["resourceServers"]` and
a config directory holding both system APIs. On 8.44.0 the first `import` creates both and the second
one fails on the My Organization API; with this change both runs are clean.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A) — N/A, bug fix with no
      public API or config surface change
