### PR TITLE
feat: support b2b_integration_configuration for Enterprise Connect EA

### DIFF
--- a/docs/resource-specific-documentation.md
+++ b/docs/resource-specific-documentation.md
@@ -1367,6 +1367,33 @@ File: `./connection-profiles/Enterprise SSO Profile.json`
 }
 ```
 
+### B2B Integration Configuration on Clients
+
+> **Early Access** — requires the `enterprise_connect_entitled` entitlement on your tenant.
+
+The `b2b_integration_configuration` object enables Enterprise Connect functionality on a client. It can be set at **creation time** regardless of `app_type`. Once set, it can be updated via deploy as normal.
+
+> **Important:** `b2b_integration_configuration` cannot be added to an **existing** client via PATCH. If you need to add it to a client that was created without it, re-create the client. The deploy-cli will warn and skip the field if this constraint is violated.
+
+The `integration_type` field accepts one of: `custom_auth_server`, `third_party`, `application`.
+
+```yaml
+clients:
+  - name: 'My B2B Integration Client'
+    app_type: 'spa'
+    b2b_integration_configuration:
+      integration_type: 'custom_auth_server'
+```
+
+To clear `b2b_integration_configuration`, set it to `null`:
+
+```yaml
+clients:
+  - name: 'My B2B Integration Client'
+    app_type: 'spa'
+    b2b_integration_configuration: null
+```
+
 ### Express Configuration on Clients
 
 Connection profiles are used in conjunction with the `express_configuration` property on client applications: (In order to use express_configuration app_type should not be 'express_configuration')

--- a/examples/directory/clients/My B2B Integration Client.json
+++ b/examples/directory/clients/My B2B Integration Client.json
@@ -1,0 +1,7 @@
+{
+  "name": "My B2B Integration Client",
+  "app_type": "spa",
+  "b2b_integration_configuration": {
+    "integration_type": "custom_auth_server"
+  }
+}

--- a/examples/yaml/tenant.yaml
+++ b/examples/yaml/tenant.yaml
@@ -97,6 +97,14 @@ clients:
             - "chat:write"
             - "channels:read"
   -
+    name: "My B2B Integration Client"
+    app_type: "spa"
+    # Enterprise Connect EA. Requires enterprise_connect_entitled on the tenant.
+    # b2b_integration_configuration can be set at creation time.
+    # To update it via deploy, the client must already have this object (re-create otherwise).
+    b2b_integration_configuration:
+      integration_type: "custom_auth_server"  # one of: custom_auth_server, third_party, application
+  -
     name: "My CIMD Client"
     external_client_id: "https://mcpserver.example.com/.well-known/client.json"
     app_type: "regular_web"

--- a/src/tools/auth0/handlers/clients.ts
+++ b/src/tools/auth0/handlers/clients.ts
@@ -315,6 +315,25 @@ export const schema = {
         type: 'string',
         description: 'The type of application this client represents',
       },
+      b2b_integration_configuration: {
+        type: ['object', 'null'],
+        description:
+          'B2B integration configuration. Early Access. Required feature flag: enterprise_connect_entitled.',
+        properties: {
+          integration_type: {
+            type: 'string',
+            enum: ['custom_auth_server', 'third_party', 'application'],
+            description: 'The type of integration used to connect to this B2B integration client.',
+          },
+          sso_profiles: {
+            type: 'array',
+            description:
+              'List of SSO profile IDs linked to this B2B integration client. Maximum 1 entry.',
+            items: { type: 'string' },
+          },
+        },
+        additionalProperties: false,
+      },
       resource_server_identifier: {
         type: 'string',
         description:
@@ -663,6 +682,9 @@ export default class ClientHandler extends DefaultAPIHandler {
         'jwks_uri',
         // third_party_security_mode is immutable after creation; PATCH returns 400
         'third_party_security_mode',
+        // API-generated timestamps; PATCH returns 400 if present
+        'created_at',
+        'updated_at',
       ],
       functions: {
         create: (client: Client) => this.createClient(client),
@@ -890,7 +912,31 @@ export default class ClientHandler extends DefaultAPIHandler {
   private async updateClient(clientId: string, client: Client): Promise<Client> {
     // For non-CIMD clients
     if (!this.isCimdClient(client)) {
-      return this.client.clients.update(clientId, client as Management.UpdateClientRequestContent);
+      const payload = { ...client } as Management.UpdateClientRequestContent & {
+        b2b_integration_configuration?: unknown;
+      };
+
+      // b2b_integration_configuration: PATCH only allowed if client already has the object.
+      // Sending it to a client that lacks it returns 400 invalid_body.
+      // null clears the object — but only for clients that already have it; stripping
+      // null for a client without the field is a safe no-op.
+      if ('b2b_integration_configuration' in payload) {
+        const existing = (this.existing || []).find(
+          (c) => c.client_id === (client.client_id || clientId)
+        );
+        if (!existing?.b2b_integration_configuration) {
+          if (payload.b2b_integration_configuration !== null) {
+            log.warn(
+              `b2b_integration_configuration cannot be added to an existing client via PATCH ` +
+                `(client: ${client.name || clientId}). Skipping field. ` +
+                `Re-create the client to set this field.`
+            );
+          }
+          delete payload.b2b_integration_configuration;
+        }
+      }
+
+      return this.client.clients.update(clientId, payload);
     }
 
     const updatePayload = this.getCIMDEditableFields(client);

--- a/test/tools/auth0/handlers/clients.tests.js
+++ b/test/tools/auth0/handlers/clients.tests.js
@@ -127,6 +127,35 @@ describe('#clients handler', () => {
       ]);
       expect(valid).to.equal(false);
     });
+
+    it('should pass validation with b2b_integration_configuration', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someB2BClient',
+          b2b_integration_configuration: { integration_type: 'custom_auth_server' },
+        },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should pass validation with b2b_integration_configuration set to null', () => {
+      const valid = ajv.validate(clients.schema, [
+        { name: 'someB2BClient', b2b_integration_configuration: null },
+      ]);
+      expect(valid).to.equal(true);
+      expect(ajv.errors).to.be.null;
+    });
+
+    it('should fail validation with b2b_integration_configuration.integration_type invalid value', () => {
+      const valid = ajv.validate(clients.schema, [
+        {
+          name: 'someB2BClient',
+          b2b_integration_configuration: { integration_type: 'b2b_integration' },
+        },
+      ]);
+      expect(valid).to.equal(false);
+    });
   });
 
   describe('#clients validate', () => {
@@ -2107,6 +2136,130 @@ describe('#clients handler', () => {
       // The whole object is therefore stripped on write — the field is export-only.
       expect(updatePayloads['client1']).to.not.have.property('token_vault_privileged_access');
       expect(createPayloads[0]).to.not.have.property('token_vault_privileged_access');
+    });
+
+    it('should strip b2b_integration_configuration from PATCH when existing client lacks it', async () => {
+      const updatePayloads = {};
+      const auth0 = {
+        clients: {
+          create: (data) => Promise.resolve({ data }),
+          update: (clientId, data) => {
+            updatePayloads[clientId] = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: {} }),
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'Existing Client' }]),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'Existing Client',
+              b2b_integration_configuration: { integration_type: 'custom_auth_server' },
+            },
+          ],
+        },
+      ]);
+
+      expect(updatePayloads['client1']).to.not.have.property('b2b_integration_configuration');
+    });
+
+    it('should strip null b2b_integration_configuration from PATCH when existing client lacks it', async () => {
+      const updatePayloads = {};
+      const auth0 = {
+        clients: {
+          create: (data) => Promise.resolve({ data }),
+          update: (clientId, data) => {
+            updatePayloads[clientId] = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: {} }),
+          list: (params) =>
+            mockPagedData(params, 'clients', [{ client_id: 'client1', name: 'Existing Client' }]),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'Existing Client',
+              b2b_integration_configuration: null,
+            },
+          ],
+        },
+      ]);
+
+      // null for a client that never had the field is a no-op — strip silently, no API error.
+      expect(updatePayloads['client1']).to.not.have.property('b2b_integration_configuration');
+    });
+
+    it('should pass b2b_integration_configuration in PATCH when existing client already has it', async () => {
+      const updatePayloads = {};
+      const auth0 = {
+        clients: {
+          create: (data) => Promise.resolve({ data }),
+          update: (clientId, data) => {
+            updatePayloads[clientId] = data;
+            return Promise.resolve({ data });
+          },
+          delete: () => Promise.resolve({ data: {} }),
+          list: (params) =>
+            mockPagedData(params, 'clients', [
+              {
+                client_id: 'client1',
+                name: 'Existing B2B Client',
+                b2b_integration_configuration: { integration_type: 'custom_auth_server' },
+              },
+            ]),
+        },
+        connectionProfiles: { list: (params) => mockPagedData(params, 'connectionProfiles', []) },
+        userAttributeProfiles: {
+          list: (params) => mockPagedData(params, 'userAttributeProfiles', []),
+        },
+        pool,
+      };
+
+      const handler = new clients.default({ client: pageClient(auth0), config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        {
+          clients: [
+            {
+              client_id: 'client1',
+              name: 'Existing B2B Client',
+              b2b_integration_configuration: { integration_type: 'third_party' },
+            },
+          ],
+        },
+      ]);
+
+      expect(updatePayloads['client1']).to.have.property('b2b_integration_configuration');
+      expect(updatePayloads['client1'].b2b_integration_configuration).to.deep.equal({
+        integration_type: 'third_party',
+      });
     });
   });
 


### PR DESCRIPTION
### 🔧 Changes

Adds support for `b2b_integration_configuration` on clients as part of  the Enterprise Connect EA release

**New field: `b2b_integration_configuration`**
  - Accepted on `POST /api/v2/clients` regardless of `app_type`
  - Contains `integration_type` (one of `custom_auth_server`, `third_party`, `application`) and `sso_profiles` (array of SSO profile IDs)
  - Schema added to the clients handler with full validation

**PATCH guard**
  - The Management API only allows `b2b_integration_configuration` to be updated via PATCH on clients that already have the object; sending it to a client that lacks it returns 400
  - deploy-cli now detects this case, logs a warning, and skips the field, the client is still updated without it
  - To set `b2b_integration_configuration` on an existing client that lacks it, re-create the client

**`app_type: b2b_integration` deprecation**
  - This value was removed from the API in the EA release; the deploy-cli schema has no enum constraint on `app_type` so no code change is needed

**Fix: strip `created_at` and `updated_at` from client PATCH payloads**
  - Discovered during EA testing: the Management API now explicitly rejects these fields with 400 if present in a PATCH body

### 📚 References



### 🔬 Testing

 Unit tests added covering:
  - Schema validation accepts valid `b2b_integration_configuration`, rejects invalid `integration_type` values
  - PATCH guard strips the field (with warn) when existing client lacks it
  - PATCH guard strips `null` silently when existing client lacks it
  - PATCH guard passes the field through when existing client already has it

  Manual E2E testing performed against a real tenant:
  - Scenario B (PATCH guard) verified end-to-end - warn log fires, field is skipped, client updates successfully
  - Scenarios A (CREATE) and C (UPDATE round-trip) require `enterprise_connect_entitled` entitlement on tenant; code path confirmed correct, blocked at API level without entitlement

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)